### PR TITLE
Bugfix/make element type visible in assessment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ls1intum/apollon",
-  "version": "2.0.14-rc.3",
+  "version": "2.0.13",
   "description": "A UML diagram editor.",
   "keywords": [],
   "homepage": "https://github.com/ls1intum/apollon#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ls1intum/apollon",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "A UML diagram editor.",
   "keywords": [],
   "homepage": "https://github.com/ls1intum/apollon#readme",

--- a/src/components/assessment/assessment-section.tsx
+++ b/src/components/assessment/assessment-section.tsx
@@ -11,6 +11,7 @@ import { I18nContext } from '../i18n/i18n-context';
 import { localized } from '../i18n/localized';
 import { ModelState } from '../store/model-state';
 import { styled } from '../theme/styles';
+import { UMLDiagramType } from '../..';
 
 const Flex = styled.div`
   display: flex;
@@ -25,6 +26,7 @@ type OwnProps = {
 type StateProps = {
   readonly: boolean;
   assessment: IAssessment | null;
+  diagramType: UMLDiagramType;
 };
 type DispatchProps = { assess: typeof AssessmentRepository.assess };
 type Props = OwnProps & StateProps & DispatchProps & I18nContext;
@@ -35,6 +37,7 @@ const enhance = compose<ComponentClass<OwnProps>>(
     (state, props) => ({
       readonly: state.editor.readonly,
       assessment: AssessmentRepository.getById(state.assessments)(props.element.id),
+      diagramType: state.diagram.type,
     }),
     { assess: AssessmentRepository.assess },
   ),
@@ -42,13 +45,22 @@ const enhance = compose<ComponentClass<OwnProps>>(
 
 class AssessmentSectionCompoennt extends Component<Props> {
   render() {
-    const { element, assessment, readonly } = this.props;
+    const { element, assessment, readonly, diagramType } = this.props;
 
     return (
       <>
         <section>
           <Header>
-            {this.props.translate('assessment.assessment')} {element.name}
+            {this.props.translate('assessment.assessment')}{' '}
+            {this.props.translate(`packages.${diagramType}.${element.type}`)}
+            {element.name ? (
+              <>
+                {' '}
+                <span style={{ display: 'inline-block' }}>{`\"${element.name}\"`}</span>
+              </>
+            ) : (
+              ''
+            )}
           </Header>
         </section>
         <section>

--- a/src/components/i18n/i18n-provider.tsx
+++ b/src/components/i18n/i18n-provider.tsx
@@ -37,6 +37,7 @@ export class I18nProvider extends Component<Props> {
       }
       return translation;
     } catch (error) {
+      console.error(error);
       return '';
     }
   };

--- a/src/components/uml-element/canvas-relationship.tsx
+++ b/src/components/uml-element/canvas-relationship.tsx
@@ -3,14 +3,12 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { Components } from '../../packages/components';
 import { UMLRelationshipType } from '../../packages/uml-relationship-type';
-import { ApollonView } from '../../services/editor/editor-types';
+import { ApollonMode, ApollonView } from '../../services/editor/editor-types';
 import { IUMLRelationship } from '../../services/uml-relationship/uml-relationship';
 import { UMLRelationshipRepository } from '../../services/uml-relationship/uml-relationship-repository';
 import { ModelState } from '../store/model-state';
 import { withTheme, withThemeProps } from '../theme/styles';
 import { UMLElementComponentProps } from './uml-element-component-props';
-
-const STROKE = 15;
 
 type OwnProps = UMLElementComponentProps & SVGProps<SVGSVGElement>;
 
@@ -22,6 +20,7 @@ type StateProps = {
   reconnecting: boolean;
   disabled: boolean;
   relationship: IUMLRelationship;
+  mode: ApollonMode;
 };
 
 type DispatchProps = {};
@@ -39,6 +38,7 @@ const enhance = compose<ComponentClass<OwnProps>>(
       reconnecting: !!state.reconnecting[props.id],
       disabled: !!Object.keys(state.reconnecting).length || !!Object.keys(state.connecting).length,
       relationship: state.elements[props.id] as IUMLRelationship,
+      mode: state.editor.mode as ApollonMode,
     }),
     {},
   ),
