### PR TITLE
[Bugfix] Keyboard Shortcuts

### DIFF
--- a/src/components/canvas/keyboard-eventlistener.tsx
+++ b/src/components/canvas/keyboard-eventlistener.tsx
@@ -115,7 +115,7 @@ class KeyboardEventListenerComponent extends Component<Props> {
         this.props.deselect();
         break;
     }
-    if (event.metaKey) {
+    if (event.metaKey || event.ctrlKey) {
       switch (event.key) {
         case 'a':
           event.preventDefault();


### PR DESCRIPTION
With this Bugfix, Keyboard Shortcuts which require the `cmd`-Key work properly on Windows Keyboards.