### PR TITLE
Implement autoresizable containers

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -1,4 +1,4 @@
-import { ApollonEditor, ApollonOptions, DiagramType, SVG } from '../src';
+import { ApollonEditor, ApollonOptions, DiagramType, SVG, UMLModel } from '../src';
 
 const container = document.getElementById('apollon')!;
 let editor: ApollonEditor | null = null;
@@ -22,8 +22,9 @@ export const onSwitch = (event: MouseEvent) => {
 export const save = () => {
   if (!editor) return;
 
-  localStorage.setItem('apollon', JSON.stringify(editor.model));
-  options = { ...options, model: editor.model };
+  const model: UMLModel = editor.model;
+  localStorage.setItem('apollon', JSON.stringify(model));
+  options = { ...options, model };
   return options;
 };
 

--- a/example/styles.css
+++ b/example/styles.css
@@ -5,10 +5,11 @@
   margin: 20px;
 }
 main {
-  width: calc(100% - 200px);
+  flex: 1 0 auto;
+  width: 800px;
 }
 aside.sidebar {
-  width: 200px;
+  flex: 0 0 10em;
   margin-left: 1em;
 }
 aside.sidebar section {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ls1intum/apollon",
-  "version": "2.0.0-beta.15",
+  "version": "2.0.0-beta.16",
   "description": "A UML diagram editor.",
   "keywords": [],
   "homepage": "https://github.com/ls1intum/apollon#readme",

--- a/src/apollon-editor.ts
+++ b/src/apollon-editor.ts
@@ -15,12 +15,12 @@ export class ApollonEditor {
   static exportModelAsSvg(model: UMLModel, options?: ExportOptions): SVG {
     const div = document.createElement('div');
     const element = createElement(Svg, { model, options });
-    render(element, div);
+    const svg = render(element, div);
     const { innerHTML } = div;
     unmountComponentAtNode(div);
     return {
       svg: innerHTML,
-      clip: model.size,
+      clip: svg.state.bounds,
     };
   }
 

--- a/src/apollon-editor.ts
+++ b/src/apollon-editor.ts
@@ -14,17 +14,13 @@ export class ApollonEditor {
 
   static exportModelAsSvg(model: UMLModel, options?: ExportOptions): SVG {
     const div = document.createElement('div');
-    const element = createElement(Svg, {
-      state: ModelState.fromModel(model),
-      options,
-    });
-    const svg = render(element, div);
+    const element = createElement(Svg, { model, options });
+    render(element, div);
     const { innerHTML } = div;
-    const { bounds } = svg.state;
     unmountComponentAtNode(div);
     return {
       svg: innerHTML,
-      clip: bounds,
+      clip: model.size,
     };
   }
 

--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -21,6 +21,13 @@ const Container = styled.div`
   height: 100%;
 `;
 
+const Svg = styled.svg`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  overflow: visible;
+`;
+
 class CanvasComponent extends Component<Props, State> {
   state: State = {
     isMounted: false,
@@ -65,18 +72,7 @@ class CanvasComponent extends Component<Props, State> {
           <Droppable onDrop={this.onDrop}>
             <Grid grid={10} width={diagram.bounds.width} height={diagram.bounds.height} show={mode !== ApollonMode.Assessment}>
               <PopupLayer ref={this.popup}>
-                <svg
-                  className="svg"
-                  width={diagram.bounds.width / 2}
-                  height={diagram.bounds.height / 2}
-                  ref={this.layer}
-                  style={{
-                    position: 'absolute',
-                    top: '50%',
-                    left: '50%',
-                    overflow: 'visible',
-                  }}
-                >
+                <Svg width={diagram.bounds.width / 2} height={diagram.bounds.height / 2} ref={this.layer}>
                   {this.state.isMounted && (
                     <g>
                       <KeyboardEventListener popup={this.popup} />
@@ -90,7 +86,7 @@ class CanvasComponent extends Component<Props, State> {
                       </ConnectLayer>
                     </g>
                   )}
-                </svg>
+                </Svg>
               </PopupLayer>
             </Grid>
           </Droppable>

--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -23,9 +23,12 @@ const Container = styled.div`
 
 const Svg = styled.svg`
   position: absolute;
-  top: 50%;
-  left: 50%;
+  top: 0;
+  left: 0;
+  width: 50%;
+  height: 50%;
   overflow: visible;
+  transform: translate(100%, 100%);
 `;
 
 class CanvasComponent extends Component<Props, State> {

--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -79,15 +79,6 @@ class CanvasComponent extends Component<Props, State> {
                 >
                   {this.state.isMounted && (
                     <g>
-                      <circle cx={0} cy={0} r={5} fill="green" />
-                      <rect
-                        x={-diagram.bounds.width / 2}
-                        y={-diagram.bounds.height / 2}
-                        width={diagram.bounds.width}
-                        height={diagram.bounds.height}
-                        fill="red"
-                        fillOpacity={0.1}
-                      />
                       <KeyboardEventListener popup={this.popup} />
                       <ConnectLayer>
                         {diagram.ownedElements.map(element => (

--- a/src/components/canvas/coordinate-system.ts
+++ b/src/components/canvas/coordinate-system.ts
@@ -2,15 +2,7 @@ import { RefObject } from 'react';
 import { Point } from '../../utils/geometry/point';
 
 export class CoordinateSystem {
-  get canvas(): HTMLElement {
-    return this.ref.current!;
-  }
-
-  get container(): HTMLElement {
-    return this.canvas.parentElement!;
-  }
-
-  constructor(public layer: RefObject<SVGSVGElement>, public ref: RefObject<HTMLElement>, public width: number, public height: number) {}
+  constructor(public layer: RefObject<SVGSVGElement>) {}
 
   offset(): Point {
     const layerBounds = this.layer.current!.getBoundingClientRect();
@@ -22,8 +14,6 @@ export class CoordinateSystem {
   }
 
   screenToPoint(x: number, y: number, snap: boolean = true): Point {
-    x = x - this.width / 2;
-    y = y - this.height / 2;
     if (snap) {
       x = Math.round(x / 10) * 10;
       y = Math.round(y / 10) * 10;
@@ -32,8 +22,6 @@ export class CoordinateSystem {
   }
 
   pointToScreen(x: number, y: number): Point {
-    x = x + this.width / 2;
-    y = y + this.height / 2;
     return new Point(x, y);
   }
 }

--- a/src/components/canvas/coordinate-system.ts
+++ b/src/components/canvas/coordinate-system.ts
@@ -10,12 +10,12 @@ export class CoordinateSystem {
     return this.canvas.parentElement!;
   }
 
-  constructor(public ref: RefObject<HTMLElement>, public width: number, public height: number) {}
+  constructor(public layer: RefObject<SVGSVGElement>, public ref: RefObject<HTMLElement>, public width: number, public height: number) {}
 
   offset(): Point {
-    const bounds = this.container.getBoundingClientRect();
-    let x = bounds.left - this.container.scrollLeft;
-    let y = bounds.top - this.container.scrollTop;
+    const layerBounds = this.layer.current!.getBoundingClientRect();
+    let x = layerBounds.left;
+    let y = layerBounds.top;
     x = Math.round(x / 10) * 10;
     y = Math.round(y / 10) * 10;
     return new Point(x, y);

--- a/src/components/canvas/grid.tsx
+++ b/src/components/canvas/grid.tsx
@@ -16,8 +16,8 @@ export const Grid = styled.div<Props>`
   z-index: 1;
   width: 100%;
   height: 100%;
-  min-width: ${({ width }: Props) => width + 1}px;
-  min-height: ${({ height }: Props) => height + 1}px;
+  min-width: ${({ width }: Props) => width}px;
+  min-height: ${({ height }: Props) => height}px;
 
   ${({ show = true, grid }) =>
     show &&
@@ -30,6 +30,7 @@ export const Grid = styled.div<Props>`
       width: 100%;
       height: 100%;
 
+      background-position: calc(50% + ${(grid * subdivisions) / 2}px) calc(50% + ${(grid * subdivisions) / 2}px);
       background-size: ${grid * subdivisions}px ${grid * subdivisions}px,
         ${grid * subdivisions}px ${grid * subdivisions}px,
         ${grid}px ${grid}px,

--- a/src/components/canvas/grid.tsx
+++ b/src/components/canvas/grid.tsx
@@ -14,8 +14,10 @@ const subdivisions = 5;
 export const Grid = styled.div<Props>`
   position: relative;
   z-index: 1;
-  width: ${({ width }: Props) => width + 1}px;
-  height: ${({ height }: Props) => height + 1}px;
+  width: 100%;
+  height: 100%;
+  min-width: ${({ width }: Props) => width + 1}px;
+  min-height: ${({ height }: Props) => height + 1}px;
 
   ${({ show = true, grid }) =>
     show &&

--- a/src/components/layouted-element/connectable.tsx
+++ b/src/components/layouted-element/connectable.tsx
@@ -116,8 +116,8 @@ export const connectable = (WrappedComponent: typeof ElementComponent): Componen
         const relationship = new RelationshipClazz();
         Object.assign(relationship, {
           type,
-          source: endpoints.source,
-          target: endpoints.target,
+          source: { ...endpoints.source },
+          target: { ...endpoints.target },
         });
         this.props.create(relationship);
       } catch (error) {}

--- a/src/components/layouted-element/droppable.tsx
+++ b/src/components/layouted-element/droppable.tsx
@@ -20,15 +20,6 @@ export const droppable = (WrappedComponent: typeof ElementComponent) => {
       element.bounds.x = position.x - offset.x;
       element.bounds.y = position.y - offset.y;
 
-      let ownerID: string | null = this.props.element.id;
-      while (ownerID) {
-        const owner = this.props.getById(ownerID);
-        if (!owner) break;
-        element.bounds.x -= owner.bounds.x;
-        element.bounds.y -= owner.bounds.y;
-        ownerID = owner.owner;
-      }
-
       this.props.create(element);
     };
 
@@ -41,21 +32,19 @@ export const droppable = (WrappedComponent: typeof ElementComponent) => {
     }
   }
 
-  interface StateProps {
-    getById: (id: string) => Element | null;
-  }
+  type StateProps = {};
 
-  interface DispatchProps {
+  type DispatchProps = {
     create: typeof ElementRepository.create;
-  }
+  };
 
   type Props = OwnProps & StateProps & DispatchProps & CanvasContext;
 
   return compose<ComponentClass<OwnProps>>(
     withCanvas,
     connect<StateProps, DispatchProps, OwnProps, ModelState>(
-      state => ({ getById: ElementRepository.getById(state.elements) }),
-      { create: ElementRepository.create }
-    )
+      null,
+      { create: ElementRepository.create },
+    ),
   )(Droppable);
 };

--- a/src/components/layouted-element/movable.tsx
+++ b/src/components/layouted-element/movable.tsx
@@ -46,10 +46,7 @@ export const movable = (WrappedComponent: typeof ElementComponent) => {
 
     private checkOwnership = () => {
       const target = this.props.target ? this.props.target.id : null;
-      const { id, owner } = this.props.element;
-      if (owner === target) return;
-
-      this.props.changeOwner(id, target);
+      this.props.changeOwner(this.props.element.id, target);
     };
 
     private onMouseDown = (event: MouseEvent) => {
@@ -125,7 +122,7 @@ export const movable = (WrappedComponent: typeof ElementComponent) => {
       {
         move: ElementRepository.move,
         changeOwner: ContainerRepository.changeOwner,
-      }
-    )
+      },
+    ),
   )(Movable);
 };

--- a/src/components/layouted-element/resizable.tsx
+++ b/src/components/layouted-element/resizable.tsx
@@ -72,6 +72,7 @@ export const resizable = (WrappedComponent: typeof ElementComponent) => {
       this.setState({ resizing: false, offset: new Point() });
       document.removeEventListener('mousemove', this.onMouseMove);
       document.removeEventListener('mouseup', this.onMouseUp);
+      this.props.resized(this.props.element.id);
     };
   }
 
@@ -81,6 +82,7 @@ export const resizable = (WrappedComponent: typeof ElementComponent) => {
 
   interface DispatchProps {
     resize: typeof ElementRepository.resize;
+    resized: typeof ElementRepository.resized;
   }
 
   interface State {
@@ -96,7 +98,7 @@ export const resizable = (WrappedComponent: typeof ElementComponent) => {
       state => ({
         getAbsolutePosition: ElementRepository.getAbsolutePosition(state.elements),
       }),
-      { resize: ElementRepository.resize },
+      { resize: ElementRepository.resize, resized: ElementRepository.resized },
     ),
   );
 

--- a/src/components/layouted-element/selectable.tsx
+++ b/src/components/layouted-element/selectable.tsx
@@ -19,6 +19,7 @@ export const selectable = (WrappedComponent: typeof ElementComponent): Component
     render() {
       return <WrappedComponent {...this.props} />;
     }
+
     private select = (event: MouseEvent) => {
       if (event.which !== 1 || !this.props.element.hovered || (this.props.element.selected && !event.shiftKey)) return;
       this.props.select(this.props.element.id, event.shiftKey);

--- a/src/components/layouted-relationship/relationship-component.tsx
+++ b/src/components/layouted-relationship/relationship-component.tsx
@@ -16,6 +16,8 @@ export class RelationshipComponent extends Component<Props> {
 
   render() {
     const { element, disabled } = this.props;
+    if (element.bounds.width === 1 && element.bounds.height === 1) return null;
+
     const ElementComponent = Components[element.type];
     const points = element.path.map(point => `${point.x} ${point.y}`).join(',');
 

--- a/src/components/popup/popup-layer.tsx
+++ b/src/components/popup/popup-layer.tsx
@@ -28,7 +28,7 @@ export class PopupLayer extends Component<{}, State> {
       <PopupProvider value={context}>
         {this.props.children}
         {this.state.element && (
-          <div ref={this.popup}>
+          <div ref={this.popup} style={{ position: 'absolute', left: '50%', top: '50%' }}>
             <Popup element={this.state.element} position={this.state.position} />
           </div>
         )}

--- a/src/components/sidebar/sidebar-component.tsx
+++ b/src/components/sidebar/sidebar-component.tsx
@@ -61,15 +61,11 @@ class SidebarComponent extends Component<Props, State> {
             (() => {
               const c = new ClassAttribute();
               c.name = '+ attribute: Type';
-              c.bounds.x = element.bounds.x;
-              c.bounds.y = element.bounds.y;
               return c;
             })(),
             (() => {
               const c = new ClassMethod();
               c.name = '+ method()';
-              c.bounds.x = element.bounds.x;
-              c.bounds.y = element.bounds.y;
               return c;
             })(),
           ].forEach(member => {
@@ -82,22 +78,16 @@ class SidebarComponent extends Component<Props, State> {
             (() => {
               const c = new ClassAttribute();
               c.name = 'Case1';
-              c.bounds.x = element.bounds.x;
-              c.bounds.y = element.bounds.y;
               return c;
             })(),
             (() => {
               const c = new ClassAttribute();
               c.name = 'Case2';
-              c.bounds.x = element.bounds.x;
-              c.bounds.y = element.bounds.y;
               return c;
             })(),
             (() => {
               const c = new ClassAttribute();
               c.name = 'Case3';
-              c.bounds.x = element.bounds.x;
-              c.bounds.y = element.bounds.y;
               return c;
             })(),
           ].forEach(member => {
@@ -110,8 +100,6 @@ class SidebarComponent extends Component<Props, State> {
             (() => {
               const c = new ObjectAttribute();
               c.name = 'attribute = value';
-              c.bounds.x = element.bounds.x;
-              c.bounds.y = element.bounds.y;
               return c;
             })(),
           ].forEach(member => {

--- a/src/components/sidebar/sidebar-component.tsx
+++ b/src/components/sidebar/sidebar-component.tsx
@@ -61,11 +61,15 @@ class SidebarComponent extends Component<Props, State> {
             (() => {
               const c = new ClassAttribute();
               c.name = '+ attribute: Type';
+              c.bounds.x = element.bounds.x;
+              c.bounds.y = element.bounds.y;
               return c;
             })(),
             (() => {
               const c = new ClassMethod();
               c.name = '+ method()';
+              c.bounds.x = element.bounds.x;
+              c.bounds.y = element.bounds.y;
               return c;
             })(),
           ].forEach(member => {
@@ -78,16 +82,22 @@ class SidebarComponent extends Component<Props, State> {
             (() => {
               const c = new ClassAttribute();
               c.name = 'Case1';
+              c.bounds.x = element.bounds.x;
+              c.bounds.y = element.bounds.y;
               return c;
             })(),
             (() => {
               const c = new ClassAttribute();
               c.name = 'Case2';
+              c.bounds.x = element.bounds.x;
+              c.bounds.y = element.bounds.y;
               return c;
             })(),
             (() => {
               const c = new ClassAttribute();
               c.name = 'Case3';
+              c.bounds.x = element.bounds.x;
+              c.bounds.y = element.bounds.y;
               return c;
             })(),
           ].forEach(member => {
@@ -100,6 +110,8 @@ class SidebarComponent extends Component<Props, State> {
             (() => {
               const c = new ObjectAttribute();
               c.name = 'attribute = value';
+              c.bounds.x = element.bounds.x;
+              c.bounds.y = element.bounds.y;
               return c;
             })(),
           ].forEach(member => {

--- a/src/components/store/model-state.ts
+++ b/src/components/store/model-state.ts
@@ -56,6 +56,8 @@ export class ModelState {
     root.forEach(position);
 
     const bounds = computeBoundingBoxForElements(root);
+    bounds.width = Math.ceil(bounds.width / 20) * 20;
+    bounds.height = Math.ceil(bounds.height / 20) * 20;
     for (const element of root) {
       elements[element.id].bounds.x -= bounds.width / 2;
       elements[element.id].bounds.y -= bounds.height / 2;

--- a/src/components/store/model-state.ts
+++ b/src/components/store/model-state.ts
@@ -1,6 +1,3 @@
-import { ElementType } from '../../packages/element-type';
-import { Elements } from '../../packages/elements';
-import { Relationships } from '../../packages/relationships';
 import { AssessmentState } from '../../services/assessment/assessment-types';
 import { Container } from '../../services/container/container';
 import { Diagram } from '../../services/diagram/diagram';
@@ -23,60 +20,50 @@ export interface ModelState {
 
 export class ModelState {
   static fromModel(model: UMLModel): ModelState {
-    const copy: UMLModel = JSON.parse(JSON.stringify(model));
-    let elements: { [id: string]: Element } = Object.values(copy.elements)
-      .map(umlElement => {
-        const Clazz = Elements[umlElement.type];
-        const element = new Clazz(umlElement);
-        if (copy.interactive.elements.includes(element.id)) {
-          element.interactive = true;
-        }
-        return element;
-      })
-      .reduce((r, o) => ({ ...r, [o.id]: o }), {});
+    const state = [...model.elements, ...model.relationships].reduce<ElementState>(
+      (result, element) => ({
+        ...result,
+        [element.id]: {
+          owner: null,
+          ...element,
+          hovered: false,
+          selected: false,
+          interactive: [...model.interactive.elements, ...model.interactive.relationships].includes(element.id),
+        },
+      }),
+      {},
+    );
 
-    elements = Object.values(elements).reduce((state, element) => {
+    const elements = [
+      ...ElementRepository.getByIds(state)(Object.keys(state)),
+      ...RelationshipRepository.getByIds(state)(Object.keys(state)),
+    ].reduce<{ [id: string]: Element }>((result, element) => ({ ...result, [element.id]: element }), {});
+
+    const root = Object.values(elements).filter(element => !element.owner);
+
+    const position = (element: Element) => {
       if (element instanceof Container) {
-        const children = Object.values(elements)
-          .filter(child => child.owner === element.id)
-          .map<Element>(child => {
-            const Clazz = Elements[child.type as ElementType];
-            return new Clazz(child);
-          });
+        const children = Object.values(elements).filter(child => child.owner === element.id);
         element.ownedElements = children.map(child => child.id);
-        const changes = element.render(children).reduce<ElementState>((r, o) => ({ ...r, [o.id]: o }), {});
-        return { ...state, ...changes };
-      }
-      return { ...state, [element.id]: element };
-    }, {});
-
-    const relationships: { [id: string]: Relationship } = Object.values(copy.relationships)
-      .map<Relationship>(umlRelationship => {
-        const Clazz = Relationships[umlRelationship.type];
-        const relationship: Relationship = new Clazz(umlRelationship);
-        if (copy.interactive.relationships.includes(relationship.id)) {
-          relationship.interactive = true;
+        for (const child of children) {
+          position(child);
+          child.bounds.x -= element.bounds.x;
+          child.bounds.y -= element.bounds.y;
         }
-        return relationship;
-      })
-      .reduce((r, o) => ({ ...r, [o.id]: o }), {});
+        element.render(children);
+      }
+    };
+    root.forEach(position);
 
-    const rootElements = Object.values(elements).filter(element => !element.owner);
-    const bounds = computeBoundingBoxForElements(rootElements);
-    for (const id in elements) {
-      if (elements[id].owner) continue;
-      elements[id].bounds.x -= bounds.width / 2;
-      elements[id].bounds.y -= bounds.height / 2;
-    }
-    for (const id in relationships) {
-      if (relationships[id].owner) continue;
-      relationships[id].bounds.x -= bounds.width / 2;
-      relationships[id].bounds.y -= bounds.height / 2;
+    const bounds = computeBoundingBoxForElements(root);
+    for (const element of root) {
+      elements[element.id].bounds.x -= bounds.width / 2;
+      elements[element.id].bounds.y -= bounds.height / 2;
     }
 
     let width = 0;
     let height = 0;
-    for (const element of rootElements) {
+    for (const element of root) {
       width = Math.max(Math.abs(element.bounds.x), Math.abs(element.bounds.x + element.bounds.width), width);
       height = Math.max(Math.abs(element.bounds.y), Math.abs(element.bounds.y + element.bounds.height), height);
     }
@@ -93,24 +80,23 @@ export class ModelState {
         ...(() => {
           const d = new Diagram();
           Object.assign(d, {
-            type2: copy.type,
+            type2: model.type,
             bounds: computedBounds,
           });
           return d;
         })(),
-        ownedElements: Object.values(elements)
-          .filter(e => !e.owner)
-          .map(e => e.id),
-        ownedRelationships: Object.keys(relationships),
+        ownedElements: root.filter(element => !(element instanceof Relationship)).map(element => element.id),
+        ownedRelationships: root.filter(element => element instanceof Relationship).map(element => element.id),
       },
-      elements: { ...elements, ...relationships },
-      assessments: copy.assessments.reduce<AssessmentState>((r, o) => ({ ...r, [o.modelElementId]: o }), {}),
+      elements,
+      assessments: model.assessments.reduce<AssessmentState>((r, o) => ({ ...r, [o.modelElementId]: o }), {}),
     };
   }
 
   static toModel(state: ModelState): UMLModel {
-    const copy: ModelState = JSON.parse(JSON.stringify(state));
-    const elements = ElementRepository.read(copy);
+    const elements = ElementRepository.read(state.elements);
+    const relationships = RelationshipRepository.read(state.elements);
+    const root = elements.filter(element => !element.owner);
 
     const parseElement = (element: Element): UMLElement[] => {
       const cont: Element[] = element instanceof Container ? element.ownedElements.map(id => elements.find(ee => ee.id === id)!) : [];
@@ -118,9 +104,8 @@ export class ModelState {
       return [result, ...children.reduce<UMLElement[]>((r2, e3) => [...r2, ...parseElement(e3)], [])];
     };
 
-    const e = elements.filter(element => !element.owner).reduce<UMLElement[]>((r2, e2) => [...r2, ...parseElement(e2)], []);
+    const e = root.reduce<UMLElement[]>((r2, e2) => [...r2, ...parseElement(e2)], []);
 
-    const relationships = RelationshipRepository.read(copy.elements);
     const r = relationships.map<UMLRelationship>(relationship =>
       (relationship.constructor as typeof Relationship).toUMLRelationship(relationship),
     );
@@ -130,10 +115,13 @@ export class ModelState {
       relationships: relationships.filter(element => element.interactive).map<string>(element => element.id),
     };
 
-    const rootElements = elements.filter(element => !element.owner);
-    const bounds = computeBoundingBoxForElements(rootElements);
+    const bounds = computeBoundingBoxForElements(root);
     for (const element of e) {
-      if (element.owner) continue;
+      if (element.owner) {
+        const absolutePosition = ElementRepository.getAbsolutePosition(state.elements)(element.id);
+        element.bounds.x = absolutePosition.x;
+        element.bounds.y = absolutePosition.y;
+      }
       element.bounds.x -= bounds.x;
       element.bounds.y -= bounds.y;
     }
@@ -150,11 +138,11 @@ export class ModelState {
     return {
       version: '2.0',
       size,
-      type: copy.diagram.type2,
+      type: state.diagram.type2,
       interactive,
       elements: e,
       relationships: r,
-      assessments: Object.values(copy.assessments),
+      assessments: Object.values(state.assessments),
     };
   }
 }

--- a/src/components/store/model-state.ts
+++ b/src/components/store/model-state.ts
@@ -97,7 +97,7 @@ export class ModelState {
 
     const e = elements.filter(element => !element.owner).reduce<UMLElement[]>((r2, e2) => [...r2, ...parseElement(e2)], []);
 
-    const relationships = RelationshipRepository.read(copy);
+    const relationships = RelationshipRepository.read(copy.elements);
     const r = relationships.map<UMLRelationship>(relationship =>
       (relationship.constructor as typeof Relationship).toUMLRelationship(relationship),
     );

--- a/src/components/theme/styles.ts
+++ b/src/components/theme/styles.ts
@@ -20,7 +20,6 @@ export const defaults: Styles = {
   interactiveAreaColor: 'rgba(0, 220, 0, 0.3)',
   interactiveAreaHoverColor: 'rgba(0, 220, 0, 0.15)',
   fontFamily: 'HelveticaNeue, Helvetica, Arial, Verdana, sans-serif',
-  headingFontFamily:
-    'HelveticaNeue-Light, Helvetica, Arial, Verdana, sans-serif',
+  headingFontFamily: 'HelveticaNeue-Light, Helvetica, Arial, Verdana, sans-serif',
   headingFontWeight: 300,
 };

--- a/src/packages/class-diagram/class-association/class-association.ts
+++ b/src/packages/class-diagram/class-association/class-association.ts
@@ -45,9 +45,10 @@ export abstract class ClassAssociation extends Relationship {
       this.multiplicity = { ...this.multiplicity, source: multiplicity };
       this.role = { ...this.role, source: role };
     }
+
     if ('multiplicity' in values.target) {
       const { multiplicity, role, ...target } = values.target;
-      values.target = target;
+      this.target = target;
       this.multiplicity = { ...this.multiplicity, target: multiplicity };
       this.role = { ...this.role, target: role };
     }

--- a/src/packages/class-diagram/class-association/class-association.tsx
+++ b/src/packages/class-diagram/class-association/class-association.tsx
@@ -2,44 +2,54 @@ import { UMLClassAssociation } from '..';
 import { IRelationship, Relationship } from '../../../services/relationship/relationship';
 import { UMLRelationship } from '../../../typings';
 
-export abstract class ClassAssociation extends Relationship {
+export interface IClassAssociation extends IRelationship {
+  multiplicity: { source: string; target: string };
+  role: { source: string; target: string };
+}
 
+export abstract class ClassAssociation extends Relationship {
   static toUMLRelationship(relationship: ClassAssociation): UMLClassAssociation {
     const umlRelationship = Relationship.toUMLRelationship(relationship);
     return {
       ...umlRelationship,
       source: {
         ...umlRelationship.source,
-        multiplicity: relationship.multiplicity.source,
-        role: relationship.role.source,
+        multiplicity: relationship.multiplicity.source || '',
+        role: relationship.role.source || '',
       },
       target: {
         ...umlRelationship.target,
-        multiplicity: relationship.multiplicity.target,
-        role: relationship.role.target,
+        multiplicity: relationship.multiplicity.target || '',
+        role: relationship.role.target || '',
       },
     };
   }
   multiplicity = { source: '', target: '' };
   role = { source: '', target: '' };
 
-  constructor(values?: IRelationship);
+  constructor(values?: IClassAssociation);
   constructor(values?: UMLClassAssociation);
   constructor(values?: IRelationship | UMLRelationship);
-  constructor(values?: IRelationship | UMLClassAssociation) {
-    super();
-    if (values && 'multiplicity' in values.source) {
+  constructor(values?: IClassAssociation | UMLClassAssociation) {
+    super(values);
+    if (!values) return;
+
+    if ('multiplicity' in values) {
+      this.multiplicity = { ...values.multiplicity };
+      this.role = { ...values.role };
+    }
+
+    if ('multiplicity' in values.source) {
       const { multiplicity, role, ...source } = values.source;
-      values.source = source;
+      this.source = source;
       this.multiplicity = { ...this.multiplicity, source: multiplicity };
       this.role = { ...this.role, source: role };
     }
-    if (values && 'multiplicity' in values.target) {
+    if ('multiplicity' in values.target) {
       const { multiplicity, role, ...target } = values.target;
       values.target = target;
       this.multiplicity = { ...this.multiplicity, target: multiplicity };
       this.role = { ...this.role, target: role };
     }
-    Object.assign(this, values);
   }
 }

--- a/src/packages/class-diagram/classifier/classifier.ts
+++ b/src/packages/class-diagram/classifier/classifier.ts
@@ -55,6 +55,7 @@ export abstract class Classifier extends Container {
 
     let y = this.headerHeight;
     for (const attribute of attributes) {
+      attribute.bounds.x = 0;
       attribute.bounds.y = y;
       attribute.bounds.width = this.bounds.width;
       y += attribute.bounds.height;
@@ -62,6 +63,7 @@ export abstract class Classifier extends Container {
     if (!this.isEnumeration) {
       this.deviderPosition = y;
       for (const method of methods) {
+        method.bounds.x = 0;
         method.bounds.y = y;
         method.bounds.width = this.bounds.width;
         y += method.bounds.height;

--- a/src/packages/class-diagram/classifier/classifier.ts
+++ b/src/packages/class-diagram/classifier/classifier.ts
@@ -49,45 +49,33 @@ export abstract class Classifier extends Container {
     super(values);
   }
 
-  render(elements: Element[]): Element[] {
-    const [parent, ...children] = super.render(elements);
-    const attributes = children.filter(c => c instanceof ClassAttribute);
-    let methods = children.filter(c => c instanceof ClassMethod);
+  render(children: Element[]): Element[] {
+    const attributes = children.filter(child => child instanceof ClassAttribute);
+    let methods = children.filter(child => child instanceof ClassMethod);
 
     let y = this.headerHeight;
-    for (const child of attributes) {
-      child.bounds.y = y;
-      child.bounds.width = this.bounds.width;
-      y += child.bounds.height;
+    for (const attribute of attributes) {
+      attribute.bounds.y = y;
+      attribute.bounds.width = this.bounds.width;
+      y += attribute.bounds.height;
     }
     if (!this.isEnumeration) {
       this.deviderPosition = y;
-      for (const child of methods) {
-        child.bounds.y = y;
-        child.bounds.width = this.bounds.width;
-        y += child.bounds.height;
+      for (const method of methods) {
+        method.bounds.y = y;
+        method.bounds.width = this.bounds.width;
+        y += method.bounds.height;
       }
     } else {
       this.deviderPosition = 0;
       methods = [];
     }
-    this.ownedElements = [...attributes.map(e => e.id), ...methods.map(e => e.id)];
 
-    parent.bounds.height = y;
-    return [parent, ...attributes, ...methods];
+    this.bounds.height = y;
+    return [this, ...attributes, ...methods];
   }
 
-  addElement(newElement: Element, currentElements: Element[]): Element[] {
-    const [parent, ...children] = super.addElement(newElement, currentElements);
-    return this.render(children);
-  }
-
-  removeElement(removedElement: string, currentElements: Element[]): Element[] {
-    const [parent, ...children] = super.removeElement(removedElement, currentElements);
-    return this.render(children);
-  }
-
-  resizeElement(children: Element[]): Element[] {
+  resize(children: Element[]): Element[] {
     const minWidth = children.reduce((width, child) => Math.max(width, ClassMember.calculateWidth(child.name)), 100);
     this.bounds.width = Math.max(this.bounds.width, minWidth);
     return [
@@ -104,8 +92,8 @@ export abstract class Classifier extends Container {
     return {
       element: {
         ...base,
-        attributes: children.filter(e => e instanceof ClassAttribute).map(e2 => e2.id),
-        methods: children.filter(e => e instanceof ClassMethod).map(e2 => e2.id),
+        attributes: children.filter(child => child instanceof ClassAttribute).map(child => child.id),
+        methods: children.filter(child => child instanceof ClassMethod).map(child => child.id),
       },
       children,
     };

--- a/src/packages/common/package/package.tsx
+++ b/src/packages/common/package/package.tsx
@@ -44,4 +44,11 @@ export class Package extends Container {
     const [_, ...children] = super.removeElement(removedElement, currentElements);
     return this.render(children);
   }
+
+  resizeElement(children: Element[]): Element[] {
+    const bounds = computeBoundingBoxForElements(children);
+    this.bounds.width = Math.max(this.bounds.width, bounds.x + bounds.width, 100);
+    this.bounds.height = Math.max(this.bounds.height, bounds.y + bounds.height, 100);
+    return [this, ...children];
+  }
 }

--- a/src/packages/common/package/package.tsx
+++ b/src/packages/common/package/package.tsx
@@ -1,5 +1,7 @@
 import { CommonElementType } from '..';
 import { Container } from '../../../services/container/container';
+import { Element } from '../../../services/element/element';
+import { computeBoundingBoxForElements } from '../../../utils/geometry/boundary';
 
 export class Package extends Container {
   static features = {
@@ -9,4 +11,37 @@ export class Package extends Container {
   };
 
   type = CommonElementType.Package;
+
+  render(elements: Element[]): Element[] {
+    const [parent, ...children] = super.render(elements);
+    const absoluteChildren: Element[] = children.map<Element>(child => {
+      child.bounds.x += parent.bounds.x;
+      child.bounds.y += parent.bounds.y;
+      return child;
+    });
+    const bounds = computeBoundingBoxForElements([parent, ...absoluteChildren]);
+    const relativeChildren: Element[] = absoluteChildren.map<Element>(child => {
+      child.bounds.x -= parent.bounds.x;
+      child.bounds.y -= parent.bounds.y;
+      return child;
+    });
+    const deltaX = bounds.x - parent.bounds.x;
+    const deltaY = bounds.y - parent.bounds.y;
+    relativeChildren.forEach(child => {
+      child.bounds.x -= deltaX;
+      child.bounds.y -= deltaY;
+    });
+    const resizedParent = new Package({ ...parent, bounds });
+    return [resizedParent, ...relativeChildren];
+  }
+
+  addElement(newElement: Element, currentElements: Element[]): Element[] {
+    const [_, ...children] = super.addElement(newElement, currentElements);
+    return this.render(children);
+  }
+
+  removeElement(removedElement: string, currentElements: Element[]): Element[] {
+    const [_, ...children] = super.removeElement(removedElement, currentElements);
+    return this.render(children);
+  }
 }

--- a/src/packages/common/package/package.tsx
+++ b/src/packages/common/package/package.tsx
@@ -35,17 +35,7 @@ export class Package extends Container {
     return [resizedParent, ...relativeChildren];
   }
 
-  addElement(newElement: Element, currentElements: Element[]): Element[] {
-    const [_, ...children] = super.addElement(newElement, currentElements);
-    return this.render(children);
-  }
-
-  removeElement(removedElement: string, currentElements: Element[]): Element[] {
-    const [_, ...children] = super.removeElement(removedElement, currentElements);
-    return this.render(children);
-  }
-
-  resizeElement(children: Element[]): Element[] {
+  resize(children: Element[]): Element[] {
     const bounds = computeBoundingBoxForElements(children);
     this.bounds.width = Math.max(this.bounds.width, bounds.x + bounds.width, 100);
     this.bounds.height = Math.max(this.bounds.height, bounds.y + bounds.height, 100);

--- a/src/packages/object-diagram/object-name/object-name.ts
+++ b/src/packages/object-diagram/object-name/object-name.ts
@@ -26,6 +26,7 @@ export class ObjectName extends Container {
 
     let y = this.headerHeight;
     for (const child of children) {
+      child.bounds.x = 0;
       child.bounds.y = y;
       child.bounds.width = this.bounds.width;
       y += child.bounds.height;

--- a/src/packages/object-diagram/object-name/object-name.ts
+++ b/src/packages/object-diagram/object-name/object-name.ts
@@ -35,17 +35,7 @@ export class ObjectName extends Container {
     return [parent, ...children];
   }
 
-  addElement(newElement: Element, currentElements: Element[]): Element[] {
-    const [parent, ...children] = super.addElement(newElement, currentElements);
-    return this.render(children);
-  }
-
-  removeElement(removedElement: string, currentElements: Element[]): Element[] {
-    const [parent, ...children] = super.removeElement(removedElement, currentElements);
-    return this.render(children);
-  }
-
-  resizeElement(children: Element[]): Element[] {
+  resize(children: Element[]): Element[] {
     const minWidth = children.reduce((width, child) => Math.max(width, ObjectAttribute.calculateWidth(child.name)), 100);
     this.bounds.width = Math.max(this.bounds.width, minWidth);
     return [

--- a/src/packages/use-case-diagram/use-case-system/use-case-system.ts
+++ b/src/packages/use-case-diagram/use-case-system/use-case-system.ts
@@ -1,7 +1,39 @@
 import { UseCaseElementType } from '..';
 import { Container } from '../../../services/container/container';
+import { Element } from '../../../services/element/element';
+import { computeBoundingBoxForElements } from '../../../utils/geometry/boundary';
 
 export class UseCaseSystem extends Container {
   static features = { ...Container.features, connectable: false };
   type = UseCaseElementType.UseCaseSystem;
+
+  render(elements: Element[]): Element[] {
+    const [parent, ...children] = super.render(elements);
+    const absoluteChildren: Element[] = children.map<Element>(child => {
+      child.bounds.x += parent.bounds.x;
+      child.bounds.y += parent.bounds.y;
+      return child;
+    });
+    const bounds = computeBoundingBoxForElements([parent, ...absoluteChildren]);
+    const relativeChildren: Element[] = absoluteChildren.map<Element>(child => {
+      child.bounds.x -= parent.bounds.x;
+      child.bounds.y -= parent.bounds.y;
+      return child;
+    });
+    const deltaX = bounds.x - parent.bounds.x;
+    const deltaY = bounds.y - parent.bounds.y;
+    relativeChildren.forEach(child => {
+      child.bounds.x -= deltaX;
+      child.bounds.y -= deltaY;
+    });
+    const resizedParent = new UseCaseSystem({ ...parent, bounds });
+    return [resizedParent, ...relativeChildren];
+  }
+
+  resize(children: Element[]): Element[] {
+    const bounds = computeBoundingBoxForElements(children);
+    this.bounds.width = Math.max(this.bounds.width, bounds.x + bounds.width, 100);
+    this.bounds.height = Math.max(this.bounds.height, bounds.y + bounds.height, 100);
+    return [this, ...children];
+  }
 }

--- a/src/scenes/svg-styles.ts
+++ b/src/scenes/svg-styles.ts
@@ -1,0 +1,11 @@
+import { css } from 'styled-components';
+
+export const Style = css`
+  text {
+    fill: black;
+    font-family: HelveticaNeue, Helvetica, Arial, Verdana, sans-serif;
+  }
+  * {
+    overflow: visible;
+  }
+`;

--- a/src/scenes/svg.tsx
+++ b/src/scenes/svg.tsx
@@ -64,11 +64,12 @@ const getInitialState = ({ state, options }: Props): State => {
   let elements = normalizeState(state);
 
   const bounds = computeBoundingBox(elements.filter(element => keepOriginalSize || layout.includes(element.id)));
-  if (options && options.margin) {
-    bounds.x -= options.margin;
-    bounds.y -= options.margin;
-    bounds.width += options.margin * 2;
-    bounds.height += options.margin * 2;
+  if (options) {
+    const margin = getMargin(options.margin);
+    bounds.x -= margin.left;
+    bounds.y -= margin.top;
+    bounds.width += margin.left + margin.right;
+    bounds.height += margin.top + margin.bottom;
   }
 
   elements = elements
@@ -79,6 +80,14 @@ const getInitialState = ({ state, options }: Props): State => {
       return element;
     });
   return { bounds, elements };
+};
+
+const getMargin = (margin: ExportOptions['margin']): { top: number; right: number; bottom: number; left: number } => {
+  if (typeof margin === 'number') {
+    return { top: margin, right: margin, bottom: margin, left: margin };
+  }
+  const result = { top: 0, right: 0, bottom: 0, left: 0 };
+  return Object.assign(result, margin);
 };
 
 const normalizeState = (state: ModelState): Element[] => {

--- a/src/scenes/svg.tsx
+++ b/src/scenes/svg.tsx
@@ -6,6 +6,7 @@ import { Relationships } from '../packages/relationships';
 import { Element } from '../services/element/element';
 import { ExportOptions, UMLModel } from '../typings';
 import { Boundary } from '../utils/geometry/boundary';
+import { Style } from './svg-styles';
 
 interface Props {
   model: UMLModel;
@@ -128,15 +129,7 @@ export class Svg extends Component<Props, State> {
         fill="white"
       >
         <defs>
-          <style>{`
-            text {
-              fill: black;
-              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
-            }
-            * {
-              overflow: visible;
-            }
-          `}</style>
+          <style>{Style}</style>
         </defs>
         {elements.map(element => {
           const ElementComponent = Components[element.type];

--- a/src/scenes/svg.tsx
+++ b/src/scenes/svg.tsx
@@ -151,7 +151,15 @@ export class Svg extends Component<Props, State> {
         fill="white"
       >
         <defs>
-          <style>{`text { fill: black } * { overflow: visible; }`}</style>
+          <style>{`
+            text {
+              fill: black;
+              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
+            }
+            * {
+              overflow: visible;
+            }
+          `}</style>
         </defs>
         {elements.map(element => {
           const ElementComponent = Components[element.type];

--- a/src/services/container/container-reducer.ts
+++ b/src/services/container/container-reducer.ts
@@ -1,7 +1,6 @@
 import { Reducer } from 'redux';
-import { ElementRepository } from '../element/element-repository';
 import { ElementState } from '../element/element-types';
-import { Container } from './container';
+import { IContainer } from './container';
 import { ContainerActions, ContainerActionTypes } from './container-types';
 
 const initialState: ElementState = {};
@@ -10,8 +9,7 @@ export const ContainerReducer: Reducer<ElementState, ContainerActions> = (state 
   switch (action.type) {
     case ContainerActionTypes.APPEND_CHILD: {
       const { payload } = action;
-      const container = ElementRepository.getById(state)(payload.owner);
-      if (!(container instanceof Container)) return state;
+      const container = state[payload.owner] as IContainer;
       return {
         ...state,
         [payload.owner]: {
@@ -23,15 +21,14 @@ export const ContainerReducer: Reducer<ElementState, ContainerActions> = (state 
     }
     case ContainerActionTypes.REMOVE_CHILD: {
       const { payload } = action;
-      const container = ElementRepository.getById(state)(payload.owner);
-      if (!(container instanceof Container)) return state;
+      const container = state[payload.owner] as IContainer;
       return {
         ...state,
         [payload.owner]: {
           ...container,
           ownedElements: container.ownedElements.filter(id => id !== payload.id),
         },
-        [payload.id]: { ...state[payload.id], owner: null },
+        ...(state[payload.id] && { [payload.id]: { ...state[payload.id], owner: null } }),
       };
     }
   }

--- a/src/services/container/container-saga.ts
+++ b/src/services/container/container-saga.ts
@@ -82,7 +82,10 @@ function* appendChild({ payload }: AppendChildAction) {
 function* removeChild({ payload }: RemoveChildAction) {
   const { elements }: ModelState = yield select();
   const element = ElementRepository.getById(elements)(payload.id);
-  if (!element) return;
+  if (!element) {
+    yield renderContainer(payload.owner);
+    return;
+  }
   const position = { x: element.bounds.x, y: element.bounds.y };
   let owner = ElementRepository.getById(elements)(payload.owner);
   while (owner) {
@@ -94,8 +97,6 @@ function* removeChild({ payload }: RemoveChildAction) {
 
   const delta = { x: position.x - element.bounds.x, y: position.y - element.bounds.y };
   yield put<MoveAction>(ElementRepository.move(element.id, delta));
-
-  yield renderContainer(payload.owner);
 }
 
 function* handleOwnerChange({ payload }: ChangeOwnerAction) {

--- a/src/services/container/container-saga.ts
+++ b/src/services/container/container-saga.ts
@@ -11,6 +11,7 @@ import {
   ResizeAction,
   UpdateAction,
 } from '../element/element-types';
+import { RelationshipRepository } from '../relationship/relationship-repository';
 import { Container } from './container';
 import { AppendChildAction, ChangeOwnerAction, ContainerActionTypes, RemoveChildAction } from './container-types';
 
@@ -102,7 +103,12 @@ function* handleOwnerChange({ payload }: ChangeOwnerAction) {
 
   const { elements }: ModelState = yield select();
   const selection = Object.values(elements).filter(e => e.selected);
-  if (selection.length > 1) return;
+  if (selection.length > 1) {
+    if (payload.owner) {
+      yield renderContainer(payload.owner);
+    }
+    return;
+  }
 
   const element = ElementRepository.getById(elements)(payload.id);
   if (!element) return;
@@ -113,6 +119,10 @@ function* handleOwnerChange({ payload }: ChangeOwnerAction) {
   }
 
   const owner = payload.owner && ElementRepository.getById(elements)(payload.owner);
+
+  if (!owner && payload.owner && RelationshipRepository.getById(elements)(payload.owner)) {
+    return;
+  }
 
   const current = element.owner && ElementRepository.getById(elements)(element.owner);
   if (owner && !(owner.constructor as typeof Container).features.droppable) return;

--- a/src/services/container/container.ts
+++ b/src/services/container/container.ts
@@ -23,19 +23,7 @@ export abstract class Container extends Element implements IContainer {
     return [this, ...children];
   }
 
-  addElement(newElement: Element, currentElements: Element[]): Element[] {
-    this.ownedElements.push(newElement.id);
-    newElement.owner = this.id;
-    return [this, ...currentElements, newElement];
-  }
-
-  removeElement(removedElement: string, currentElements: Element[]): Element[] {
-    this.ownedElements = this.ownedElements.filter(id => id !== removedElement);
-    const children = currentElements.filter(e => e.id !== removedElement);
-    return [this, ...children];
-  }
-
-  resizeElement(children: Element[]): Element[] {
+  resize(children: Element[]): Element[] {
     return [this, ...children];
   }
 }

--- a/src/services/diagram/diagram-reducer.ts
+++ b/src/services/diagram/diagram-reducer.ts
@@ -34,6 +34,13 @@ export const DiagramReducer: Reducer<DiagramState, DiagramActions> = (state = in
         ownedRelationships: state.ownedRelationships.filter(id => id !== payload.id),
       };
     }
+    case DiagramActionTypes.UPDATE_BOUNDS: {
+      const { payload } = action;
+      return {
+        ...state,
+        bounds: { ...payload.bounds },
+      };
+    }
   }
   return state;
 };

--- a/src/services/diagram/diagram-types.ts
+++ b/src/services/diagram/diagram-types.ts
@@ -1,18 +1,16 @@
 import { Action as ReduxAction } from 'redux';
 import { IDiagram } from './diagram';
+import { Boundary } from '../../utils/geometry/boundary';
 
 export const enum DiagramActionTypes {
   ADD_ELEMENT = '@@diagram/ADD_ELEMENT',
   ADD_RELATIONSHIP = '@@diagram/ADD_RELATIONSHIP',
   DELETE_ELEMENT = '@@diagram/DELETE_ELEMENT',
   DELETE_RELATIONSHIP = '@@diagram/DELETE_RELATIONSHIP',
+  UPDATE_BOUNDS = '@@diagram/UPDATE_BOUNDS',
 }
 
-export type DiagramActions =
-  | AddElementAction
-  | AddRelationshipAction
-  | DeleteElementAction
-  | DeleteRelationshipAction;
+export type DiagramActions = AddElementAction | AddRelationshipAction | DeleteElementAction | DeleteRelationshipAction | UpdateBoundsAction;
 
 export interface AddElementAction extends ReduxAction<DiagramActionTypes.ADD_ELEMENT> {
   payload: {
@@ -20,24 +18,27 @@ export interface AddElementAction extends ReduxAction<DiagramActionTypes.ADD_ELE
   };
 }
 
-export interface AddRelationshipAction
-  extends ReduxAction<DiagramActionTypes.ADD_RELATIONSHIP> {
+export interface AddRelationshipAction extends ReduxAction<DiagramActionTypes.ADD_RELATIONSHIP> {
   payload: {
     id: string;
   };
 }
 
-export interface DeleteElementAction
-  extends ReduxAction<DiagramActionTypes.DELETE_ELEMENT> {
+export interface DeleteElementAction extends ReduxAction<DiagramActionTypes.DELETE_ELEMENT> {
   payload: {
     id: string;
   };
 }
 
-export interface DeleteRelationshipAction
-  extends ReduxAction<DiagramActionTypes.DELETE_RELATIONSHIP> {
+export interface DeleteRelationshipAction extends ReduxAction<DiagramActionTypes.DELETE_RELATIONSHIP> {
   payload: {
     id: string;
+  };
+}
+
+export interface UpdateBoundsAction extends ReduxAction<DiagramActionTypes.UPDATE_BOUNDS> {
+  payload: {
+    bounds: Boundary;
   };
 }
 

--- a/src/services/diagram/diagram.ts
+++ b/src/services/diagram/diagram.ts
@@ -18,8 +18,8 @@ export class Diagram extends Container implements IDiagram {
 
   bounds: Boundary = {
     ...this.bounds,
-    width: 1600,
-    height: 1600,
+    width: 800,
+    height: 300,
   };
 
   constructor(values?: IDiagram);

--- a/src/services/element/element-repository.ts
+++ b/src/services/element/element-repository.ts
@@ -4,7 +4,7 @@ import { ElementType } from '../../packages/element-type';
 import { Elements } from '../../packages/elements';
 import { Point } from '../../utils/geometry/point';
 import { notEmpty } from '../../utils/not-empty';
-import { Element, IElement } from './element';
+import { Element } from './element';
 import {
   ChangeAction,
   CreateAction,
@@ -75,6 +75,10 @@ export class ElementRepository {
     if (!ElementClass) return null;
 
     return new ElementClass(element);
+  };
+
+  static getByIds = (state: ElementState) => (ids: string[]): Element[] => {
+    return ids.map(ElementRepository.getById(state)).filter(notEmpty);
   };
 
   static read = (state: ModelState): Element[] => {

--- a/src/services/element/element-repository.ts
+++ b/src/services/element/element-repository.ts
@@ -17,6 +17,7 @@ import {
   MoveAction,
   RenameAction,
   ResizeAction,
+  ResizedAction,
   SelectAction,
   UpdateAction,
 } from './element-types';
@@ -47,9 +48,14 @@ export class ElementRepository {
     payload: { id },
   });
 
-  static resize: ActionCreator<ResizeAction> = (id: string, delta: { width: number; height: number }) => ({
+  static resize = (id: string, delta: { width: number; height: number }): ResizeAction => ({
     type: ElementActionTypes.RESIZE,
     payload: { id, delta },
+  });
+
+  static resized = (id: string): ResizedAction => ({
+    type: ElementActionTypes.RESIZED,
+    payload: { id },
   });
 
   static move = (id: string | null, delta: { x: number; y: number }): MoveAction => ({

--- a/src/services/element/element-repository.ts
+++ b/src/services/element/element-repository.ts
@@ -87,14 +87,9 @@ export class ElementRepository {
     return ids.map(ElementRepository.getById(state)).filter(notEmpty);
   };
 
-  static read = (state: ModelState): Element[] => {
-    const elements = Object.keys(state.elements).reduce<ElementState>((r, e) => {
-      if (state.elements[e].type in ElementType) return { ...r, [e]: state.elements[e] };
-      return r;
-    }, {});
-
-    return Object.values(elements)
-      .map<Element | null>(element => ElementRepository.getById(state.elements)(element.id))
+  static read = (state: ElementState): Element[] => {
+    return Object.keys(state)
+      .map(ElementRepository.getById(state))
       .filter(notEmpty);
   };
 

--- a/src/services/element/element-types.ts
+++ b/src/services/element/element-types.ts
@@ -9,6 +9,7 @@ export const enum ElementActionTypes {
   SELECT = '@@element/SELECT',
   MAKE_INTERACTIVE = '@@element/MAKE_INTERACTIVE',
   RESIZE = '@@element/RESIZE',
+  RESIZED = '@@element/RESIZED',
   MOVE = '@@element/MOVE',
   UPDATE = '@@element/UPDATE',
   CHANGE = '@@element/CHANGE',
@@ -59,6 +60,12 @@ export interface ResizeAction extends Action<ElementActionTypes.RESIZE> {
   };
 }
 
+export interface ResizedAction extends Action<ElementActionTypes.RESIZED> {
+  payload: {
+    id: string;
+  };
+}
+
 export interface MoveAction extends Action<ElementActionTypes.MOVE> {
   payload: {
     id: string | null;
@@ -103,6 +110,7 @@ export type ElementActions =
   | SelectAction
   | MakeInteractiveAction
   | ResizeAction
+  | ResizedAction
   | MoveAction
   | ChangeAction
   | RenameAction

--- a/src/services/element/element.ts
+++ b/src/services/element/element.ts
@@ -30,7 +30,7 @@ export abstract class Element implements IElement {
   readonly id: string = uuid();
   name: string = '';
   abstract readonly type: ElementType | RelationshipType;
-  readonly bounds: Boundary = new Boundary(0, 0, 200, 100);
+  readonly bounds: Boundary = { x: 0, y: 0, width: 200, height: 100 };
   owner: string | null = null;
 
   hovered: boolean = false;
@@ -41,7 +41,15 @@ export abstract class Element implements IElement {
   constructor(values?: UMLElement);
   constructor(values?: IElement | UMLElement);
   constructor(values?: IElement | UMLElement) {
-    Object.assign(this, values);
+    if (values) {
+      Object.assign(this, { ...values, bounds: { ...values.bounds } });
+    }
+  }
+
+  copy<T extends Element>(): T {
+    const Constructor = (this.constructor as any) as new (values: IElement) => T;
+    const copy = new Constructor(this);
+    return copy;
   }
 
   toUMLElement(element: Element, children: Element[]): { element: UMLElement; children: Element[] } {

--- a/src/services/relationship/relationship-repository.ts
+++ b/src/services/relationship/relationship-repository.ts
@@ -1,7 +1,6 @@
 import { ModelState } from '../../components/store/model-state';
 import { RelationshipType } from '../../packages/relationship-type';
 import { Relationships } from '../../packages/relationships';
-import { UMLRelationship } from '../../typings';
 import { notEmpty } from '../../utils/not-empty';
 import { ElementState } from '../element/element-types';
 import { Port } from '../element/port';
@@ -29,14 +28,14 @@ export class RelationshipRepository {
     return new RelationshipClass(relationship);
   };
 
-  static read = (state: ModelState): Relationship[] => {
-    const relationships = Object.keys(state.elements).reduce<ElementState>((r, e) => {
-      if (state.elements[e].type in RelationshipType) return { ...r, [e]: state.elements[e] };
+  static read = (state: ElementState): Relationship[] => {
+    const relationships = Object.keys(state).reduce<ElementState>((r, e) => {
+      if (state[e].type in RelationshipType) return { ...r, [e]: state[e] };
       return r;
     }, {});
 
     return Object.values(relationships)
-      .map<Relationship | null>(element => RelationshipRepository.getById(state.elements)(element.id))
+      .map<Relationship | null>(element => RelationshipRepository.getById(state)(element.id))
       .filter(notEmpty);
   };
 }

--- a/src/services/relationship/relationship-repository.ts
+++ b/src/services/relationship/relationship-repository.ts
@@ -1,4 +1,3 @@
-import { ModelState } from '../../components/store/model-state';
 import { RelationshipType } from '../../packages/relationship-type';
 import { Relationships } from '../../packages/relationships';
 import { notEmpty } from '../../utils/not-empty';
@@ -26,6 +25,10 @@ export class RelationshipRepository {
     if (!RelationshipClass) return null;
 
     return new RelationshipClass(relationship);
+  };
+
+  static getByIds = (state: ElementState) => (ids: string[]): Relationship[] => {
+    return ids.map(RelationshipRepository.getById(state)).filter(notEmpty);
   };
 
   static read = (state: ElementState): Relationship[] => {

--- a/src/services/relationship/relationship-saga.ts
+++ b/src/services/relationship/relationship-saga.ts
@@ -107,6 +107,18 @@ function* recalc(id: string) {
   const bounds = { x, y, width, height };
   path = path.map(point => new Point(point.x - x, point.y - y));
 
+  if (bounds.width === 1 && bounds.height === 1) {
+    yield put<RedrawAction>({
+      type: RelationshipActionTypes.REDRAW,
+      payload: {
+        id: relationship.id,
+        path,
+        bounds,
+      },
+    });
+    return;
+  }
+
   const copy: Relationship = relationship.copy();
   Object.assign(copy, { bounds: { ...bounds }, path: [...path] });
   let computedBounds: Boundary = yield computeBoundingBoxForRelationship(copy);

--- a/src/services/relationship/relationship-saga.ts
+++ b/src/services/relationship/relationship-saga.ts
@@ -102,22 +102,10 @@ function* recalc(id: string) {
 
   const x = Math.min(...path.map(point => point.x));
   const y = Math.min(...path.map(point => point.y));
-  const width = Math.max(Math.max(...path.map(point => point.x)) - x, 1);
-  const height = Math.max(Math.max(...path.map(point => point.y)) - y, 1);
+  const width = Math.max(...path.map(point => point.x)) - x;
+  const height = Math.max(...path.map(point => point.y)) - y;
   const bounds = { x, y, width, height };
   path = path.map(point => new Point(point.x - x, point.y - y));
-
-  if (bounds.width === 1 && bounds.height === 1) {
-    yield put<RedrawAction>({
-      type: RelationshipActionTypes.REDRAW,
-      payload: {
-        id: relationship.id,
-        path,
-        bounds,
-      },
-    });
-    return;
-  }
 
   const copy: Relationship = relationship.copy();
   Object.assign(copy, { bounds: { ...bounds }, path: [...path] });

--- a/src/services/relationship/relationship-saga.ts
+++ b/src/services/relationship/relationship-saga.ts
@@ -14,7 +14,7 @@ import { ConnectAction, CreateAction, RedrawAction, RelationshipActionTypes } fr
 export function* RelationshipSaga() {
   yield takeEvery(RelationshipActionTypes.CREATE, handleRelationshipCreation);
   yield takeEvery(RelationshipActionTypes.CONNECT, handleRelationshipConnect);
-  yield takeLatest(ElementActionTypes.MOVE, handleElementMove);
+  yield takeEvery(ElementActionTypes.MOVE, handleElementMove);
   yield takeEvery(ElementActionTypes.RESIZE, handleElementResize);
   yield takeLatest(ElementActionTypes.UPDATE, handleElementUpdate);
   yield takeLatest(ElementActionTypes.DELETE, handleElementDelete);

--- a/src/services/relationship/relationship.ts
+++ b/src/services/relationship/relationship.ts
@@ -27,7 +27,7 @@ export abstract class Relationship extends Element implements IRelationship {
 
   abstract readonly type: RelationshipType;
 
-  path = [{ x: 0, y: 0 }, { x: 0, y: 0 }];
+  path = [{ x: 0, y: 0 }, { x: 200, y: 100 }];
 
   source: Port = {
     element: '',
@@ -44,6 +44,14 @@ export abstract class Relationship extends Element implements IRelationship {
   constructor(values?: IRelationship | UMLRelationship);
   constructor(values?: IRelationship | UMLRelationship) {
     super();
-    Object.assign(this, values);
+    if (values) {
+      Object.assign(this, {
+        ...values,
+        path: [...values.path],
+        bounds: { ...values.bounds },
+        source: { ...values.source },
+        target: { ...values.target },
+      });
+    }
   }
 }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -88,6 +88,8 @@ export interface ExportOptions {
 export interface SVG {
   svg: string;
   clip: {
+    x: number;
+    y: number;
     width: number;
     height: number;
   };

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -79,7 +79,7 @@ export interface ApollonOptions {
 }
 
 export interface ExportOptions {
-  margin?: number;
+  margin?: number | { top?: number; right?: number; bottom?: number; left?: number };
   keepOriginalSize?: boolean;
   include?: string[];
   exclude?: string[];

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -88,8 +88,6 @@ export interface ExportOptions {
 export interface SVG {
   svg: string;
   clip: {
-    x: number;
-    y: number;
     width: number;
     height: number;
   };

--- a/src/utils/geometry/boundary.ts
+++ b/src/utils/geometry/boundary.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { Components } from '../../packages/components';
+import { Element } from '../../services/element/element';
 import { Relationship } from '../../services/relationship/relationship';
 import { Point } from './point';
 
@@ -42,6 +43,18 @@ export function computeBoundingBox(points: Point[]): Boundary {
     width: maxX - minX,
     height: maxY - minY,
   };
+}
+
+export function computeBoundingBoxForElements(elements: Element[]): Boundary {
+  if (!elements.length) {
+    return { x: 0, y: 0, width: 0, height: 0 };
+  }
+  const boundaries: Boundary[] = elements.map<Boundary>(element => ({ ...element.bounds }));
+  const x = Math.min(...boundaries.map(bounds => bounds.x));
+  const y = Math.min(...boundaries.map(bounds => bounds.y));
+  const width = Math.max(...boundaries.map(bounds => bounds.x + bounds.width)) - x;
+  const height = Math.max(...boundaries.map(bounds => bounds.y + bounds.height)) - y;
+  return { x, y, width, height };
 }
 
 export async function computeBoundingBoxForRelationship(relationship: Relationship): Promise<Boundary> {

--- a/src/utils/geometry/boundary.ts
+++ b/src/utils/geometry/boundary.ts
@@ -68,8 +68,8 @@ export async function computeBoundingBoxForRelationship(relationship: Relationsh
         bounds = {
           x: child.x - parent.x,
           y: child.y - parent.y,
-          width: child.width,
-          height: child.height,
+          width: Math.max(child.width, 1),
+          height: Math.max(child.height, 1),
         };
       }
       unmountComponentAtNode(svg);

--- a/src/utils/geometry/boundary.ts
+++ b/src/utils/geometry/boundary.ts
@@ -12,10 +12,6 @@ export interface Boundary {
   height: number;
 }
 
-export class Boundary {
-  constructor(public x: number, public y: number, public width: number, public height: number) {}
-}
-
 export function computeBoundingBox(points: Point[]): Boundary {
   if (points.length === 0) {
     return { x: 0, y: 0, width: 0, height: 0 };
@@ -65,7 +61,7 @@ export async function computeBoundingBoxForRelationship(relationship: Relationsh
   const element = createElement(Component, { element: relationship });
   return new Promise((resolve, reject) => {
     render(element, svg, () => {
-      let bounds: Boundary = new Boundary(0, 0, 0, 0);
+      let bounds: Boundary = { x: 0, y: 0, width: 0, height: 0 };
       if (svg.firstElementChild) {
         const parent = svg.getBoundingClientRect() as DOMRect;
         const child = svg.firstElementChild.getBoundingClientRect() as DOMRect;

--- a/src/utils/geometry/boundary.ts
+++ b/src/utils/geometry/boundary.ts
@@ -57,6 +57,7 @@ export async function computeBoundingBoxForRelationship(relationship: Relationsh
   const Component = Components[relationship.type];
   const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   svg.style.visibility = 'none';
+  svg.style.fontFamily = 'HelveticaNeue, Helvetica, Arial, Verdana, sans-serif';
   document.body.appendChild(svg);
   const element = createElement(Component, { element: relationship });
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
### Motivation and Context

Elements inside a container should not overlap their container. Therefore, the app now listens to resize or move events of elements to adjust their container size accordingly. The same functionality was added to the surrounding diagram to prevent unnecessary scrollbars on the canvas.

### Description

Side Effects now handle the following use cases:
- After an element was moved within a container overlapping its boundaries, the container is resized to fit the element
- While an element is resized within a container and tries to overlap its boundaries, the container is resized to fit the element
- At all time, the boundaries of the surrounding diagram container is computed and stored in the model state. Only, if the diagram boundary exceeds the visible canvas area, scrollbars are shown.
- The exposed `UMLModel` now contains only absolutely positioned elements. This makes further processing like drawing as SVG easier.
- Optimised transformation between positioning on screen and in model by highly relying on css which boost the performance