### PR TITLE
Remove unnecessary strokedasharray

### DIFF
--- a/src/main/packages/common/uml-association/uml-association-component.tsx
+++ b/src/main/packages/common/uml-association/uml-association-component.tsx
@@ -16,7 +16,6 @@ const Marker = {
       refY="15"
       orient="auto"
       markerUnits="strokeWidth"
-      strokeDasharray="1,0"
     >
       <path d="M0,29 L30,15 L0,1" fill="none" stroke="black" />
     </marker>
@@ -59,7 +58,6 @@ const Marker = {
       refY="15"
       orient="auto"
       markerUnits="strokeWidth"
-      strokeDasharray="1,0"
     >
       <path d="M0,1 L0,29 L30,15 z" fill="white" stroke="black" />
     </marker>

--- a/src/main/packages/common/uml-dependency/uml-dependency-component.tsx
+++ b/src/main/packages/common/uml-dependency/uml-dependency-component.tsx
@@ -12,7 +12,6 @@ export const UMLDependencyComponent: SFC<Props> = ({ element }) => (
       refY="15"
       orient="auto"
       markerUnits="strokeWidth"
-      strokeDasharray="1,0"
     >
       <path d="M0,29 L30,15 L0,1" fill="none" stroke="black" />
     </marker>

--- a/src/main/packages/common/uml-interface-required/uml-interface-required-component.tsx
+++ b/src/main/packages/common/uml-interface-required/uml-interface-required-component.tsx
@@ -67,7 +67,6 @@ const UMLInterfaceRequiredC: SFC<Props> = (props: Props) => {
         refY="0"
         orient="auto"
         markerUnits="strokeWidth"
-        strokeDasharray="1,0"
       >
         {/*M -> Move to, A -> Arc radiusX, radiusY, x-axis-rotation, bow-flag, endpointX,endpointY */}
         <path

--- a/src/main/packages/flowchart/flowchart-flowline/flowchart-flowline-component.tsx
+++ b/src/main/packages/flowchart/flowchart-flowline/flowchart-flowline-component.tsx
@@ -51,7 +51,6 @@ export const FlowchartFlowlineComponent: SFC<Props> = ({ element }) => {
         refY="15"
         orient="auto"
         markerUnits="strokeWidth"
-        strokeDasharray="1,0"
       >
         <path d="M0,29 L30,15 L0,1" fill="none" stroke="black" />
       </marker>

--- a/src/main/packages/uml-activity-diagram/uml-activity-control-flow/uml-activity-control-flow-component.tsx
+++ b/src/main/packages/uml-activity-diagram/uml-activity-control-flow/uml-activity-control-flow-component.tsx
@@ -51,7 +51,6 @@ export const UMLActivityControlFlowComponent: SFC<Props> = ({ element }) => {
         refY="15"
         orient="auto"
         markerUnits="strokeWidth"
-        strokeDasharray="1,0"
       >
         <path d="M0,29 L30,15 L0,1" fill="none" stroke="black" />
       </marker>

--- a/src/main/packages/uml-petri-net/uml-petri-net-arc/uml-petri-net-arc-component.tsx
+++ b/src/main/packages/uml-petri-net/uml-petri-net-arc/uml-petri-net-arc-component.tsx
@@ -21,7 +21,6 @@ export const UMLPetriNetArcComponent: SFC<Props> = ({ element }) => {
         refY="15"
         orient="auto"
         markerUnits="strokeWidth"
-        strokeDasharray="1,0"
       >
         <path d="M0,1 L0,29 L30,15 z" fill="black" />
       </marker>

--- a/src/main/packages/uml-use-case-diagram/uml-use-case-extend/uml-use-case-extend-component.tsx
+++ b/src/main/packages/uml-use-case-diagram/uml-use-case-extend/uml-use-case-extend-component.tsx
@@ -13,7 +13,6 @@ const Arrow: SFC<{ id: string } & SVGProps<SVGPathElement>> = ({ id, ...props })
       refY="15"
       orient="auto"
       markerUnits="strokeWidth"
-      strokeDasharray="1,0"
     >
       <path d="M0,29 L30,15 L0,1" fill="none" stroke="black" />
     </marker>

--- a/src/main/packages/uml-use-case-diagram/uml-use-case-generalization/uml-use-case-generalization-component.tsx
+++ b/src/main/packages/uml-use-case-diagram/uml-use-case-generalization/uml-use-case-generalization-component.tsx
@@ -12,7 +12,6 @@ export const UMLUseCaseGeneralizationComponent: SFC<Props> = ({ element }) => (
       refY="15"
       orient="auto"
       markerUnits="strokeWidth"
-      strokeDasharray="1,0"
     >
       <path d="M0,1 L0,29 L30,15 z" fill="white" stroke="black" />
     </marker>

--- a/src/main/packages/uml-use-case-diagram/uml-use-case-include/uml-use-case-include-component.tsx
+++ b/src/main/packages/uml-use-case-diagram/uml-use-case-include/uml-use-case-include-component.tsx
@@ -13,7 +13,6 @@ const Arrow: SFC<{ id: string } & SVGProps<SVGPathElement>> = ({ id, ...props })
       refY="15"
       orient="auto"
       markerUnits="strokeWidth"
-      strokeDasharray="1,0"
     >
       <path d="M0,29 L30,15 L0,1" fill="none" stroke="black" />
     </marker>

--- a/src/tests/packages/flowchart/flowchart-flowline/__snapshots__/flowchart-flowline-component-test.tsx.snap
+++ b/src/tests/packages/flowchart/flowchart-flowline/__snapshots__/flowchart-flowline-component-test.tsx.snap
@@ -13,7 +13,6 @@ exports[`render the flowchart-flowline-component 1`] = `
           orient="auto"
           refX="30"
           refY="15"
-          stroke-dasharray="1,0"
           viewBox="0 0 30 30"
         >
           <path

--- a/src/tests/packages/uml-activity-diagram/uml-activity-control-flow/__snapshots__/uml-activity-control-flow-component-test.tsx.snap
+++ b/src/tests/packages/uml-activity-diagram/uml-activity-control-flow/__snapshots__/uml-activity-control-flow-component-test.tsx.snap
@@ -13,7 +13,6 @@ exports[`render the uml-activity-control-flow-component 1`] = `
           orient="auto"
           refX="30"
           refY="15"
-          stroke-dasharray="1,0"
           viewBox="0 0 30 30"
         >
           <path

--- a/src/tests/packages/uml-component-diagram/uml-component-dependency/__snapshots__/uml-component-dependency-component-test.tsx.snap
+++ b/src/tests/packages/uml-component-diagram/uml-component-dependency/__snapshots__/uml-component-dependency-component-test.tsx.snap
@@ -13,7 +13,6 @@ exports[`render the uml-component-dependency-component 1`] = `
           orient="auto"
           refX="30"
           refY="15"
-          stroke-dasharray="1,0"
           viewBox="0 0 30 30"
         >
           <path

--- a/src/tests/packages/uml-component-diagram/uml-component-required-interface/__snapshots__/uml-component-required-interface-component-test.tsx.snap
+++ b/src/tests/packages/uml-component-diagram/uml-component-required-interface/__snapshots__/uml-component-required-interface-component-test.tsx.snap
@@ -13,7 +13,6 @@ exports[`render the uml-component-required-interface-component 1`] = `
           orient="auto"
           refX="0"
           refY="0"
-          stroke-dasharray="1,0"
           viewBox="0 0 27 27"
         >
           <path

--- a/src/tests/packages/uml-deployment-diagram/uml-deployment-dependency/__snapshots__/uml-deployment-dependency-component-test.tsx.snap
+++ b/src/tests/packages/uml-deployment-diagram/uml-deployment-dependency/__snapshots__/uml-deployment-dependency-component-test.tsx.snap
@@ -13,7 +13,6 @@ exports[`render the uml-deplyoment-dependency-component 1`] = `
           orient="auto"
           refX="30"
           refY="15"
-          stroke-dasharray="1,0"
           viewBox="0 0 30 30"
         >
           <path

--- a/src/tests/packages/uml-deployment-diagram/uml-deployment-required-interface/__snapshots__/uml-deployment-required-interface-component-test.tsx.snap
+++ b/src/tests/packages/uml-deployment-diagram/uml-deployment-required-interface/__snapshots__/uml-deployment-required-interface-component-test.tsx.snap
@@ -13,7 +13,6 @@ exports[`render the uml-deplyoment-required-interface-component 1`] = `
           orient="auto"
           refX="0"
           refY="0"
-          stroke-dasharray="1,0"
           viewBox="0 0 27 27"
         >
           <path

--- a/src/tests/packages/uml-petri-diagram/uml-petri-net-arc/__snapshots__/uml-petri-net-arc-component-test.tsx.snap
+++ b/src/tests/packages/uml-petri-diagram/uml-petri-net-arc/__snapshots__/uml-petri-net-arc-component-test.tsx.snap
@@ -13,7 +13,6 @@ exports[`render the uml-petri-net-arc-component 1`] = `
           orient="auto"
           refX="30"
           refY="15"
-          stroke-dasharray="1,0"
           viewBox="0 0 30 30"
         >
           <path

--- a/src/tests/packages/uml-use-case-diagram/uml-use-case-extend/__snapshots__/uml-use-case-extend-component-test.tsx.snap
+++ b/src/tests/packages/uml-use-case-diagram/uml-use-case-extend/__snapshots__/uml-use-case-extend-component-test.tsx.snap
@@ -14,7 +14,6 @@ exports[`render the uml-use-case-extend-component 1`] = `
             orient="auto"
             refX="30"
             refY="15"
-            stroke-dasharray="1,0"
             viewBox="0 0 30 30"
           >
             <path

--- a/src/tests/packages/uml-use-case-diagram/uml-use-case-generalization/__snapshots__/uml-use-case-generalization-component-test.tsx.snap
+++ b/src/tests/packages/uml-use-case-diagram/uml-use-case-generalization/__snapshots__/uml-use-case-generalization-component-test.tsx.snap
@@ -13,7 +13,6 @@ exports[`render the uml-use-case-generalization-component 1`] = `
           orient="auto"
           refX="30"
           refY="15"
-          stroke-dasharray="1,0"
           viewBox="0 0 30 30"
         >
           <path

--- a/src/tests/packages/uml-use-case-diagram/uml-use-case-include/__snapshots__/uml-use-case-include-component-test.tsx.snap
+++ b/src/tests/packages/uml-use-case-diagram/uml-use-case-include/__snapshots__/uml-use-case-include-component-test.tsx.snap
@@ -14,7 +14,6 @@ exports[`render the uml-use-case-include-component 1`] = `
             orient="auto"
             refX="30"
             refY="15"
-            stroke-dasharray="1,0"
             viewBox="0 0 30 30"
           >
             <path


### PR DESCRIPTION
### Description
Removes strokeDashArray="1,0" from files. 0 is an invalid value for strokeDashArray. Nothing should change with this PR. 

### Steps for Testing
1. Try all types of diagrams
2. Check relationships and their markers
3. Apollon should behave as usual
