### PR TITLE
Allow Package Names

### DIFF
--- a/src/packages/common/package/package-component.tsx
+++ b/src/packages/common/package/package-component.tsx
@@ -5,6 +5,9 @@ export const PackageComponent: SFC<Props> = ({ element, children }) => (
   <g>
     <path d={`M 0 10 V 0 H 40 V 10`} stroke="black" />
     <rect y="10" width="100%" height={element.bounds.height - 10} stroke="black" />
+    <text x="50%" y="15" dominantBaseline="hanging" textAnchor="middle" fontWeight="bold">
+      {element.name}
+    </text>
     {children}
   </g>
 );

--- a/src/packages/common/package/package.ts
+++ b/src/packages/common/package/package.ts
@@ -7,7 +7,6 @@ export class Package extends Container {
   static features = {
     ...Container.features,
     connectable: false,
-    editable: false,
   };
 
   type = CommonElementType.Package;


### PR DESCRIPTION
### Motivation and Context

Enable renaming of packages and display the name center at the top of the package.

### Screenshots

<img width="694" alt="Screenshot 2019-04-04 at 00 55 24" src="https://user-images.githubusercontent.com/38191490/55518445-614ad500-5674-11e9-859d-314ee0d81c3e.png">
