### PR TITLE
Add new drop info for assessment model

### DIFF
--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -283,6 +283,7 @@ export class ApollonEditor {
       elementType: elements[id].type as Apollon.UMLElementType | Apollon.UMLRelationshipType,
       score: assessments[id].score,
       feedback: assessments[id].feedback,
+      additionalInfo: assessments[id].additionalInfo,
     }));
 
     // check if previous assessment differs from current selection, if yes -> notify subscribers

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -283,7 +283,7 @@ export class ApollonEditor {
       elementType: elements[id].type as Apollon.UMLElementType | Apollon.UMLRelationshipType,
       score: assessments[id].score,
       feedback: assessments[id].feedback,
-      additionalInfo: assessments[id].additionalInfo,
+      dropInfo: assessments[id].dropInfo,
     }));
 
     // check if previous assessment differs from current selection, if yes -> notify subscribers

--- a/src/main/components/uml-element/assessable/assessable.tsx
+++ b/src/main/components/uml-element/assessable/assessable.tsx
@@ -154,8 +154,8 @@ export const assessable = (
         const { id: elementId, assessment } = this.props;
         const score = instruction.credits;
         const feedback = instruction.feedback;
-        const additionalInfo = { instructionId: instruction.id };
-        this.props.assess(elementId, { ...assessment, score, feedback, additionalInfo });
+        const dropInfo = { instructionId: instruction.id };
+        this.props.assess(elementId, { ...assessment, score, feedback, dropInfo }, 'DROPPED');
         this.props.updateStart(elementId);
       }
     };

--- a/src/main/components/uml-element/assessable/assessable.tsx
+++ b/src/main/components/uml-element/assessable/assessable.tsx
@@ -154,7 +154,8 @@ export const assessable = (
         const { id: elementId, assessment } = this.props;
         const score = instruction.credits;
         const feedback = instruction.feedback;
-        this.props.assess(elementId, { ...assessment, score, feedback });
+        const additionalInfo = { instructionId: instruction.id };
+        this.props.assess(elementId, { ...assessment, score, feedback, additionalInfo });
         this.props.updateStart(elementId);
       }
     };

--- a/src/main/services/assessment/assessment-repository.ts
+++ b/src/main/services/assessment/assessment-repository.ts
@@ -2,11 +2,17 @@ import { IAssessment } from './assessment';
 import { AssessAction, AssessmentActionTypes, AssessmentState } from './assessment-types';
 
 export class AssessmentRepository {
-  static assess = (element: string, assessment: IAssessment): AssessAction => ({
-    type: AssessmentActionTypes.ASSESS,
-    payload: { element, assessment },
-    undoable: false,
-  });
+  static assess = (element: string, assessment: IAssessment, assessmentType?: 'MANUAL' | 'DROPPED'): AssessAction => {
+    const payloadAssessment = { ...assessment } as IAssessment;
+    if (assessmentType !== 'DROPPED' && payloadAssessment.dropInfo) {
+      delete payloadAssessment.dropInfo;
+    }
+    return {
+      type: AssessmentActionTypes.ASSESS,
+      payload: { element, assessment: payloadAssessment },
+      undoable: false,
+    };
+  };
 
   static getById = (assessments: AssessmentState) => (id: string): IAssessment | null => {
     const assessment = assessments[id];

--- a/src/main/services/assessment/assessment.ts
+++ b/src/main/services/assessment/assessment.ts
@@ -1,5 +1,5 @@
 export interface IAssessment {
   score: number;
   feedback?: string;
-  additionalInfo?: any;
+  dropInfo?: any;
 }

--- a/src/main/services/assessment/assessment.ts
+++ b/src/main/services/assessment/assessment.ts
@@ -1,4 +1,5 @@
 export interface IAssessment {
   score: number;
   feedback?: string;
+  additionalInfo?: any;
 }

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -102,6 +102,7 @@ export type Assessment = {
   elementType: UMLElementType | UMLRelationshipType;
   score: number;
   feedback?: string;
+  additionalInfo?: any;
 };
 
 export type ExportOptions = {

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -102,7 +102,7 @@ export type Assessment = {
   elementType: UMLElementType | UMLRelationshipType;
   score: number;
   feedback?: string;
-  additionalInfo?: any;
+  dropInfo?: any;
 };
 
 export type ExportOptions = {


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
During the assessment of modeling exercises in Artemis, if the grading instruction used as a feedback for UML element, the corresponding instruction id does not match with the feedback. With this PR, I introduced new `dropInfo` for Assessment. When the instruction is dropped into feedback field, it stores the ` instruction.id` in `dropInfo`.  So that, Artemis can match the feedback with the corresponding grading instruction.


