### PR TITLE
Support Microsoft Edge

### DIFF
--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -48,8 +48,10 @@ class CanvasComponent extends Component<Props, State> {
 
   center = () => {
     const container = this.canvas.current!.parentElement!;
-    const { width, height } = container.getBoundingClientRect();
-    container.scrollTo(this.props.diagram.bounds.width / 2 - width / 2, this.props.diagram.bounds.height / 2 - height / 2);
+    if ('scrollTo' in container) {
+      const { width, height } = container.getBoundingClientRect();
+      container.scrollTo(this.props.diagram.bounds.width / 2 - width / 2, this.props.diagram.bounds.height / 2 - height / 2);
+    }
   };
 
   onDrop = (event: DropEvent) => {

--- a/src/components/container/container.tsx
+++ b/src/components/container/container.tsx
@@ -8,5 +8,6 @@ export const Editor = styled.div`
   max-width: inherit;
 
   overflow: auto;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
   border: 1px solid ${props => props.theme.color.gray500};
 `;

--- a/src/packages/class-diagram/class-association/class-association-component.tsx
+++ b/src/packages/class-diagram/class-association/class-association-component.tsx
@@ -83,25 +83,22 @@ export const ClassAssociationComponent: SFC<Props> = ({ element }) => {
       case Direction.Up:
         return {
           dx: position === 'TOP' ? -5 : 5,
-          dominantBaseline: 'text-after-edge',
           textAnchor: position === 'TOP' ? 'end' : 'start',
         };
       case Direction.Right:
         return {
-          dy: position === 'TOP' ? -10 : 5,
-          dominantBaseline: position === 'TOP' ? 'text-after-edge' : 'text-before-edge',
+          dy: position === 'TOP' ? -10 : 21,
           textAnchor: 'start',
         };
       case Direction.Down:
         return {
           dx: position === 'TOP' ? -5 : 5,
-          dominantBaseline: 'text-before-edge',
+          dy: 10,
           textAnchor: position === 'TOP' ? 'end' : 'start',
         };
       case Direction.Left:
         return {
-          dy: position === 'TOP' ? -10 : 5,
-          dominantBaseline: position === 'TOP' ? 'text-after-edge' : 'text-before-edge',
+          dy: position === 'TOP' ? -10 : 21,
           textAnchor: 'end',
         };
     }

--- a/src/packages/common/package/package-component.tsx
+++ b/src/packages/common/package/package-component.tsx
@@ -5,7 +5,7 @@ export const PackageComponent: SFC<Props> = ({ element, children }) => (
   <g>
     <path d={`M 0 10 V 0 H 40 V 10`} stroke="black" />
     <rect y="10" width="100%" height={element.bounds.height - 10} stroke="black" />
-    <text x="50%" y="15" dominantBaseline="hanging" textAnchor="middle" fontWeight="bold">
+    <text x="50%" y="15" dy={10} textAnchor="middle" fontWeight="bold">
       {element.name}
     </text>
     {children}

--- a/src/packages/communication-diagram/communication-link/communication-link-component.tsx
+++ b/src/packages/communication-diagram/communication-link/communication-link-component.tsx
@@ -51,7 +51,7 @@ export const CommunicationLinkComponent: SFC<Props> = ({ element }) => {
         </>
       ) : (
         <>
-          <text x={position.x} y={position.y} dy={-6} fontSize="85%" dominantBaseline="text-after-edge" textAnchor="middle">
+          <text x={position.x} y={position.y} dy={-6} fontSize="85%" textAnchor="middle">
             <tspan fontWeight="bold" fontSize="120%">
               {targets.length ? '⟶' : ''}
             </tspan>
@@ -61,7 +61,7 @@ export const CommunicationLinkComponent: SFC<Props> = ({ element }) => {
               </tspan>
             ))}
           </text>
-          <text x={position.x} y={position.y} dy={3} fontSize="85%" dominantBaseline="text-before-edge" textAnchor="middle">
+          <text x={position.x} y={position.y} dy={18} fontSize="85%" textAnchor="middle">
             <tspan fontWeight="bold" fontSize="120%">
               {sources.length ? '⟵' : ''}
             </tspan>

--- a/src/utils/geometry/boundary.ts
+++ b/src/utils/geometry/boundary.ts
@@ -67,8 +67,8 @@ export async function computeBoundingBoxForRelationship(relationship: Relationsh
         const parent = svg.getBoundingClientRect() as DOMRect;
         const child = svg.firstElementChild.getBoundingClientRect() as DOMRect;
         bounds = {
-          x: child.x - parent.x,
-          y: child.y - parent.y,
+          x: child.left - parent.left,
+          y: child.top - parent.top,
           width: Math.max(child.width, 1),
           height: Math.max(child.height, 1),
         };


### PR DESCRIPTION
### Motivation and Context

Support at least Microsoft Edge for whatever reason.

### Description

Tested Apollon in following environment and fixed exceptions for unsupported features:
 - On large diagrams, Edge will not scroll automatically to the center of the diagram
 - Hide unnecessary scrollbars
 - Right now, the svg attribute `dominant-baseline` does not work in Edge. So far, we fixed the places where the use of this attribute is critical for usability

### Environment

```
Microsoft Edge 44.17763.1.0
Microsoft EdgeHTML 18.17763
```