### PR TITLE
Change Logic of displaying FeedbackIcon

### DIFF
--- a/src/components/uml-element/assessable/assessable.tsx
+++ b/src/components/uml-element/assessable/assessable.tsx
@@ -77,10 +77,24 @@ export const assessable = (
         <WrappedComponent {...props}>
           {assessment && (
             <g transform={`translate(${position.x} ${position.y})`} pointerEvents={'none'}>
-              <Container />
-              {assessment.score === 0 && <FeedbackIcon />}
-              {assessment.score > 0 && <CorrectIcon />}
-              {assessment.score < 0 && <WrongIcon />}
+              {assessment.score === 0 && !!assessment.feedback && (
+                <>
+                  <Container />
+                  <FeedbackIcon />
+                </>
+              )}
+              {assessment.score > 0 && (
+                <>
+                  <Container />
+                  <CorrectIcon />
+                </>
+              )}
+              {assessment.score < 0 && (
+                <>
+                  <Container />
+                  <WrongIcon />
+                </>
+              )}
             </g>
           )}
         </WrappedComponent>


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes
- [x] I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Change logic when showing FeedbackIcon to indicate that there is specific feedback on this element. Before showing when score is 0 and no feedback is set. Now it is required that there is written feedback to show the FeedbackIcon

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Go into assessment mode
2. Assess an element, type in score 0 and add a feedback 
3. Expected outcome: feedback icon is shown
4. Delete the feedback
5. Expected outcome: feedback button disappears 

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/22955066/80284453-d9bc8200-871e-11ea-9278-0601fe55730f.png)