@@ -56,8 +56,12 @@ export class CanvasRelationshipComponent extends Component<Props> {
       relationship,
       children,
       theme,
+      mode,
       ...props
     } = this.props;
+
+    // increase relationship hit box in assessment mode
+    const STROKE = mode == ApollonMode.Assessment ? 35 : 15;
 
     const ChildComponent = Components[relationship.type as UMLRelationshipType];
 

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -25,56 +25,65 @@
     "feedback": "Bewertung"
   },
   "packages": {
-    "classDiagram": {
-      "package": "Paket",
-      "class": "Klasse",
-      "abstract": "Abstrakt",
-      "interface": "Schnittstelle",
-      "enumeration": "Aufzählung",
-      "attribute": "Attribut",
-      "method": "Methode",
-      "aggregation": "Aggregation",
-      "bidirectional": "Assoziation (bidirektional)",
-      "composition": "Komposition",
-      "dependency": "Abhängigkeit",
-      "inheritance": "Vererbung",
-      "realization": "Realisierung",
-      "unidirectional": "Assoziation (unidirektional)"
+    "ClassDiagram": {
+      "Package": "Paket",
+      "Class": "Klasse",
+      "AbstractClass": "Abstrakt",
+      "Interface": "Schnittstelle",
+      "Enumeration": "Aufzählung",
+      "ClassAttribute": "Attribut",
+      "ClassMethod": "Methode",
+      "ClassAggregation": "Aggregation",
+      "ClassBidirectional": "Assoziation (bidirektional)",
+      "ClassComposition": "Komposition",
+      "ClassDependency": "Abhängigkeit",
+      "ClassInheritance": "Vererbung",
+      "ClassRealization": "Realisierung",
+      "ClassUnidirectional": "Assoziation (unidirektional)"
     },
-    "objectDiagram": {
-      "objectName": "Objekt",
-      "objectAttribute": "Attribut"
+    "ObjectDiagram": {
+      "ObjectName": "Objekt",
+      "ObjectAttribute": "Attribut",
+      "ObjectMethod": "Methode",
+      "ObjectLink": "Beziehung"
     },
-    "activityDiagram": {
-      "activity": "Aktivität",
-      "actionNode": "Aktion",
-      "objectNode": "Objekt",
-      "condition": "Bedingung",
-      "controlFlow": "Kontrollfluss"
+    "ActivityDiagram": {
+      "Activity": "Aktivität",
+      "ActivityActionNode": "Aktion",
+      "ActivityFinalNode": "Endknoten",
+      "ActivityForkNode": "Verzweigungsknoten",
+      "ActivityInitialNode": "Startknoten",
+      "ActivityMergeNode": "Bedingung",
+      "ActivityObjectNode": "Objekt",
+      "ActivityControlFlow": "Kontrollfluss"
     },
-    "useCaseDiagram": {
-      "useCase": "Anwendungsfall",
-      "actor": "Akteur",
-      "system": "System",
-      "association": "Assoziation",
-      "extend": "Extend",
-      "generalization": "Generalisierung",
-      "include": "Include"
+    "UseCaseDiagram": {
+      "UseCase": "Anwendungsfall",
+      "UseCaseActor": "Akteur",
+      "UseCaseSystem": "System",
+      "UseCaseAssociation": "Assoziation",
+      "UseCaseExtend": "Extend",
+      "UseCaseGeneralization": "Generalisierung",
+      "UseCaseInclude": "Include"
     },
-    "communicationDiagram": {
-      "communicationLink": "Kommunikation"
+    "CommunicationDiagram": {
+      "ObjectName": "Objekt",
+      "ObjectAttribute": "Attribut",
+      "ObjectMethod": "Methode",
+      "CommunicationLink": "Kommunikation"
     },
-    "componentDiagram": {
-      "component": "Komponente",
-      "dependency": "Abhängigkeit",
-      "interface": "Schnittstelle",
-      "interfaceProvided": "Bereitgestellte Schnittstelle",
-      "interfaceRequired": "Verwendete Schnittstelle"
+    "ComponentDiagram": {
+      "Component": "Komponente",
+      "ComponentDependency": "Abhängigkeit",
+      "ComponentInterface": "Schnittstelle",
+      "ComponentInterfaceProvided": "Bereitgestellte Schnittstelle",
+      "ComponentInterfaceRequired": "Verwendete Schnittstelle"
     },
-    "deploymentDiagram": {
-      "node": "Knoten",
-      "artifact": "Artefakt",
-      "stereotype": "Stereotyp"
+    "DeploymentDiagram": {
+      "DeploymentNode": "Knoten",
+      "Component": "Komponente",
+      "DeploymentArtifact": "Artefakt",
+      "DeploymentAssociation": "Deployment Verbindung"
     }
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -25,56 +25,65 @@
     "feedback": "Feedback"
   },
   "packages": {
-    "classDiagram": {
-      "package": "Package",
-      "class": "Class",
-      "abstract": "Abstract",
-      "interface": "Interface",
-      "enumeration": "Enumeration",
-      "attribute": "Attribute",
-      "method": "Method",
-      "aggregation": "Aggregation",
-      "bidirectional": "Association (bidirectional)",
-      "composition": "Composition",
-      "dependency": "Dependency",
-      "inheritance": "Inheritance",
-      "realization": "Realization",
-      "unidirectional": "Association (unidirectional)"
+    "ClassDiagram": {
+      "Package": "Package",
+      "Class": "Class",
+      "AbstractClass": "Abstract",
+      "Interface": "Interface",
+      "Enumeration": "Enumeration",
+      "ClassAttribute": "Attribute",
+      "ClassMethod": "Method",
+      "ClassAggregation": "Aggregation",
+      "ClassBidirectional": "Association (bidirectional)",
+      "ClassComposition": "Composition",
+      "ClassDependency": "Dependency",
+      "ClassInheritance": "Inheritance",
+      "ClassRealization": "Realization",
+      "ClassUnidirectional": "Association (unidirectional)"
     },
-    "objectDiagram": {
-      "objectName": "Object",
-      "objectAttribute": "Attribute"
+    "ObjectDiagram": {
+      "ObjectName": "Object",
+      "ObjectAttribute": "Attribute",
+      "ObjectMethod": "Method",
+      "ObjectLink": "Relationship"
     },
-    "activityDiagram": {
-      "activity": "Activity",
-      "actionNode": "Action",
-      "objectNode": "Object",
-      "condition": "Condition",
-      "controlFlow": "Control Flow"
+    "ActivityDiagram": {
+      "Activity": "Activity",
+      "ActivityActionNode": "Action",
+      "ActivityFinalNode": "Final Node",
+      "ActivityForkNode": "Fork Node",
+      "ActivityInitialNode": "Initial Node",
+      "ActivityMergeNode": "Condition",
+      "ActivityObjectNode": "Object",
+      "ActivityControlFlow": "Control Flow"
     },
-    "useCaseDiagram": {
-      "useCase": "UseCase",
-      "actor": "Actor",
-      "system": "System",
-      "association": "Association",
-      "extend": "Extend",
-      "generalization": "Generalization",
-      "include": "Include"
+    "UseCaseDiagram": {
+      "UseCase": "UseCase",
+      "UseCaseActor": "Actor",
+      "UseCaseSystem": "System",
+      "UseCaseAssociation": "Association",
+      "UseCaseExtend": "Extend",
+      "UseCaseGeneralization": "Generalization",
+      "UseCaseInclude": "Include"
     },
-    "communicationDiagram": {
-      "communicationLink": "Communication Link"
+    "CommunicationDiagram": {
+      "ObjectName": "Object",
+      "ObjectAttribute": "Attribute",
+      "ObjectMethod": "Method",
+      "CommunicationLink": "Communication Link"
     },
-    "componentDiagram": {
-      "component": "Component",
-      "dependency": "Dependency",
-      "interface": "Interface",
-      "interfaceProvided": "Provided Interface",
-      "interfaceRequired": "Required Interface"
+    "ComponentDiagram": {
+      "Component": "Component",
+      "ComponentDependency": "Dependency",
+      "ComponentInterface": "Interface",
+      "ComponentInterfaceProvided": "Provided Interface",
+      "ComponentInterfaceRequired": "Required Interface"
     },
-    "deploymentDiagram": {
-      "node": "Node",
-      "artifact": "Artifact",
-      "stereotype": "Stereotype"
+    "DeploymentDiagram": {
+      "DeploymentNode": "Node",
+      "Component": "Component",
+      "DeploymentArtifact": "Artifact",
+      "DeploymentAssociation": "Deployment Association"
     }
   }
 }

--- a/src/packages/common/uml-classifier/uml-classifier-update.tsx
+++ b/src/packages/common/uml-classifier/uml-classifier-update.tsx
@@ -77,13 +77,13 @@ class ClassifierUpdate extends Component<Props> {
         <section>
           <Switch value={element.type as keyof typeof ClassElementType} onChange={this.toggle} color="primary">
             <Switch.Item value={ClassElementType.AbstractClass}>
-              {this.props.translate('packages.classDiagram.abstract')}
+              {this.props.translate('packages.ClassDiagram.AbstractClass')}
             </Switch.Item>
             <Switch.Item value={ClassElementType.Interface}>
-              {this.props.translate('packages.classDiagram.interface')}
+              {this.props.translate('packages.ClassDiagram.Interface')}
             </Switch.Item>
             <Switch.Item value={ClassElementType.Enumeration}>
-              {this.props.translate('packages.classDiagram.enumeration')}
+              {this.props.translate('packages.ClassDiagram.Enumeration')}
             </Switch.Item>
           </Switch>
           <Divider />

--- a/src/packages/uml-activity-diagram/activity-preview.ts
+++ b/src/packages/uml-activity-diagram/activity-preview.ts
@@ -16,7 +16,7 @@ export const composeActivityPreview: ComposePreview = (
   const elements: UMLElement[] = [];
 
   // Activity
-  elements.push(new UMLActivity({ name: translate('packages.activityDiagram.activity') }));
+  elements.push(new UMLActivity({ name: translate('packages.ActivityDiagram.Activity') }));
 
   // Activity Initial Node
   elements.push(new UMLActivityInitialNode());
@@ -25,15 +25,15 @@ export const composeActivityPreview: ComposePreview = (
   elements.push(new UMLActivityFinalNode());
 
   // Activity Action Node
-  const activityActionNode = new UMLActivityActionNode({ name: translate('packages.activityDiagram.actionNode') });
+  const activityActionNode = new UMLActivityActionNode({ name: translate('packages.ActivityDiagram.ActivityActionNode') });
   elements.push(activityActionNode);
 
   // Activity Object Node
-  const activityObjectNode = new UMLActivityObjectNode({ name: translate('packages.activityDiagram.objectNode') });
+  const activityObjectNode = new UMLActivityObjectNode({ name: translate('packages.ActivityDiagram.ActivityObjectNode') });
   elements.push(activityObjectNode);
 
   // Activity Merge Node
-  const activityMergeNode = new UMLActivityMergeNode({ name: translate('packages.activityDiagram.condition') });
+  const activityMergeNode = new UMLActivityMergeNode({ name: translate('packages.ActivityDiagram.ActivityMergeNode') });
   elements.push(activityMergeNode);
 
   // Activity Fork Node

--- a/src/packages/uml-activity-diagram/uml-activity-control-flow/uml-activity-control-flow-update.tsx
+++ b/src/packages/uml-activity-diagram/uml-activity-control-flow/uml-activity-control-flow-update.tsx
@@ -30,7 +30,7 @@ class ActivityControlFlowUpdate extends Component<Props> {
         <section>
           <Flex>
             <Header gutter={false} style={{ flexGrow: 1 }}>
-              {this.props.translate('packages.activityDiagram.controlFlow')}
+              {this.props.translate('packages.ActivityDiagram.ActivityControlFlow')}
             </Header>
             <Button color="link" onClick={() => this.props.flip(element.id)}>
               <ExchangeIcon />

--- a/src/packages/uml-class-diagram/class-preview.ts
+++ b/src/packages/uml-class-diagram/class-preview.ts
@@ -13,11 +13,11 @@ export const composeClassPreview: ComposePreview = (layer: ILayer, translate: (i
   const elements: UMLElement[] = [];
 
   // UML Package
-  const umlPackage = new UMLClassPackage({ name: translate('packages.classDiagram.package') });
+  const umlPackage = new UMLClassPackage({ name: translate('packages.ClassDiagram.Package') });
   elements.push(umlPackage);
 
   // UML Class
-  const umlClass = new UMLClass({ name: translate('packages.classDiagram.class') });
+  const umlClass = new UMLClass({ name: translate('packages.ClassDiagram.Class') });
   const umlClassAttribute = new UMLClassAttribute({
     name: translate('sidebar.classAttribute'),
     owner: umlClass.id,
@@ -30,7 +30,7 @@ export const composeClassPreview: ComposePreview = (layer: ILayer, translate: (i
   elements.push(...(umlClass.render(layer, [umlClassAttribute, umlClassMethod]) as UMLElement[]));
 
   // UML Abstract Class
-  const umlAbstract = new UMLAbstractClass({ name: translate('packages.classDiagram.abstract') });
+  const umlAbstract = new UMLAbstractClass({ name: translate('packages.ClassDiagram.AbstractClass') });
   const umlAbstractAttribute = new UMLClassAttribute({
     name: translate('sidebar.classAttribute'),
     owner: umlAbstract.id,
@@ -46,7 +46,7 @@ export const composeClassPreview: ComposePreview = (layer: ILayer, translate: (i
 
   // UML Interface
   const umlInterface = new UMLInterface({
-    name: translate('packages.classDiagram.interface'),
+    name: translate('packages.ClassDiagram.Interface'),
     bounds: { height: 110 },
   });
   const umlInterfaceAttribute = new UMLClassAttribute({
@@ -64,7 +64,7 @@ export const composeClassPreview: ComposePreview = (layer: ILayer, translate: (i
 
   // UML Enumeration
   const umlEnumeration = new UMLEnumeration({
-    name: translate('packages.classDiagram.enumeration'),
+    name: translate('packages.ClassDiagram.Enumeration'),
     bounds: { height: 140 },
   });
   const umlEnumerationCase1 = new UMLClassAttribute({

--- a/src/packages/uml-class-diagram/uml-class-association/uml-class-association-update.tsx
+++ b/src/packages/uml-class-diagram/uml-class-association/uml-class-association-update.tsx
@@ -79,25 +79,25 @@ class ClassAssociationComponent extends Component<Props> {
         <section>
           <Dropdown value={element.type as keyof typeof ClassRelationshipType} onChange={this.onChange}>
             <Dropdown.Item value={ClassRelationshipType.ClassAggregation}>
-              {this.props.translate('packages.classDiagram.aggregation')}
+              {this.props.translate('packages.ClassDiagram.ClassAggregation')}
             </Dropdown.Item>
             <Dropdown.Item value={ClassRelationshipType.ClassUnidirectional}>
-              {this.props.translate('packages.classDiagram.unidirectional')}
+              {this.props.translate('packages.ClassDiagram.ClassUnidirectional')}
             </Dropdown.Item>
             <Dropdown.Item value={ClassRelationshipType.ClassBidirectional}>
-              {this.props.translate('packages.classDiagram.bidirectional')}
+              {this.props.translate('packages.ClassDiagram.ClassBidirectional')}
             </Dropdown.Item>
             <Dropdown.Item value={ClassRelationshipType.ClassComposition}>
-              {this.props.translate('packages.classDiagram.composition')}
+              {this.props.translate('packages.ClassDiagram.ClassComposition')}
             </Dropdown.Item>
             <Dropdown.Item value={ClassRelationshipType.ClassDependency}>
-              {this.props.translate('packages.classDiagram.dependency')}
+              {this.props.translate('packages.ClassDiagram.ClassDependency')}
             </Dropdown.Item>
             <Dropdown.Item value={ClassRelationshipType.ClassInheritance}>
-              {this.props.translate('packages.classDiagram.inheritance')}
+              {this.props.translate('packages.ClassDiagram.ClassInheritance')}
             </Dropdown.Item>
             <Dropdown.Item value={ClassRelationshipType.ClassRealization}>
-              {this.props.translate('packages.classDiagram.realization')}
+              {this.props.translate('packages.ClassDiagram.ClassRealization')}
             </Dropdown.Item>
           </Dropdown>
           <Divider />

--- a/src/packages/uml-communication-diagram/communication-preview.ts
+++ b/src/packages/uml-communication-diagram/communication-preview.ts
@@ -11,7 +11,7 @@ export const composeCommunicationPreview: ComposePreview = (
   const elements: UMLElement[] = [];
 
   // Object
-  const umlObject = new UMLObjectName({ name: translate('packages.objectDiagram.objectName') });
+  const umlObject = new UMLObjectName({ name: translate('packages.CommunicationDiagram.ObjectName') });
   const umlObjectAttribute = new UMLObjectAttribute({
     name: translate('sidebar.classAttribute'),
     owner: umlObject.id,

--- a/src/packages/uml-communication-diagram/uml-communication-link/uml-communication-link-component.tsx
+++ b/src/packages/uml-communication-diagram/uml-communication-link/uml-communication-link-component.tsx
@@ -44,7 +44,7 @@ export const UMLCommunicationLinkComponent: SFC<Props> = ({ element }) => {
                 <tspan fontWeight="bold" fontSize="120%">
                   {sources.length ? '↓' : ''}
                 </tspan>
-                {sources.map((source, i) => (
+                {sources.reverse().map((source, i) => (
                   <tspan key={i} x={position.x + 20} dy={i === 0 ? undefined : '1.2em'}>
                     {source.name}
                   </tspan>

--- a/src/packages/uml-communication-diagram/uml-communication-link/uml-communication-link-update.tsx
+++ b/src/packages/uml-communication-diagram/uml-communication-link/uml-communication-link-update.tsx
@@ -71,7 +71,7 @@ class CommunicationLinkUpdate extends Component<Props> {
     const { element, update } = this.props;
     if (!element.messages.find(message => message.name === value)) {
       update<UMLCommunicationLink>(element.id, {
-        messages: [...element.messages, { name: value, direction: 'target' }],
+        messages: [...element.messages, { name: value, direction: 'source' }],
       });
     }
   };

--- a/src/packages/uml-communication-diagram/uml-communication-link/uml-communication-link-update.tsx
+++ b/src/packages/uml-communication-diagram/uml-communication-link/uml-communication-link-update.tsx
@@ -35,7 +35,7 @@ class CommunicationLinkUpdate extends Component<Props> {
       <div>
         <section>
           <Flex>
-            <Header gutter={false}>{this.props.translate('packages.communicationDiagram.communicationLink')}</Header>
+            <Header gutter={false}>{this.props.translate('packages.CommunicationDiagram.CommunicationLink')}</Header>
             <Button color="link" onClick={() => this.props.delete(element.id)}>
               <TrashIcon />
             </Button>

--- a/src/packages/uml-component-diagram/component-preview.ts
+++ b/src/packages/uml-component-diagram/component-preview.ts
@@ -11,11 +11,11 @@ export const composeComponentPreview: ComposePreview = (
   const elements: UMLElement[] = [];
 
   // UML Component
-  const umlComponent = new UMLComponent({ name: translate('packages.componentDiagram.component') });
+  const umlComponent = new UMLComponent({ name: translate('packages.ComponentDiagram.Component') });
   elements.push(umlComponent);
 
   // UML Deployment Artifact
-  const umlComponentInterface = new UMLComponentInterface({ name: translate('packages.componentDiagram.interface') });
+  const umlComponentInterface = new UMLComponentInterface({ name: translate('packages.ComponentDiagram.ComponentInterface') });
   const [umlInterface] = umlComponentInterface.render(layer) as [UMLElement];
   elements.push(umlInterface);
 

--- a/src/packages/uml-component-diagram/uml-component-association-update.tsx
+++ b/src/packages/uml-component-diagram/uml-component-association-update.tsx
@@ -45,13 +45,13 @@ class ComponentAssociationUpdate extends Component<Props> {
         <section>
           <Dropdown value={element.type as keyof typeof ComponentRelationshipType} onChange={this.onChange}>
             <Dropdown.Item value={ComponentRelationshipType.ComponentDependency}>
-              {this.props.translate('packages.componentDiagram.dependency')}
+              {this.props.translate('packages.ComponentDiagram.ComponentDependency')}
             </Dropdown.Item>
             <Dropdown.Item value={ComponentRelationshipType.ComponentInterfaceProvided}>
-              {this.props.translate('packages.componentDiagram.interfaceProvided')}
+              {this.props.translate('packages.ComponentDiagram.ComponentInterfaceProvided')}
             </Dropdown.Item>
             <Dropdown.Item value={ComponentRelationshipType.ComponentInterfaceRequired}>
-              {this.props.translate('packages.componentDiagram.interfaceRequired')}
+              {this.props.translate('packages.ComponentDiagram.ComponentInterfaceRequired')}
             </Dropdown.Item>
           </Dropdown>
         </section>

--- a/src/packages/uml-deployment-diagram/deployment-preview.ts
+++ b/src/packages/uml-deployment-diagram/deployment-preview.ts
@@ -12,15 +12,15 @@ export const composeDeploymentPreview: ComposePreview = (
   const elements: UMLElement[] = [];
 
   // UML Deployment Node
-  const umlDeploymentNode = new UMLDeploymentNode({ name: translate('packages.deploymentDiagram.node') });
+  const umlDeploymentNode = new UMLDeploymentNode({ name: translate('packages.DeploymentDiagram.DeploymentNode') });
   elements.push(umlDeploymentNode);
 
   // UML Component
-  const umlComponent = new UMLComponent({ name: translate('packages.componentDiagram.component') });
+  const umlComponent = new UMLComponent({ name: translate('packages.ComponentDiagram.Component') });
   elements.push(umlComponent);
 
   // UML Deployment Artifact
-  const umlDeploymentArtifact = new UMLDeploymentArtifact({ name: translate('packages.deploymentDiagram.artifact') });
+  const umlDeploymentArtifact = new UMLDeploymentArtifact({ name: translate('packages.DeploymentDiagram.DeploymentArtifact') });
   elements.push(umlDeploymentArtifact);
 
   return elements;

--- a/src/packages/uml-object-diagram/object-preview.ts
+++ b/src/packages/uml-object-diagram/object-preview.ts
@@ -11,7 +11,7 @@ export const composeObjectPreview: ComposePreview = (
   const elements: UMLElement[] = [];
 
   // Object
-  const umlObject = new UMLObjectName({ name: translate('packages.objectDiagram.objectName') });
+  const umlObject = new UMLObjectName({ name: translate('packages.ObjectDiagram.ObjectName') });
   const umlObjectMember = new UMLObjectAttribute({
     name: translate('sidebar.objectAttribute'),
     owner: umlObject.id,

--- a/src/packages/uml-use-case-diagram/uml-use-case-association/uml-use-case-association-update.tsx
+++ b/src/packages/uml-use-case-diagram/uml-use-case-association/uml-use-case-association-update.tsx
@@ -43,13 +43,13 @@ class UseCaseAssociationUpdate extends Component<Props> {
                 {
                   {
                     [UseCaseRelationshipType.UseCaseAssociation]: this.props.translate(
-                      'packages.useCaseDiagram.association',
+                      'packages.UseCaseDiagram.UseCaseAssociation',
                     ),
                     [UseCaseRelationshipType.UseCaseGeneralization]: this.props.translate(
-                      'packages.useCaseDiagram.generalization',
+                      'packages.UseCaseDiagram.UseCaseGeneralization',
                     ),
-                    [UseCaseRelationshipType.UseCaseInclude]: this.props.translate('packages.useCaseDiagram.include'),
-                    [UseCaseRelationshipType.UseCaseExtend]: this.props.translate('packages.useCaseDiagram.extend'),
+                    [UseCaseRelationshipType.UseCaseInclude]: this.props.translate('packages.UseCaseDiagram.UseCaseInclude'),
+                    [UseCaseRelationshipType.UseCaseExtend]: this.props.translate('packages.UseCaseDiagram.UseCaseExtend'),
                   }[element.type]
                 }
               </Header>
@@ -66,16 +66,16 @@ class UseCaseAssociationUpdate extends Component<Props> {
           <Divider />
           <Dropdown value={element.type} onChange={this.onChange}>
             <Dropdown.Item value={UseCaseRelationshipType.UseCaseAssociation}>
-              {this.props.translate('packages.useCaseDiagram.association')}
+              {this.props.translate('packages.UseCaseDiagram.UseCaseAssociation')}
             </Dropdown.Item>
             <Dropdown.Item value={UseCaseRelationshipType.UseCaseGeneralization}>
-              {this.props.translate('packages.useCaseDiagram.generalization')}
+              {this.props.translate('packages.UseCaseDiagram.UseCaseGeneralization')}
             </Dropdown.Item>
             <Dropdown.Item value={UseCaseRelationshipType.UseCaseInclude}>
-              {this.props.translate('packages.useCaseDiagram.include')}
+              {this.props.translate('packages.UseCaseDiagram.UseCaseInclude')}
             </Dropdown.Item>
             <Dropdown.Item value={UseCaseRelationshipType.UseCaseExtend}>
-              {this.props.translate('packages.useCaseDiagram.extend')}
+              {this.props.translate('packages.UseCaseDiagram.UseCaseExtend')}
             </Dropdown.Item>
           </Dropdown>
         </section>

--- a/src/packages/uml-use-case-diagram/use-case-preview.ts
+++ b/src/packages/uml-use-case-diagram/use-case-preview.ts
@@ -12,15 +12,15 @@ export const composeUseCasePreview: ComposePreview = (
   const elements: UMLElement[] = [];
 
   // UML Use Case
-  const umlUseCase = new UMLUseCase({ name: translate('packages.useCaseDiagram.useCase') });
+  const umlUseCase = new UMLUseCase({ name: translate('packages.UseCaseDiagram.UseCase') });
   elements.push(umlUseCase);
 
   // UML Actor
-  const umlActor = new UMLUseCaseActor({ name: translate('packages.useCaseDiagram.actor') });
+  const umlActor = new UMLUseCaseActor({ name: translate('packages.UseCaseDiagram.UseCaseActor') });
   elements.push(umlActor);
 
   // UML System
-  const umlSystem = new UMLUseCaseSystem({ name: translate('packages.useCaseDiagram.system') });
+  const umlSystem = new UMLUseCaseSystem({ name: translate('packages.UseCaseDiagram.UseCaseSystem') });
   elements.push(umlSystem);
 
   return elements;


### PR DESCRIPTION
### Checklist 
- [x] I added multiple screenshots/screencasts of my UI changes
- [x] I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Gives tutors more information on the element they are assessing. Sometimes it is not possible to recognize the element type, because some elements might look the same

### Description
<!-- Describe your changes in detail -->
translation files follow the UMLElementType-Name-Schema, which makes it possible to get the translation of an element by diagram type + element type

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Check translations for all UML Elements + UML Relationships in German and English
2. Go to Assessment Mode and double click element. **Important: Editor must be in corresponding mode to object which should be assessed**.
3. New Schema: "Assessment for _ElementType_ '_ElementName_' "


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/22955066/82561513-ceb90e00-9b73-11ea-81dd-80c8b29cb110.png)

![image](https://user-images.githubusercontent.com/22955066/82561625-fc05bc00-9b73-11ea-800e-f184c83f63a4.png)

Closes #101 
