### PR TITLE
Extend Activity Diagrams

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -45,7 +45,8 @@
     "activityDiagram": {
       "actionNode": "Aktion",
       "objectNode": "Objekt",
-      "condition": "Bedingung"
+      "condition": "Bedingung",
+      "controlFlow": "Kontrollfluss"
     },
     "useCaseDiagram": {
       "useCase": "Anwendungsfall",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -15,7 +15,8 @@
     "methods": "Methoden",
     "association": "Assoziation",
     "multiplicity": "Multiziplität",
-    "role": "Rolle"
+    "role": "Rolle",
+    "condition": "Optionen"
   },
   "assessment": {
     "assessment": "Bewertung für",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -15,7 +15,8 @@
     "methods": "Methods",
     "association": "Association",
     "multiplicity": "Multiplicity",
-    "role": "Role"
+    "role": "Role",
+    "condition": "Options"
   },
   "assessment": {
     "assessment": "Assessment for",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -45,7 +45,8 @@
     "activityDiagram": {
       "actionNode": "Action",
       "objectNode": "Object",
-      "condition": "Condition"
+      "condition": "Condition",
+      "controlFlow": "Control Flow"
     },
     "useCaseDiagram": {
       "useCase": "UseCase",

--- a/src/packages/activity-diagram/activity-control-flow/activity-control-flow-component.tsx
+++ b/src/packages/activity-diagram/activity-control-flow/activity-control-flow-component.tsx
@@ -1,39 +1,41 @@
 import React, { SFC } from 'react';
-import { Port } from '../../../services/element/port';
-import { Direction } from '../../../typings';
+import { Point } from '../../../utils/geometry/point';
 import { ActivityControlFlow } from './activity-control-flow';
 
 export const ActivityControlFlowComponent: SFC<Props> = ({ element }) => {
-  const layoutText = (location: Port['direction']) => {
-    switch (location) {
-      case Direction.Up:
+  let position = { x: 0, y: 0 };
+  let direction: 'v' | 'h' = 'v';
+  const path = element.path.map(point => new Point(point.x, point.y));
+  let distance =
+    path.reduce((length, point, i, points) => (i + 1 < points.length ? length + points[i + 1].subtract(point).length : length), 0) / 2;
+
+  for (let index = 0; index < path.length - 1; index++) {
+    const vector = path[index + 1].subtract(path[index]);
+    if (vector.length > distance) {
+      const norm = vector.normalize();
+      direction = Math.abs(norm.x) > Math.abs(norm.y) ? 'h' : 'v';
+      position = path[index].add(norm.scale(distance));
+      break;
+    }
+    distance -= vector.length;
+  }
+
+  const layoutText = (dir: 'v' | 'h') => {
+    switch (dir) {
+      case 'v':
         return {
-          dx: -5,
-          dominantBaseline: 'text-after-edge',
-          textAnchor: 'end',
-        };
-      case Direction.Right:
-        return {
-          dy: -10,
-          dominantBaseline: 'text-after-edge',
+          dx: 5,
+          dominantBaseline: 'middle',
           textAnchor: 'start',
         };
-      case Direction.Down:
+      case 'h':
         return {
-          dx: -5,
-          dominantBaseline: 'text-before-edge',
-          textAnchor: 'end',
-        };
-      case Direction.Left:
-        return {
-          dy: -10,
+          dy: -5,
           dominantBaseline: 'text-after-edge',
-          textAnchor: 'end',
+          textAnchor: 'middle',
         };
     }
   };
-
-  const source = { ...element.path[0] };
 
   return (
     <g>
@@ -57,7 +59,7 @@ export const ActivityControlFlowComponent: SFC<Props> = ({ element }) => {
         strokeWidth={1}
         markerEnd={`url(#marker-${element.id})`}
       />
-      <text x={source.x} y={source.y} {...layoutText(element.source.direction)}>
+      <text x={position.x} y={position.y} {...layoutText(direction)}>
         {element.name}
       </text>
     </g>

--- a/src/packages/activity-diagram/activity-control-flow/activity-control-flow-component.tsx
+++ b/src/packages/activity-diagram/activity-control-flow/activity-control-flow-component.tsx
@@ -1,30 +1,68 @@
 import React, { SFC } from 'react';
-import {ActivityControlFlow} from './activity-control-flow';
+import { Port } from '../../../services/element/port';
+import { Direction } from '../../../typings';
+import { ActivityControlFlow } from './activity-control-flow';
 
-export const ActivityControlFlowComponent: SFC<Props> = ({ element }) => (
-  <g>
-    <marker
-      id={`marker-${element.id}`}
-      viewBox="0 0 30 30"
-      markerWidth="22"
-      markerHeight="30"
-      refX="30"
-      refY="15"
-      orient="auto"
-      markerUnits="strokeWidth"
-      strokeDasharray="1,0"
-    >
-      <path d="M0,29 L30,15 L0,1" fill="none" stroke="black" />
-    </marker>
-    <polyline
-      points={element.path.map(point => `${point.x} ${point.y}`).join(',')}
-      stroke="black"
-      fill="none"
-      strokeWidth={1}
-      markerEnd={`url(#marker-${element.id})`}
-    />
-  </g>
-);
+export const ActivityControlFlowComponent: SFC<Props> = ({ element }) => {
+  const layoutText = (location: Port['direction']) => {
+    switch (location) {
+      case Direction.Up:
+        return {
+          dx: -5,
+          dominantBaseline: 'text-after-edge',
+          textAnchor: 'end',
+        };
+      case Direction.Right:
+        return {
+          dy: -10,
+          dominantBaseline: 'text-after-edge',
+          textAnchor: 'start',
+        };
+      case Direction.Down:
+        return {
+          dx: -5,
+          dominantBaseline: 'text-before-edge',
+          textAnchor: 'end',
+        };
+      case Direction.Left:
+        return {
+          dy: -10,
+          dominantBaseline: 'text-after-edge',
+          textAnchor: 'end',
+        };
+    }
+  };
+
+  const source = { ...element.path[0] };
+
+  return (
+    <g>
+      <marker
+        id={`marker-${element.id}`}
+        viewBox="0 0 30 30"
+        markerWidth="22"
+        markerHeight="30"
+        refX="30"
+        refY="15"
+        orient="auto"
+        markerUnits="strokeWidth"
+        strokeDasharray="1,0"
+      >
+        <path d="M0,29 L30,15 L0,1" fill="none" stroke="black" />
+      </marker>
+      <polyline
+        points={element.path.map(point => `${point.x} ${point.y}`).join(',')}
+        stroke="black"
+        fill="none"
+        strokeWidth={1}
+        markerEnd={`url(#marker-${element.id})`}
+      />
+      <text x={source.x} y={source.y} {...layoutText(element.source.direction)}>
+        {element.name}
+      </text>
+    </g>
+  );
+};
 
 interface Props {
   element: ActivityControlFlow;

--- a/src/packages/activity-diagram/activity-control-flow/activity-control-flow-popup.tsx
+++ b/src/packages/activity-diagram/activity-control-flow/activity-control-flow-popup.tsx
@@ -7,6 +7,8 @@ import { I18nContext } from '../../../components/i18n/i18n-context';
 import { localized } from '../../../components/i18n/localized';
 import { Header } from '../../../components/popup/controls/header';
 import { Section } from '../../../components/popup/controls/section';
+import { TextField } from '../../../components/popup/controls/textfield';
+import { ElementRepository } from '../../../services/element/element-repository';
 import { RelationshipRepository } from '../../../services/relationship/relationship-repository';
 import { ModelState } from './../../../components/store/model-state';
 import { ActivityControlFlow } from './activity-control-flow';
@@ -29,9 +31,16 @@ class ActivityControlFlowPopupComponent extends Component<Props> {
             <FlipIcon fill="black" onClick={() => this.props.flip(element.id)} />
           </Flex>
         </Section>
+        <Section>
+          <TextField value={element.name} onUpdate={this.rename} />
+        </Section>
       </div>
     );
   }
+
+  private rename = (value: string) => {
+    this.props.rename(this.props.element.id, value);
+  };
 }
 
 type OwnProps = {
@@ -41,6 +50,7 @@ type OwnProps = {
 type StateProps = {};
 
 type DispatchProps = {
+  rename: typeof ElementRepository.rename;
   flip: typeof RelationshipRepository.flip;
 };
 
@@ -51,6 +61,7 @@ const enhance = compose<ComponentClass<OwnProps>>(
   connect<StateProps, DispatchProps, OwnProps, ModelState>(
     null,
     {
+      rename: ElementRepository.rename,
       flip: RelationshipRepository.flip,
     },
   ),

--- a/src/packages/activity-diagram/activity-control-flow/activity-control-flow-popup.tsx
+++ b/src/packages/activity-diagram/activity-control-flow/activity-control-flow-popup.tsx
@@ -1,0 +1,59 @@
+import React, { Component, ComponentClass } from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import styled from 'styled-components';
+import { FlipIcon } from '../../../components/controls/flip-icon';
+import { I18nContext } from '../../../components/i18n/i18n-context';
+import { localized } from '../../../components/i18n/localized';
+import { Header } from '../../../components/popup/controls/header';
+import { Section } from '../../../components/popup/controls/section';
+import { RelationshipRepository } from '../../../services/relationship/relationship-repository';
+import { ModelState } from './../../../components/store/model-state';
+import { ActivityControlFlow } from './activity-control-flow';
+
+const Flex = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+class ActivityControlFlowPopupComponent extends Component<Props> {
+  render() {
+    const { element } = this.props;
+
+    return (
+      <div>
+        <Section>
+          <Flex>
+            <Header>{this.props.translate('packages.activityDiagram.controlFlow')}</Header>
+            <FlipIcon fill="black" onClick={() => this.props.flip(element.id)} />
+          </Flex>
+        </Section>
+      </div>
+    );
+  }
+}
+
+type OwnProps = {
+  element: ActivityControlFlow;
+};
+
+type StateProps = {};
+
+type DispatchProps = {
+  flip: typeof RelationshipRepository.flip;
+};
+
+type Props = OwnProps & StateProps & DispatchProps & I18nContext;
+
+const enhance = compose<ComponentClass<OwnProps>>(
+  localized,
+  connect<StateProps, DispatchProps, OwnProps, ModelState>(
+    null,
+    {
+      flip: RelationshipRepository.flip,
+    },
+  ),
+);
+
+export const ActivityControlFlowPopup = enhance(ActivityControlFlowPopupComponent);

--- a/src/packages/activity-diagram/activity-final-node/activity-final-node.ts
+++ b/src/packages/activity-diagram/activity-final-node/activity-final-node.ts
@@ -1,10 +1,20 @@
 import { ActivityElementType } from '..';
-import { Element } from '../../../services/element/element';
-import { Boundary } from '../../../utils/geometry/boundary';
+import { Element, IElement } from '../../../services/element/element';
+import { UMLElement } from '../../../typings';
 
 export class ActivityFinalNode extends Element {
   static features = { ...Element.features, editable: false };
 
   type = ActivityElementType.ActivityFinalNode;
-  bounds: Boundary = { ...this.bounds, width: 45, height: 45 };
+
+  constructor(values?: IElement);
+  constructor(values?: UMLElement);
+  constructor(values?: IElement | UMLElement);
+  constructor(values?: IElement | UMLElement) {
+    super(values);
+
+    if (!values) {
+      Object.assign(this, { bounds: { ...this.bounds, width: 45, height: 45 } });
+    }
+  }
 }

--- a/src/packages/activity-diagram/activity-fork-node/activity-fork-node.ts
+++ b/src/packages/activity-diagram/activity-fork-node/activity-fork-node.ts
@@ -1,10 +1,20 @@
 import { ActivityElementType } from '..';
-import { Element } from '../../../services/element/element';
-import { Boundary } from '../../../utils/geometry/boundary';
+import { Element, IElement } from '../../../services/element/element';
+import { UMLElement } from '../../../typings';
 
 export class ActivityForkNode extends Element {
   static features = { ...Element.features, editable: false };
 
   type = ActivityElementType.ActivityForkNode;
-  bounds: Boundary = { ...this.bounds, width: 20, height: 60 };
+
+  constructor(values?: IElement);
+  constructor(values?: UMLElement);
+  constructor(values?: IElement | UMLElement);
+  constructor(values?: IElement | UMLElement) {
+    super(values);
+
+    if (!values) {
+      Object.assign(this, { bounds: { ...this.bounds, width: 20, height: 60 } });
+    }
+  }
 }

--- a/src/packages/activity-diagram/activity-initial-node/activity-initial-node.ts
+++ b/src/packages/activity-diagram/activity-initial-node/activity-initial-node.ts
@@ -1,10 +1,20 @@
 import { ActivityElementType } from '..';
-import { Element } from '../../../services/element/element';
-import { Boundary } from '../../../utils/geometry/boundary';
+import { Element, IElement } from '../../../services/element/element';
+import { UMLElement } from '../../../typings';
 
 export class ActivityInitialNode extends Element {
   static features = { ...Element.features, editable: false };
 
   type = ActivityElementType.ActivityInitialNode;
-  bounds: Boundary = { ...this.bounds, width: 45, height: 45 };
+
+  constructor(values?: IElement);
+  constructor(values?: UMLElement);
+  constructor(values?: IElement | UMLElement);
+  constructor(values?: IElement | UMLElement) {
+    super(values);
+
+    if (!values) {
+      Object.assign(this, { bounds: { ...this.bounds, width: 45, height: 45 } });
+    }
+  }
 }

--- a/src/packages/activity-diagram/activity-merge-node/activity-merge-node-popup.tsx
+++ b/src/packages/activity-diagram/activity-merge-node/activity-merge-node-popup.tsx
@@ -1,0 +1,86 @@
+import React, { Component, ComponentClass } from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import styled from 'styled-components';
+import { I18nContext } from '../../../components/i18n/i18n-context';
+import { localized } from '../../../components/i18n/localized';
+import { Divider } from '../../../components/popup/controls/divider';
+import { Header } from '../../../components/popup/controls/header';
+import { Section } from '../../../components/popup/controls/section';
+import { TextField } from '../../../components/popup/controls/textfield';
+import { Element } from '../../../services/element/element';
+import { ElementRepository } from '../../../services/element/element-repository';
+import { Relationship } from '../../../services/relationship/relationship';
+import { RelationshipRepository } from '../../../services/relationship/relationship-repository';
+import { ModelState } from './../../../components/store/model-state';
+import { ActivityMergeNode } from './activity-merge-node';
+
+const Flex = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+class ActivityMergeNodePopupComponent extends Component<Props> {
+  render() {
+    const { element, relationships } = this.props;
+
+    const decisions = relationships.filter(relationship => relationship.source.element === element.id);
+    const targets = this.props.getByIds(decisions.map(relationship => relationship.target.element));
+
+    return (
+      <div>
+        <Section>
+          <TextField value={element.name} onUpdate={this.onUpdate} />
+          <Divider />
+        </Section>
+        <Section>
+          <Header>{this.props.translate('popup.condition')}</Header>
+          {decisions.map((decision, i) => (
+            <Flex key={decision.id}>
+              <span>→&nbsp;{targets[i].name}&nbsp;</span>
+              <TextField value={decision.name} onUpdate={this.onUpdateOption(decision.id)} />
+            </Flex>
+          ))}
+        </Section>
+      </div>
+    );
+  }
+
+  private onUpdate = (value: string) => {
+    const { element, rename } = this.props;
+    rename(element.id, value);
+  };
+
+  private onUpdateOption = (id: string) => (value: string) => {
+    const { rename } = this.props;
+    rename(id, value);
+  };
+}
+
+type OwnProps = {
+  element: ActivityMergeNode;
+};
+
+type StateProps = {
+  relationships: Relationship[];
+  getByIds: (id: string[]) => Element[];
+};
+
+type DispatchProps = {
+  rename: typeof ElementRepository.rename;
+};
+
+type Props = OwnProps & StateProps & DispatchProps & I18nContext;
+
+const enhance = compose<ComponentClass<OwnProps>>(
+  localized,
+  connect<StateProps, DispatchProps, OwnProps, ModelState>(
+    state => ({ relationships: RelationshipRepository.read(state.elements), getByIds: ElementRepository.getByIds(state.elements) }),
+    {
+      rename: ElementRepository.rename,
+    },
+  ),
+);
+
+export const ActivityMergeNodePopup = enhance(ActivityMergeNodePopupComponent);

--- a/src/packages/activity-diagram/activity-merge-node/activity-merge-node.ts
+++ b/src/packages/activity-diagram/activity-merge-node/activity-merge-node.ts
@@ -1,8 +1,18 @@
 import { ActivityElementType } from '..';
-import { Element } from '../../../services/element/element';
-import { Boundary } from '../../../utils/geometry/boundary';
+import { Element, IElement } from '../../../services/element/element';
+import { UMLElement } from '../../../typings';
 
 export class ActivityMergeNode extends Element {
   type = ActivityElementType.ActivityMergeNode;
-  bounds: Boundary = { ...this.bounds, height: 60 };
+
+  constructor(values?: IElement);
+  constructor(values?: UMLElement);
+  constructor(values?: IElement | UMLElement);
+  constructor(values?: IElement | UMLElement) {
+    super(values);
+
+    if (!values) {
+      Object.assign(this, { bounds: { ...this.bounds, height: 60 } });
+    }
+  }
 }

--- a/src/packages/popups.ts
+++ b/src/packages/popups.ts
@@ -1,5 +1,6 @@
 import { ComponentClass } from 'react';
 import { ActivityControlFlowPopup } from './activity-diagram/activity-control-flow/activity-control-flow-popup';
+import { ActivityMergeNodePopup } from './activity-diagram/activity-merge-node/activity-merge-node-popup';
 import { ClassAssociationPopup } from './class-diagram/class-association/class-association-popup';
 import { ClassifierPopup } from './class-diagram/classifier/classifier-popup';
 import { DefaultPopup } from './common/default-popup';
@@ -24,7 +25,7 @@ export const Popups: { [key in ElementType | RelationshipType]: ComponentClass<{
   [ElementType.ActivityFinalNode]: DefaultPopup,
   [ElementType.ActivityForkNode]: DefaultPopup,
   [ElementType.ActivityInitialNode]: DefaultPopup,
-  [ElementType.ActivityMergeNode]: DefaultPopup,
+  [ElementType.ActivityMergeNode]: ActivityMergeNodePopup,
   [ElementType.ActivityObjectNode]: DefaultPopup,
   [ElementType.UseCase]: DefaultPopup,
   [ElementType.UseCaseActor]: DefaultPopup,

--- a/src/packages/popups.ts
+++ b/src/packages/popups.ts
@@ -1,11 +1,11 @@
 import { ComponentClass } from 'react';
-import { ElementType } from './element-type';
-import { RelationshipType } from './relationship-type';
-
+import { ActivityControlFlowPopup } from './activity-diagram/activity-control-flow/activity-control-flow-popup';
 import { ClassAssociationPopup } from './class-diagram/class-association/class-association-popup';
 import { ClassifierPopup } from './class-diagram/classifier/classifier-popup';
 import { DefaultPopup } from './common/default-popup';
+import { ElementType } from './element-type';
 import { ObjectNamePopup } from './object-diagram/object-name/object-name-popup';
+import { RelationshipType } from './relationship-type';
 import { UseCaseAssociationPopup } from './use-case-diagram/use-case-association/use-case-association-popup';
 
 export type Popups = { [key in ElementType | RelationshipType]: ComponentClass<{ element: any }> | null };
@@ -37,7 +37,7 @@ export const Popups: { [key in ElementType | RelationshipType]: ComponentClass<{
   [RelationshipType.ClassRealization]: ClassAssociationPopup,
   [RelationshipType.ClassUnidirectional]: ClassAssociationPopup,
   [RelationshipType.ObjectLink]: null,
-  [RelationshipType.ActivityControlFlow]: null,
+  [RelationshipType.ActivityControlFlow]: ActivityControlFlowPopup,
   [RelationshipType.UseCaseAssociation]: UseCaseAssociationPopup,
   [RelationshipType.UseCaseExtend]: UseCaseAssociationPopup,
   [RelationshipType.UseCaseGeneralization]: UseCaseAssociationPopup,


### PR DESCRIPTION
### Motivation and Context

For Activity Diagrams, some features were missing or buggy.

### Description

- All Activity Diagram related Elements can now be resized correctly
- One can now flip activity control flows.
- For conditions, the different paths can now be named and the name is displayed.

### Screenshots

<img width="517" alt="Screenshot 2019-04-06 at 20 18 33" src="https://user-images.githubusercontent.com/38191490/55673523-48773500-58a9-11e9-8f34-5df58dd026b2.png">

> Relationship flip button in new control flow popup

<img width="537" alt="Screenshot 2019-04-06 at 20 19 10" src="https://user-images.githubusercontent.com/38191490/55673532-70669880-58a9-11e9-8c7d-557781a2d59e.png">

> Naming of different option paths for conditions