### PR TITLE
Reduce redux operations for many elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "*.{ts,tsx,js,css,md}": "prettier --write"
   },
   "dependencies": {
+    "cpu-benchmark": "1.0.1",
     "is-mobile": "2.2.2",
     "pepjs": "0.5.3",
     "react": "17.0.1",

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -17,6 +17,8 @@ import { Dispatch } from './utils/actions/actions';
 import { UMLDiagramType, UMLModel } from './typings';
 import { debounce } from './utils/debounce';
 import { ErrorBoundary } from './components/controls/error-boundary/ErrorBoundary';
+// @ts-ignore
+import { dist } from 'cpu-benchmark';
 
 export class ApollonEditor {
   /**
@@ -114,6 +116,8 @@ export class ApollonEditor {
   constructor(private container: HTMLElement, private options: Apollon.ApollonOptions) {
     let state: PartialModelState | undefined = options.model ? ModelState.fromModel(options.model) : {};
 
+    let performance = this.getPerformance();
+
     state = {
       ...state,
       diagram: new UMLDiagram({
@@ -122,6 +126,7 @@ export class ApollonEditor {
       }),
       editor: {
         ...state.editor,
+        performance,
         view: ApollonView.Modelling,
         mode: options.mode || ApollonMode.Exporting,
         readonly: options.readonly || false,
@@ -248,6 +253,25 @@ export class ApollonEditor {
    */
   exportAsSVG(options?: Apollon.ExportOptions): Apollon.SVG {
     return ApollonEditor.exportModelAsSvg(this.model, options, this.options.theme);
+  }
+
+  /**
+   * measures performance of the computer the apollon editor is opened
+   * @returns number of operations that can be done in 100 milliseconds
+   */
+  private getPerformance(): number {
+    let performance;
+    if (window && window.localStorage) {
+      let performanceString = window.localStorage.getItem('apollon_performance');
+      if (!performanceString) {
+        performance = dist(100);
+      } else {
+        performance = Number.parseInt(performanceString);
+      }
+    } else {
+      performance = dist(100);
+    }
+    return performance;
   }
 
   private componentDidMount = () => {

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -13,7 +13,10 @@ import { UMLElementComponentProps } from './uml-element-component-props';
 
 const STROKE = 5;
 
-type OwnProps = { child?: ComponentClass<UMLElementComponentProps> } & UMLElementComponentProps &
+type OwnProps = {
+  pos?: { x: number; y: number };
+  child?: ComponentClass<UMLElementComponentProps>;
+} & UMLElementComponentProps &
   SVGProps<SVGSVGElement>;
 
 type StateProps = {
@@ -58,7 +61,6 @@ class CanvasElementComponent extends Component<Props> {
       theme,
       ...props
     } = this.props;
-
     let elements = null;
     if (UMLContainer.isUMLContainer(element) && ChildComponent) {
       elements = element.ownedElements.map((id) => <ChildComponent key={id} id={id} />);
@@ -74,10 +76,11 @@ class CanvasElementComponent extends Component<Props> {
         ? element.highlight
         : 'white';
 
+    const position = props.pos ? props.pos : element.bounds;
     return (
       <svg
         {...props}
-        {...element.bounds}
+        {...position}
         pointerEvents={moving ? 'none' : undefined}
         fillOpacity={moving ? 0.7 : undefined}
         fill={highlight}

--- a/src/main/components/uml-element/movable/movable.tsx
+++ b/src/main/components/uml-element/movable/movable.tsx
@@ -8,11 +8,14 @@ import { ModelState } from '../../store/model-state';
 import { UMLElementComponentProps } from '../uml-element-component-props';
 import isMobile from 'is-mobile';
 import { getClientEventCoordinates } from '../../../utils/touch-event';
-import { debounce } from '../../../utils/debounce';
+import { IUMLElement } from '../../../services/uml-element/uml-element';
 
 type StateProps = {
   movable: boolean;
   moving: boolean;
+  element: IUMLElement;
+  numberOfElements: number;
+  performance: number;
 };
 
 type DispatchProps = {
@@ -25,6 +28,8 @@ type Props = UMLElementComponentProps & StateProps & DispatchProps;
 
 const initialState = {
   offset: new Point(),
+  pos: { x: 0, y: 0, width: 200, height: 100 },
+  moving: false,
 };
 
 type State = typeof initialState;
@@ -33,6 +38,9 @@ const enhance = connect<StateProps, DispatchProps, UMLElementComponentProps, Mod
   (state, props) => ({
     movable: state.selected.includes(props.id) && !state.resizing.includes(props.id) && !state.connecting.length,
     moving: state.moving.includes(props.id),
+    element: state.elements[props.id],
+    numberOfElements: Object.keys(state.elements).length,
+    performance: state.editor.performance,
   }),
   {
     start: UMLElementRepository.startMoving,
@@ -45,9 +53,9 @@ export const movable = (
   WrappedComponent: ComponentType<UMLElementComponentProps>,
 ): ConnectedComponent<ComponentType<Props>, UMLElementComponentProps> => {
   class Movable extends Component<Props, State> {
-    state = initialState;
+    state = { ...initialState, pos: this.props.element.bounds };
     moveWindow: { x: number; y: number } = { x: 0, y: 0 };
-
+    animationFrame: any;
     move = (x: number, y: number) => {
       x = Math.round(x / 10) * 10;
       y = Math.round(y / 10) * 10;
@@ -55,13 +63,23 @@ export const movable = (
 
       this.setState((state) => ({ offset: state.offset.add(x, y) }));
       this.moveWindow = { x: this.moveWindow.x + x, y: this.moveWindow.y + y };
-      this.debouncedMove(this.moveWindow);
+      if (this.animationFrame) {
+        cancelAnimationFrame(this.animationFrame);
+      }
+      this.animationFrame = requestAnimationFrame(this.animate);
     };
 
-    private debouncedMove = debounce(() => {
-      this.props.move(this.moveWindow);
+    private animate = (time: any) => {
+      if (this.shouldNotUpdateReduxWhileMoving()) {
+        this.setState((state) => ({
+          pos: { ...this.props.element.bounds, x: state.pos.x + this.moveWindow.x, y: state.pos.y + this.moveWindow.y },
+        }));
+      } else {
+        this.props.move(this.moveWindow);
+      }
       this.moveWindow = { x: 0, y: 0 };
-    }, 2);
+      this.animationFrame = requestAnimationFrame(this.animate);
+    };
 
     componentDidMount() {
       const node = findDOMNode(this) as HTMLElement;
@@ -90,26 +108,47 @@ export const movable = (
     }
 
     render() {
-      const { movable: _, start, move, end, ...props } = this.props;
-      return <WrappedComponent {...props} />;
+      const { movable: _, start, move, end, numberOfElements, performance, element, ...props } = this.props;
+      return this.shouldNotUpdateReduxWhileMoving() && this.props.moving && (this.state.pos.x || this.state.pos.y) ? (
+        <WrappedComponent {...{ pos: this.state.pos }} {...props} />
+      ) : (
+        <WrappedComponent {...props} />
+      );
     }
 
     private onPointerDown = (event: PointerEvent | TouchEvent) => {
       if (event.which && event.which !== 1) {
         return;
       }
-
       const clientEventCoordinates = getClientEventCoordinates(event);
+      this.setState({ moving: true }, () => {
+        if (this.shouldNotUpdateReduxWhileMoving()) {
+          this.setState({
+            offset: new Point(clientEventCoordinates.clientX, clientEventCoordinates.clientY),
+            pos: { ...this.props.element.bounds },
+          });
+        } else {
+          this.setState({
+            offset: new Point(clientEventCoordinates.clientX, clientEventCoordinates.clientY),
+          });
+        }
+      });
 
-      this.setState({ offset: new Point(clientEventCoordinates.clientX, clientEventCoordinates.clientY) });
       if (isMobile({ tablet: true })) {
         document.addEventListener('touchmove', this.onPointerMove);
         document.addEventListener('touchend', this.onPointerUp, { once: true });
       } else {
         document.addEventListener('pointermove', this.onPointerMove);
         document.addEventListener('pointerup', this.onPointerUp, { once: true });
+        document.addEventListener('pointerleave', this.onPointerLeave);
       }
       setTimeout(() => !this.props.movable && this.onPointerUp(), 0);
+    };
+
+    private onPointerLeave = () => {
+      if (this.state.moving) {
+        this.onPointerUp();
+      }
     };
 
     private onPointerMove = (event: PointerEvent | TouchEvent) => {
@@ -132,13 +171,43 @@ export const movable = (
       } else {
         document.removeEventListener('pointermove', this.onPointerMove);
       }
+
       if (!this.props.moving) {
+        this.setState({ moving: false });
         return;
       }
 
-      this.setState(initialState);
+      cancelAnimationFrame(this.animationFrame);
+      if (this.shouldNotUpdateReduxWhileMoving()) {
+        this.props.move({
+          ...this.props.element.bounds,
+          x: this.state.pos.x - this.props.element.bounds.x,
+          y: this.state.pos.y - this.props.element.bounds.y,
+        });
+      }
+      this.setState({ moving: false });
+
       this.props.end();
     };
+
+    private shouldNotUpdateReduxWhileMoving() {
+      const performance = this.props.performance;
+      const numberOfElements = this.props.numberOfElements;
+      if (!this.state.moving) {
+        return false;
+      }
+
+      if (this.props.moving) {
+        if (performance > 50000) {
+          return numberOfElements > 100;
+        } else if (performance > 5000) {
+          return numberOfElements > 50;
+        } else if (performance > 1000) {
+          return numberOfElements > 10;
+        }
+      }
+      return true;
+    }
   }
 
   return enhance(Movable);

--- a/src/main/services/editor/editor-reducer.ts
+++ b/src/main/services/editor/editor-reducer.ts
@@ -8,6 +8,7 @@ const initialState: EditorState = {
   enableCopyPasteToClipboard: false,
   mode: ApollonMode.Exporting,
   view: ApollonView.Modelling,
+  performance: 1000,
   features: {
     hoverable: true,
     selectable: true,

--- a/src/main/services/editor/editor-types.ts
+++ b/src/main/services/editor/editor-types.ts
@@ -29,6 +29,7 @@ export type EditorState = {
   readonly enableCopyPasteToClipboard: boolean;
   readonly view: ApollonView;
   readonly features: UMLElementFeatures;
+  readonly performance: number;
 };
 
 export type EditorActions = ChangeViewAction;

--- a/src/main/services/uml-element/movable/moving-reducer.ts
+++ b/src/main/services/uml-element/movable/moving-reducer.ts
@@ -6,23 +6,20 @@ export const MovingReducer: Reducer<MovingState, Actions> = (state = {}, action)
   switch (action.type) {
     case MovingActionTypes.MOVE: {
       const { payload } = action;
-
-      return payload.ids.reduce<MovingState>(
-        (elements, id) => ({
-          ...elements,
-          ...(id in elements && {
-            [id]: {
-              ...elements[id],
-              bounds: {
-                ...elements[id].bounds,
-                x: elements[id].bounds.x + payload.delta.x,
-                y: elements[id].bounds.y + payload.delta.y,
-              },
+      const elements = { ...state };
+      payload.ids.forEach((id) => {
+        if (id in elements) {
+          elements[id] = {
+            ...elements[id],
+            bounds: {
+              ...elements[id].bounds,
+              x: elements[id].bounds.x + payload.delta.x,
+              y: elements[id].bounds.y + payload.delta.y,
             },
-          }),
-        }),
-        state,
-      );
+          };
+        }
+      });
+      return elements;
     }
   }
 

--- a/src/main/services/uml-element/resizable/resizing-reducer.ts
+++ b/src/main/services/uml-element/resizable/resizing-reducer.ts
@@ -6,23 +6,20 @@ export const ResizingReducer: Reducer<ResizingState, Actions> = (state = {}, act
   switch (action.type) {
     case ResizingActionTypes.RESIZE: {
       const { payload } = action;
-
-      return payload.ids.reduce<ResizingState>(
-        (elements, id) => ({
-          ...elements,
-          ...(id in elements && {
-            [id]: {
-              ...elements[id],
-              bounds: {
-                ...elements[id].bounds,
-                width: Math.max(elements[id].bounds.width + payload.delta.width, 0),
-                height: Math.max(elements[id].bounds.height + payload.delta.height, 0),
-              },
+      const elements = { ...state };
+      payload.ids.forEach((id) => {
+        if (id in elements) {
+          elements[id] = {
+            ...elements[id],
+            bounds: {
+              ...elements[id].bounds,
+              width: Math.max(elements[id].bounds.width + payload.delta.width, 0),
+              height: Math.max(elements[id].bounds.height + payload.delta.height, 0),
             },
-          }),
-        }),
-        state,
-      );
+          };
+        }
+      });
+      return elements;
     }
   }
 

--- a/src/tests/apollon-editor-test.tsx
+++ b/src/tests/apollon-editor-test.tsx
@@ -1,4 +1,3 @@
-// @ts-ignore
 import * as React from 'react';
 import { render as testLibraryRender } from '@testing-library/react';
 import * as Apollon from '../main/apollon-editor';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4455,6 +4455,11 @@ cp-file@^7.0.0:
     nested-error-stacks "^2.0.0"
     p-event "^4.1.0"
 
+cpu-benchmark@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cpu-benchmark/-/cpu-benchmark-1.0.1.tgz#6f59584599563563193ffad803a5c193f2e624c8"
+  integrity sha512-b6FmkWdWvwKySXIdMFjXqh9xkWl5MCDq5EZv26/PxzlSoY+/pugsA8wx2rUJ4/w7MhtU/GqmKmifr+uufgMFnw==
+
 cpy@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/cpy/-/cpy-8.1.1.tgz#066ed4c6eaeed9577df96dae4db9438c1a90df62"


### PR DESCRIPTION
### Checklist
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
Updating redux state with the movement of elements can cause problems when there are many elements on the page. With this change we are updating redux state at the end of the movement when there are many elements. Number of elements is determined according to cpu power of the user.

### Description
1. Added cpu performance measure at the beginning
2. Moved element position change to state when there are many elements
3. Removed unnecessary state duplication from reducers
4. Used animationframe instead of debounce for updating movement on mouse move

### Steps for Testing
1. Place elements on the screen and move them
2. Performance tab of Google dev tools can be used, it also allows you to add cpu throttle
