### PR TITLE
Add reachability graphs

### DIFF
--- a/public/index.html.ejs
+++ b/public/index.html.ejs
@@ -31,6 +31,7 @@
               <option value="ComponentDiagram">Component Diagram</option>
               <option value="DeploymentDiagram">Deployment Diagram</option>
               <option value="PetriNet">Petri Net</option>
+              <option value="ReachabilityGraph">Reachability Graph</option>
               <option value="SyntaxTree">Syntax Tree</option>
               <option value="Flowchart">Flowchart</option>
             </select>

--- a/src/main/components/create-pane/create-pane.tsx
+++ b/src/main/components/create-pane/create-pane.tsx
@@ -22,6 +22,7 @@ import { ModelState } from '../store/model-state';
 import { StoreProvider } from '../store/model-store';
 import { PreviewElementComponent } from './preview-element-component';
 import { composePetriNetPreview } from '../../packages/uml-petri-net/petri-net-preview';
+import { composeReachabilityGraphPreview } from '../../packages/uml-reachability-graph/reachability-graph-preview';
 import { PreviewElement } from '../../packages/compose-preview';
 import { composeSyntaxTreePreview } from '../../packages/syntax-tree/syntax-tree-preview';
 import { composeFlowchartPreview } from '../../packages/flowchart/flowchart-diagram-preview';
@@ -64,6 +65,9 @@ const getInitialState = ({ type, canvas, translate }: Props) => {
       break;
     case UMLDiagramType.PetriNet:
       previews.push(...composePetriNetPreview(canvas, translate));
+      break;
+    case UMLDiagramType.ReachabilityGraph:
+      previews.push(...composeReachabilityGraphPreview(canvas, translate));
       break;
     case UMLDiagramType.SyntaxTree:
       previews.push(...composeSyntaxTreePreview(canvas, translate));

--- a/src/main/i18n/de.json
+++ b/src/main/i18n/de.json
@@ -96,6 +96,10 @@
       "PetriNetPlace": "Platz",
       "PetriNetTransition": "Transition"
     },
+    "ReachabilityGraph": {
+      "ReachabilityGraphIsInitialMarking": "Ist Anfangsmarkierung",
+      "ReachabilityGraphMarking": "Markierung"
+    },
     "SyntaxTree": {
       "SyntaxTreeTerminal": "Terminal",
       "SyntaxTreeNonterminal": "Nichtterminal",

--- a/src/main/i18n/en.json
+++ b/src/main/i18n/en.json
@@ -96,6 +96,10 @@
       "PetriNetPlace": "Place",
       "PetriNetTransition": "Transition"
     },
+    "ReachabilityGraph": {
+      "ReachabilityGraphIsInitialMarking": "Is initial marking",
+      "ReachabilityGraphMarking": "Marking"
+    },
     "SyntaxTree": {
       "SyntaxTreeTerminal": "Terminal",
       "SyntaxTreeNonterminal": "Nonterminal",

--- a/src/main/packages/components.ts
+++ b/src/main/packages/components.ts
@@ -33,6 +33,8 @@ import { ConnectedComponent } from 'react-redux';
 import { UMLPetriNetPlaceComponent } from './uml-petri-net/uml-petri-net-place/uml-petri-net-place-component';
 import { UMLPetriNetTransitionComponent } from './uml-petri-net/uml-petri-net-transition/uml-petri-net-transition-component';
 import { UMLPetriNetArcComponent } from './uml-petri-net/uml-petri-net-arc/uml-petri-net-arc-component';
+import { UMLReachabilityGraphArcComponent } from './uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-component';
+import { UMLReachabilityGraphMarkingComponent } from './uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-component';
 import { UMLComponentComponent } from './common/uml-component/uml-component-component';
 import { SyntaxTreeTerminalComponent } from './syntax-tree/syntax-tree-terminal/syntax-tree-terminal-component';
 import { SyntaxTreeNonterminalComponent } from './syntax-tree/syntax-tree-nonterminal/syntax-tree-nonterminal-component';
@@ -77,6 +79,7 @@ export const Components: {
   [UMLElementType.DeploymentInterface]: UMLInterfaceComponent,
   [UMLElementType.PetriNetTransition]: UMLPetriNetTransitionComponent,
   [UMLElementType.PetriNetPlace]: UMLPetriNetPlaceComponent,
+  [UMLElementType.ReachabilityGraphMarking]: UMLReachabilityGraphMarkingComponent,
   [UMLElementType.CommunicationLinkMessage]: UMLClassifierMemberComponent,
   [UMLElementType.SyntaxTreeTerminal]: SyntaxTreeTerminalComponent,
   [UMLElementType.SyntaxTreeNonterminal]: SyntaxTreeNonterminalComponent,
@@ -107,6 +110,7 @@ export const Components: {
   [UMLRelationshipType.DeploymentInterfaceProvided]: UMLInterfaceProvidedComponent,
   [UMLRelationshipType.DeploymentInterfaceRequired]: UMLInterfaceRequiredComponent,
   [UMLRelationshipType.PetriNetArc]: UMLPetriNetArcComponent,
+  [UMLRelationshipType.ReachabilityGraphArc]: UMLReachabilityGraphArcComponent,
   [UMLRelationshipType.SyntaxTreeLink]: SyntaxTreeLinkComponent,
   [UMLRelationshipType.FlowchartFlowline]: FlowchartFlowlineComponent,
 };

--- a/src/main/packages/diagram-type.ts
+++ b/src/main/packages/diagram-type.ts
@@ -9,6 +9,7 @@ export const UMLDiagramType = {
   ComponentDiagram: 'ComponentDiagram',
   DeploymentDiagram: 'DeploymentDiagram',
   PetriNet: 'PetriNet',
+  ReachabilityGraph: 'ReachabilityGraph',
   SyntaxTree: 'SyntaxTree',
   Flowchart: 'Flowchart',
 } as const;

--- a/src/main/packages/popups.ts
+++ b/src/main/packages/popups.ts
@@ -15,6 +15,8 @@ import { UMLRelationshipType } from './uml-relationship-type';
 import { UMLUseCaseAssociationUpdate } from './uml-use-case-diagram/uml-use-case-association/uml-use-case-association-update';
 import { UMLPetriNetPlaceUpdate } from './uml-petri-net/uml-petri-net-place/uml-petri-net-place-update';
 import { UMLPetriNetArcUpdate } from './uml-petri-net/uml-petri-net-arc/uml-petri-net-arc-update';
+import { UMLReachabilityGraphArcUpdate } from './uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-update';
+import { UMLReachabilityGraphMarkingUpdate } from './uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-update';
 import { SyntaxTreeTerminalUpdate } from './syntax-tree/syntax-tree-terminal/syntax-tree-terminal-update';
 import { SyntaxTreeNonterminalUpdate } from './syntax-tree/syntax-tree-nonterminal/syntax-tree-nonterminal-update';
 import { FlowchartTerminalUpdate } from './flowchart/flowchart-terminal/flowchart-terminal-update';
@@ -55,6 +57,7 @@ export const Popups: { [key in UMLElementType | UMLRelationshipType]: ComponentT
   [UMLElementType.DeploymentInterface]: DefaultPopup,
   [UMLElementType.PetriNetPlace]: UMLPetriNetPlaceUpdate,
   [UMLElementType.PetriNetTransition]: DefaultPopup,
+  [UMLElementType.ReachabilityGraphMarking]: UMLReachabilityGraphMarkingUpdate,
   [UMLElementType.CommunicationLinkMessage]: null,
   [UMLElementType.SyntaxTreeTerminal]: SyntaxTreeTerminalUpdate,
   [UMLElementType.SyntaxTreeNonterminal]: SyntaxTreeNonterminalUpdate,
@@ -86,6 +89,7 @@ export const Popups: { [key in UMLElementType | UMLRelationshipType]: ComponentT
   [UMLRelationshipType.DeploymentInterfaceProvided]: UMLDeploymentAssociationUpdate,
   [UMLRelationshipType.DeploymentInterfaceRequired]: UMLDeploymentAssociationUpdate,
   [UMLRelationshipType.PetriNetArc]: UMLPetriNetArcUpdate,
+  [UMLRelationshipType.ReachabilityGraphArc]: UMLReachabilityGraphArcUpdate,
   [UMLRelationshipType.SyntaxTreeLink]: DefaultRelationshipPopup,
   [UMLRelationshipType.FlowchartFlowline]: FlowchartFlowlineUpdate,
 };

--- a/src/main/packages/uml-element-type.ts
+++ b/src/main/packages/uml-element-type.ts
@@ -9,6 +9,7 @@ import { CommunicationElementType } from './uml-communication-diagram';
 import { UMLDiagramType } from './diagram-type';
 import { SyntaxTreeElementType } from './syntax-tree';
 import { FlowchartElementType } from './flowchart';
+import { ReachabilityGraphElementType } from './uml-reachability-graph';
 
 export type UMLElementType =
   | keyof typeof ClassElementType
@@ -19,6 +20,7 @@ export type UMLElementType =
   | keyof typeof ComponentElementType
   | keyof typeof DeploymentElementType
   | keyof typeof PetriNetElementType
+  | keyof typeof ReachabilityGraphElementType
   | keyof typeof SyntaxTreeElementType
   | keyof typeof FlowchartElementType;
 
@@ -31,6 +33,7 @@ export const UMLElementType = {
   ...ComponentElementType,
   ...DeploymentElementType,
   ...PetriNetElementType,
+  ...ReachabilityGraphElementType,
   ...SyntaxTreeElementType,
   ...FlowchartElementType,
 };
@@ -44,6 +47,7 @@ export const UMLElementsForDiagram: { [key in UMLDiagramType]: any } = {
   [UMLDiagramType.ComponentDiagram]: ComponentElementType,
   [UMLDiagramType.DeploymentDiagram]: DeploymentElementType,
   [UMLDiagramType.PetriNet]: PetriNetElementType,
+  [UMLDiagramType.ReachabilityGraph]: ReachabilityGraphElementType,
   [UMLDiagramType.SyntaxTree]: SyntaxTreeElementType,
   [UMLDiagramType.Flowchart]: FlowchartElementType,
 };

--- a/src/main/packages/uml-elements.ts
+++ b/src/main/packages/uml-elements.ts
@@ -25,6 +25,7 @@ import { UMLUseCase } from './uml-use-case-diagram/uml-use-case/uml-use-case';
 import { UMLDeploymentInterface } from './uml-deployment-diagram/uml-deployment-interface/uml-component-interface';
 import { UMLPetriNetTransition } from './uml-petri-net/uml-petri-net-transition/uml-petri-net-transition';
 import { UMLPetriNetPlace } from './uml-petri-net/uml-petri-net-place/uml-petri-net-place';
+import { UMLReachabilityGraphMarking } from './uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking';
 import { CommunicationLinkMessage } from './uml-communication-diagram/uml-communication-link/uml-communiction-link-message';
 import { UMLDeploymentComponent } from './uml-deployment-diagram/uml-deployment-component/uml-component';
 import { UMLComponentComponent } from './uml-component-diagram/uml-component/uml-component-component';
@@ -65,6 +66,7 @@ export const UMLElements = {
   [UMLElementType.DeploymentInterface]: UMLDeploymentInterface,
   [UMLElementType.PetriNetPlace]: UMLPetriNetPlace,
   [UMLElementType.PetriNetTransition]: UMLPetriNetTransition,
+  [UMLElementType.ReachabilityGraphMarking]: UMLReachabilityGraphMarking,
   [UMLElementType.CommunicationLinkMessage]: CommunicationLinkMessage,
   [UMLElementType.SyntaxTreeTerminal]: SyntaxTreeTerminal,
   [UMLElementType.SyntaxTreeNonterminal]: SyntaxTreeNonterminal,

--- a/src/main/packages/uml-reachability-graph/index.ts
+++ b/src/main/packages/uml-reachability-graph/index.ts
@@ -1,0 +1,7 @@
+export const ReachabilityGraphElementType = {
+  ReachabilityGraphMarking: 'ReachabilityGraphMarking',
+} as const;
+
+export const ReachabilityGraphRelationshipType = {
+  ReachabilityGraphArc: 'ReachabilityGraphArc',
+} as const;

--- a/src/main/packages/uml-reachability-graph/reachability-graph-preview.ts
+++ b/src/main/packages/uml-reachability-graph/reachability-graph-preview.ts
@@ -1,0 +1,16 @@
+import { ILayer } from '../../services/layouter/layer';
+import { UMLElement } from '../../services/uml-element/uml-element';
+import { ComposePreview } from '../compose-preview';
+import { UMLReachabilityGraphMarking } from './uml-reachability-graph-marking/uml-reachability-graph-marking';
+
+export const composeReachabilityGraphPreview: ComposePreview = (
+  layer: ILayer,
+  translate: (id: string) => string,
+): UMLElement[] => {
+  const elements: UMLElement[] = [];
+
+  // Reachability Graph Marking
+  elements.push(new UMLReachabilityGraphMarking({ name: translate('packages.ReachabilityGraph.ReachabilityGraphMarking') }));
+
+  return elements;
+};

--- a/src/main/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-component.tsx
+++ b/src/main/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-component.tsx
@@ -1,0 +1,73 @@
+import React, { SFC } from 'react';
+import { Point } from '../../../utils/geometry/point';
+import { UMLReachabilityGraphArc } from './uml-reachability-graph-arc';
+
+export const UMLReachabilityGraphArcComponent: SFC<Props> = ({ element }) => {
+  let position = { x: 0, y: 0 };
+  let direction: 'v' | 'h' = 'v';
+  const path = element.path.map((point) => new Point(point.x, point.y));
+  let distance =
+    path.reduce(
+      (length, point, i, points) => (i + 1 < points.length ? length + points[i + 1].subtract(point).length : length),
+      0,
+    ) / 2;
+
+  for (let index = 0; index < path.length - 1; index++) {
+    const vector = path[index + 1].subtract(path[index]);
+    if (vector.length > distance) {
+      const norm = vector.normalize();
+      direction = Math.abs(norm.x) > Math.abs(norm.y) ? 'h' : 'v';
+      position = path[index].add(norm.scale(distance));
+      break;
+    }
+    distance -= vector.length;
+  }
+
+  const layoutText = (dir: 'v' | 'h') => {
+    switch (dir) {
+      case 'v':
+        return {
+          dx: 5,
+          dominantBaseline: 'middle',
+          textAnchor: 'start',
+        };
+      case 'h':
+        return {
+          dy: -5,
+          dominantBaseline: 'text-after-edge',
+          textAnchor: 'middle',
+        };
+    }
+  };
+
+  return (
+    <g>
+      <marker
+        id={`marker-${element.id}`}
+        viewBox="0 0 30 30"
+        markerWidth="22"
+        markerHeight="30"
+        refX="30"
+        refY="15"
+        orient="auto"
+        markerUnits="strokeWidth"
+      >
+        <path d="M0,29 L30,15 L0,1" fill="none" stroke="black" />
+      </marker>
+      <polyline
+        points={element.path.map((point) => `${point.x} ${point.y}`).join(',')}
+        stroke="black"
+        fill="none"
+        strokeWidth={1}
+        markerEnd={`url(#marker-${element.id})`}
+      />
+      <text x={position.x} y={position.y} {...layoutText(direction)} pointerEvents="none">
+        {element.name}
+      </text>
+    </g>
+  );
+};
+
+interface Props {
+  element: UMLReachabilityGraphArc;
+}

--- a/src/main/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-update.tsx
+++ b/src/main/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-update.tsx
@@ -1,0 +1,75 @@
+import React, { Component, ComponentClass } from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import { Button } from '../../../components/controls/button/button';
+import { TrashIcon } from '../../../components/controls/icon/trash';
+import { Textfield } from '../../../components/controls/textfield/textfield';
+import { I18nContext } from '../../../components/i18n/i18n-context';
+import { localized } from '../../../components/i18n/localized';
+import { ModelState } from '../../../components/store/model-state';
+import { styled } from '../../../components/theme/styles';
+import { UMLElementRepository } from '../../../services/uml-element/uml-element-repository';
+import { ExchangeIcon } from '../../../components/controls/icon/exchange';
+import { UMLRelationshipRepository } from '../../../services/uml-relationship/uml-relationship-repository';
+import { UMLReachabilityGraphArc } from './uml-reachability-graph-arc';
+
+interface OwnProps {
+  element: UMLReachabilityGraphArc;
+}
+
+type StateProps = {};
+
+interface DispatchProps {
+  update: typeof UMLElementRepository.update;
+  delete: typeof UMLElementRepository.delete;
+  flip: typeof UMLRelationshipRepository.flip;
+}
+
+type Props = OwnProps & StateProps & DispatchProps & I18nContext;
+
+const enhance = compose<ComponentClass<OwnProps>>(
+  localized,
+  connect<StateProps, DispatchProps, OwnProps, ModelState>(null, {
+    update: UMLElementRepository.update,
+    delete: UMLElementRepository.delete,
+    flip: UMLRelationshipRepository.flip,
+  }),
+);
+
+const Flex = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+`;
+
+class UMLReachabilityGraphArcUpdateComponent extends Component<Props> {
+  render() {
+    const { element } = this.props;
+
+    return (
+      <div>
+        <section>
+          <Flex>
+            <Textfield value={element.name} onChange={this.rename(element.id)} autoFocus />
+            <Button color="link" onClick={() => this.props.flip(element.id)}>
+              <ExchangeIcon />
+            </Button>
+            <Button color="link" tabIndex={-1} onClick={this.delete(element.id)}>
+              <TrashIcon />
+            </Button>
+          </Flex>
+        </section>
+      </div>
+    );
+  }
+
+  private rename = (id: string) => (value: string) => {
+    this.props.update(id, { name: value });
+  };
+
+  private delete = (id: string) => () => {
+    this.props.delete(id);
+  };
+}
+
+export const UMLReachabilityGraphArcUpdate = enhance(UMLReachabilityGraphArcUpdateComponent);

--- a/src/main/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc.ts
+++ b/src/main/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc.ts
@@ -1,0 +1,17 @@
+import { ReachabilityGraphRelationshipType } from '..';
+import { IUMLRelationship, UMLRelationship } from '../../../services/uml-relationship/uml-relationship';
+import { DeepPartial } from 'redux';
+import { UMLRelationshipCenteredDescription } from '../../../services/uml-relationship/uml-relationship-centered-description';
+
+export class UMLReachabilityGraphArc extends UMLRelationshipCenteredDescription {
+  static features = { ...UMLRelationship.features };
+  static transition = 't';
+
+  type = ReachabilityGraphRelationshipType.ReachabilityGraphArc;
+  name = UMLReachabilityGraphArc.transition;
+
+  constructor(values?: DeepPartial<IUMLRelationship>) {
+    super(values);
+    this.name = (values && values.name) || this.name;
+  }
+}

--- a/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-component.tsx
+++ b/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-component.tsx
@@ -1,0 +1,45 @@
+import React, { SFC } from 'react';
+import { UMLReachabilityGraphMarking } from './uml-reachability-graph-marking';
+import { Multiline } from '../../../utils/svg/multiline';
+
+export const UMLReachabilityGraphMarkingComponent: SFC<Props> = ({ element }) => (
+  <g>
+    <rect rx={10} ry={10} width="100%" height="100%" stroke="black" />
+    <Multiline
+      x={element.bounds.width / 2}
+      y={element.bounds.height / 2}
+      width={element.bounds.width}
+      height={element.bounds.height}
+      fontWeight="bold"
+    >
+      {element.name}
+    </Multiline>
+    {element.isInitialMarking && (
+      <g>
+        <marker
+          id={`marker-${element.id}`}
+          viewBox="0 0 30 30"
+          markerWidth="22"
+          markerHeight="30"
+          refX="30"
+          refY="15"
+          orient="auto"
+          markerUnits="strokeWidth"
+        >
+          <path d="M0,29 L30,15 L0,1" fill="none" stroke="black" />
+        </marker>
+        <polyline
+          points="-50,-50 3,3"
+          stroke="black"
+          fill="none"
+          strokeWidth={1}
+          markerEnd={`url(#marker-${element.id})`}
+        />
+      </g>
+    )}
+  </g>
+);
+
+interface Props {
+  element: UMLReachabilityGraphMarking;
+}

--- a/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-update.tsx
+++ b/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-update.tsx
@@ -1,0 +1,85 @@
+import React, { Component, ComponentClass } from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import { Button } from '../../../components/controls/button/button';
+import { TrashIcon } from '../../../components/controls/icon/trash';
+import { Textfield } from '../../../components/controls/textfield/textfield';
+import { I18nContext } from '../../../components/i18n/i18n-context';
+import { localized } from '../../../components/i18n/localized';
+import { ModelState } from '../../../components/store/model-state';
+import { styled } from '../../../components/theme/styles';
+import { UMLElementRepository } from '../../../services/uml-element/uml-element-repository';
+import { UMLReachabilityGraphMarking } from './uml-reachability-graph-marking';
+import { Divider } from '../../../components/controls/divider/divider';
+
+interface OwnProps {
+  element: UMLReachabilityGraphMarking;
+}
+
+type StateProps = {};
+
+interface DispatchProps {
+  update: typeof UMLElementRepository.update;
+  delete: typeof UMLElementRepository.delete;
+}
+
+type Props = OwnProps & StateProps & DispatchProps & I18nContext;
+
+const enhance = compose<ComponentClass<OwnProps>>(
+  localized,
+  connect<StateProps, DispatchProps, OwnProps, ModelState>(null, {
+    update: UMLElementRepository.update,
+    delete: UMLElementRepository.delete,
+  }),
+);
+
+const Flex = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+`;
+
+class UmlReachabilityGraphMarkingUpdate extends Component<Props> {
+  render() {
+    const { element } = this.props;
+
+    return (
+      <div>
+        <section>
+          <Flex>
+            <Textfield value={element.name} onChange={this.rename(element.id)} autoFocus />
+            <Button color="link" tabIndex={-1} onClick={this.delete(element.id)}>
+              <TrashIcon />
+            </Button>
+          </Flex>
+          <Divider />
+        </section>
+        <section>
+          <label htmlFor="toggleIsInitialMarking">
+            <input
+              id="toggleIsInitialMarking"
+              type="checkbox"
+              checked={element.isInitialMarking}
+              onChange={this.toggleIsInitialMarking(element.id)}
+            />
+            {this.props.translate('packages.ReachabilityGraph.ReachabilityGraphIsInitialMarking')}
+          </label>
+        </section>
+      </div>
+    );
+  }
+
+  private rename = (id: string) => (value: string) => {
+    this.props.update(id, { name: value });
+  };
+
+  private toggleIsInitialMarking = (id: string) => (event: React.FormEvent<HTMLInputElement>) => {
+    this.props.update<UMLReachabilityGraphMarking>(id, { isInitialMarking: event.currentTarget.checked });
+  };
+
+  private delete = (id: string) => () => {
+    this.props.delete(id);
+  };
+}
+
+export const UMLReachabilityGraphMarkingUpdate = enhance(UmlReachabilityGraphMarkingUpdate);

--- a/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking.ts
+++ b/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking.ts
@@ -1,0 +1,40 @@
+import { ILayer } from '../../../services/layouter/layer';
+import { ILayoutable } from '../../../services/layouter/layoutable';
+import { UMLElement } from '../../../services/uml-element/uml-element';
+import { UMLElementType } from '../../uml-element-type';
+import * as Apollon from '../../../typings';
+import { ReachabilityGraphElementType } from '..';
+import { DeepPartial } from 'redux';
+
+export class UMLReachabilityGraphMarking extends UMLElement {
+  type: UMLElementType = ReachabilityGraphElementType.ReachabilityGraphMarking;
+  isInitialMarking: boolean;
+
+  constructor(values?: DeepPartial<UMLReachabilityGraphMarking>) {
+    super(values);
+    this.isInitialMarking = values?.isInitialMarking || false;
+  }
+
+  serialize(children?: UMLElement[]): Apollon.UMLReachabilityGraphMarking {
+    return {
+      ...super.serialize(),
+      type: this.type as keyof typeof ReachabilityGraphElementType,
+      isInitialMarking: this.isInitialMarking,
+    };
+  }
+
+  deserialize<T extends Apollon.UMLModelElement>(values: T, children?: Apollon.UMLModelElement[]) {
+    const assert = (v: Apollon.UMLModelElement): v is Apollon.UMLReachabilityGraphMarking =>
+      v.type === ReachabilityGraphElementType.ReachabilityGraphMarking;
+    if (!assert(values)) {
+      return;
+    }
+
+    super.deserialize(values, children);
+    this.isInitialMarking = values.isInitialMarking;
+  }
+
+  render(canvas: ILayer): ILayoutable[] {
+    return [this];
+  }
+}

--- a/src/main/packages/uml-relationship-type.ts
+++ b/src/main/packages/uml-relationship-type.ts
@@ -7,6 +7,7 @@ import { DeploymentRelationshipType } from './uml-deployment-diagram';
 import { ObjectRelationshipType } from './uml-object-diagram';
 import { UseCaseRelationshipType } from './uml-use-case-diagram';
 import { PetriNetRelationshipType } from './uml-petri-net';
+import { ReachabilityGraphRelationshipType } from './uml-reachability-graph';
 import { SyntaxTreeRelationshipType } from './syntax-tree';
 import { FlowchartRelationshipType } from './flowchart';
 
@@ -19,6 +20,7 @@ export type UMLRelationshipType =
   | keyof typeof ComponentRelationshipType
   | keyof typeof DeploymentRelationshipType
   | keyof typeof PetriNetRelationshipType
+  | keyof typeof ReachabilityGraphRelationshipType
   | keyof typeof SyntaxTreeRelationshipType
   | keyof typeof FlowchartRelationshipType;
 
@@ -31,6 +33,7 @@ export const UMLRelationshipType = {
   ...ComponentRelationshipType,
   ...DeploymentRelationshipType,
   ...PetriNetRelationshipType,
+  ...ReachabilityGraphRelationshipType,
   ...SyntaxTreeRelationshipType,
   ...FlowchartRelationshipType,
 };
@@ -44,6 +47,7 @@ export const DefaultUMLRelationshipType: { [key in UMLDiagramType]: UMLRelations
   [UMLDiagramType.ComponentDiagram]: ComponentRelationshipType.ComponentInterfaceProvided,
   [UMLDiagramType.DeploymentDiagram]: DeploymentRelationshipType.DeploymentAssociation,
   [UMLDiagramType.PetriNet]: PetriNetRelationshipType.PetriNetArc,
+  [UMLDiagramType.ReachabilityGraph]: ReachabilityGraphRelationshipType.ReachabilityGraphArc,
   [UMLDiagramType.SyntaxTree]: SyntaxTreeRelationshipType.SyntaxTreeLink,
   [UMLDiagramType.Flowchart]: FlowchartRelationshipType.FlowchartFlowline,
 };

--- a/src/main/packages/uml-relationships.ts
+++ b/src/main/packages/uml-relationships.ts
@@ -22,6 +22,7 @@ import { UMLDeploymentInterfaceProvided } from './uml-deployment-diagram/uml-dep
 import { UMLDeploymentInterfaceRequired } from './uml-deployment-diagram/uml-deployment-interface-required/uml-deployment-interface-required';
 import { UMLDeploymentDependency } from './uml-deployment-diagram/uml-deployment-dependency/uml-deployment-dependency';
 import { UMLPetriNetArc } from './uml-petri-net/uml-petri-net-arc/uml-petri-net-arc';
+import { UMLReachabilityGraphArc } from './uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc';
 import { SyntaxTreeLink } from './syntax-tree/syntax-tree-link/syntax-tree-link';
 import { FlowchartFlowline } from './flowchart/flowchart-flowline/flowchart-flowline';
 
@@ -50,6 +51,7 @@ export const UMLRelationships = {
   [UMLRelationshipType.DeploymentInterfaceProvided]: UMLDeploymentInterfaceProvided,
   [UMLRelationshipType.DeploymentInterfaceRequired]: UMLDeploymentInterfaceRequired,
   [UMLRelationshipType.PetriNetArc]: UMLPetriNetArc,
+  [UMLRelationshipType.ReachabilityGraphArc]: UMLReachabilityGraphArc,
   [UMLRelationshipType.SyntaxTreeLink]: SyntaxTreeLink,
   [UMLRelationshipType.FlowchartFlowline]: FlowchartFlowline,
 };

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -78,6 +78,10 @@ export type UMLPetriNetPlace = UMLElement & {
   capacity: number | string;
 };
 
+export type UMLReachabilityGraphMarking = UMLElement & {
+  isInitialMarking: boolean;
+};
+
 export type UMLAssociation = UMLRelationship & {
   source: UMLRelationship['source'] & {
     multiplicity: string;

--- a/src/tests/packages/uml-reachability-graph/uml-reachability-graph-arc/__snapshots__/uml-reachability-graph-arc-component-test.tsx.snap
+++ b/src/tests/packages/uml-reachability-graph/uml-reachability-graph-arc/__snapshots__/uml-reachability-graph-arc-component-test.tsx.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render the uml-reachability-graph-arc-component 1`] = `
+<body>
+  <div>
+    <svg>
+      <g>
+        <marker
+          id="marker-test-id"
+          markerHeight="30"
+          markerUnits="strokeWidth"
+          markerWidth="22"
+          orient="auto"
+          refX="30"
+          refY="15"
+          viewBox="0 0 30 30"
+        >
+          <path
+            d="M0,29 L30,15 L0,1"
+            fill="none"
+            stroke="black"
+          />
+        </marker>
+        <polyline
+          fill="none"
+          marker-end="url(#marker-test-id)"
+          points="0 0,200 100"
+          stroke="black"
+          stroke-width="1"
+        />
+        <text
+          dominant-baseline="text-after-edge"
+          dy="-5"
+          pointer-events="none"
+          text-anchor="middle"
+          x="100"
+          y="50"
+        >
+          TestReachabilityGraphArc
+        </text>
+      </g>
+    </svg>
+  </div>
+</body>
+`;

--- a/src/tests/packages/uml-reachability-graph/uml-reachability-graph-arc/__snapshots__/uml-reachability-graph-arc-update-test.tsx.snap
+++ b/src/tests/packages/uml-reachability-graph/uml-reachability-graph-arc/__snapshots__/uml-reachability-graph-arc-update-test.tsx.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test reachability graph arc update render 1`] = `
+<body>
+  <div>
+    <div>
+      <section>
+        <div
+          class="sc-gWXaA-D dwiBOv"
+        >
+          <input
+            class="sc-hBURRC sc-fotPbf ezKeeT ictcNQ"
+            value="UMLClassBidirectional"
+          />
+          <button
+            class="sc-kDThTU sc-iqsfdx bmjioK iJozYQ"
+            color="link"
+          >
+            <svg
+              class="sc-bdvvaa xcZOT"
+              height="16px"
+              viewBox="0 0 512 512"
+              width="16px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M508.485 184.485l-92.485 92c-4.687 4.686-12.284 4.686-16.97 0l-7.071-7.07c-4.687-4.686-4.687-12.284 0-16.971L452.893 192H12c-6.627 0-12-5.373-12-12v-8c0-6.627 5.373-12 12-12h440.905l-60.946-60.444c-4.687-4.686-4.687-12.284 0-16.971l7.07-7.07c4.687-4.686 12.284-4.686 16.971 0l92.485 92c4.687 4.686 4.686 12.284 0 16.97zm-504.97 160l92.485 92c4.687 4.686 12.284 4.686 16.971 0l7.07-7.07c4.687-4.686 4.687-12.284 0-16.971L59.095 352H500c6.627 0 12-5.373 12-12v-8c0-6.627-5.373-12-12-12H59.107l60.934-60.444c4.687-4.686 4.687-12.284 0-16.971l-7.071-7.07c-4.686-4.686-12.284-4.687-16.97 0l-92.485 92c-4.686 4.686-4.687 12.284 0 16.97z"
+              />
+            </svg>
+          </button>
+          <button
+            class="sc-kDThTU sc-iqsfdx bmjioK iJozYQ"
+            color="link"
+            tabindex="-1"
+          >
+            <svg
+              class="sc-bdvvaa xcZOT"
+              height="16px"
+              viewBox="0 0 448 512"
+              width="16px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M440 64H336l-33.6-44.8A48 48 0 0 0 264 0h-80a48 48 0 0 0-38.4 19.2L112 64H8a8 8 0 0 0-8 8v16a8 8 0 0 0 8 8h18.9l33.2 372.3a48 48 0 0 0 47.8 43.7h232.2a48 48 0 0 0 47.8-43.7L421.1 96H440a8 8 0 0 0 8-8V72a8 8 0 0 0-8-8zM171.2 38.4A16.1 16.1 0 0 1 184 32h80a16.1 16.1 0 0 1 12.8 6.4L296 64H152zm184.8 427a15.91 15.91 0 0 1-15.9 14.6H107.9A15.91 15.91 0 0 1 92 465.4L59 96h330z"
+              />
+            </svg>
+          </button>
+        </div>
+      </section>
+    </div>
+  </div>
+</body>
+`;

--- a/src/tests/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-component-test.tsx
+++ b/src/tests/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-component-test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { UMLReachabilityGraphArc } from '../../../../main/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc';
+import { UMLReachabilityGraphArcComponent } from '../../../../main/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-component';
+import { UMLReachabilityGraphMarking } from '../../../../main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking';
+import { Direction } from '../../../../main/services/uml-element/uml-element-port';
+
+it('render the uml-reachability-graph-arc-component', () => {
+  const source: UMLReachabilityGraphMarking = new UMLReachabilityGraphMarking({ name: 'TestReachabilityGraphArc' });
+  const target: UMLReachabilityGraphMarking = new UMLReachabilityGraphMarking({ name: 'TestReachabilityGraphArc' });
+  const element: UMLReachabilityGraphArc = new UMLReachabilityGraphArc({
+    id: 'test-id',
+    name: 'TestReachabilityGraphArc',
+    source: { element: source.id, direction: Direction.Up },
+    target: { element: target.id, direction: Direction.Up },
+  });
+  const { getByText, baseElement } = render(
+    <svg>
+      <UMLReachabilityGraphArcComponent element={element} />
+    </svg>,
+  );
+  expect(getByText(element.name)).toBeInTheDocument();
+  expect(baseElement).toMatchSnapshot();
+});

--- a/src/tests/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-update-test.tsx
+++ b/src/tests/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-update-test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { UMLElement } from '../../../../main/services/uml-element/uml-element';
+import { UMLClassBidirectional } from '../../../../main/packages/uml-class-diagram/uml-class-bidirectional/uml-class-bidirectional';
+import { Direction } from '../../../../main/services/uml-element/uml-element-port';
+import { getRealStore } from '../../../test-utils/test-utils';
+import { wrappedRender } from '../../../test-utils/render';
+import { fireEvent } from '@testing-library/react';
+import { UMLReachabilityGraphArc } from '../../../../main/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc';
+import { UMLReachabilityGraphArcUpdate } from '../../../../main/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-update';
+import { UMLReachabilityGraphMarking } from '../../../../main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking';
+
+describe('test reachability graph arc update', () => {
+  const elements: UMLElement[] = [];
+  let source: UMLReachabilityGraphMarking;
+  let target: UMLReachabilityGraphMarking;
+  let reachabilityGraphArc: UMLReachabilityGraphArc;
+
+  beforeEach(() => {
+    // initialize  objects
+    source = new UMLReachabilityGraphMarking({ id: 'source-test-id' });
+    target = new UMLReachabilityGraphMarking({ id: 'target-test-id' });
+    reachabilityGraphArc = new UMLReachabilityGraphArc({
+      id: 'test-id',
+      name: 'UMLClassBidirectional',
+      source: { element: source.id, direction: Direction.Up },
+      target: { element: target.id, direction: Direction.Up },
+    });
+    elements.push(source, target, reachabilityGraphArc);
+  });
+
+  it('render', () => {
+    const store = getRealStore(undefined, elements);
+
+    const { baseElement } = wrappedRender(<UMLReachabilityGraphArcUpdate element={reachabilityGraphArc} />, { store });
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('flip', () => {
+    const store = getRealStore(undefined, elements);
+
+    const { getAllByRole } = wrappedRender(<UMLReachabilityGraphArcUpdate element={reachabilityGraphArc} />, { store });
+    const buttons = getAllByRole('button');
+    buttons[0].click();
+
+    const element = store.getState().elements[reachabilityGraphArc.id] as UMLClassBidirectional;
+
+    expect(element.target).toEqual(reachabilityGraphArc.source);
+    expect(element.source).toEqual(reachabilityGraphArc.target);
+  });
+
+  it('delete', () => {
+    const store = getRealStore(undefined, elements);
+
+    const { getAllByRole } = wrappedRender(<UMLReachabilityGraphArcUpdate element={reachabilityGraphArc} />, { store });
+    const buttons = getAllByRole('button');
+    buttons[1].click();
+
+    expect(store.getState().elements).not.toContain(reachabilityGraphArc.id);
+  });
+
+  it('change name', () => {
+    const store = getRealStore(undefined, elements);
+
+    const { getByRole } = wrappedRender(<UMLReachabilityGraphArcUpdate element={reachabilityGraphArc} />, { store });
+    const nameField = getByRole('textbox');
+    const updatedValue = '0';
+    fireEvent.change(nameField, { target: { value: updatedValue } });
+
+    const updatedElement = store.getState().elements[reachabilityGraphArc.id] as UMLReachabilityGraphArc;
+
+    expect(updatedElement.name).toEqual(updatedValue);
+  });
+});

--- a/src/tests/packages/uml-reachability-graph/uml-reachability-graph-marking/__snapshots__/uml-reachability-graph-marking-component-test.tsx.snap
+++ b/src/tests/packages/uml-reachability-graph/uml-reachability-graph-marking/__snapshots__/uml-reachability-graph-marking-component-test.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`uml-reachability-graph-marking-component render the uml-reachability-graph-marking-component 1`] = `
+<body>
+  <div>
+    <svg>
+      <g>
+        <rect
+          height="100%"
+          rx="10"
+          ry="10"
+          stroke="black"
+          width="100%"
+        />
+        <text
+          font-weight="bold"
+          height="100"
+          pointer-events="none"
+          text-anchor="middle"
+          width="200"
+          x="100"
+          y="50"
+        >
+          <tspan>
+             
+          </tspan>
+        </text>
+      </g>
+    </svg>
+  </div>
+</body>
+`;

--- a/src/tests/packages/uml-reachability-graph/uml-reachability-graph-marking/__snapshots__/uml-reachability-graph-marking-update-test.tsx.snap
+++ b/src/tests/packages/uml-reachability-graph/uml-reachability-graph-marking/__snapshots__/uml-reachability-graph-marking-update-test.tsx.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test reachability graph arc update render 1`] = `
+<body>
+  <div>
+    <div>
+      <section>
+        <div
+          class="sc-cCcYRi iuPvJz"
+        >
+          <input
+            class="sc-hBURRC sc-fotPbf ezKeeT ictcNQ"
+            value=""
+          />
+          <button
+            class="sc-kDThTU sc-iqsfdx bmjioK iJozYQ"
+            color="link"
+            tabindex="-1"
+          >
+            <svg
+              class="sc-bdvvaa xcZOT"
+              height="16px"
+              viewBox="0 0 448 512"
+              width="16px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M440 64H336l-33.6-44.8A48 48 0 0 0 264 0h-80a48 48 0 0 0-38.4 19.2L112 64H8a8 8 0 0 0-8 8v16a8 8 0 0 0 8 8h18.9l33.2 372.3a48 48 0 0 0 47.8 43.7h232.2a48 48 0 0 0 47.8-43.7L421.1 96H440a8 8 0 0 0 8-8V72a8 8 0 0 0-8-8zM171.2 38.4A16.1 16.1 0 0 1 184 32h80a16.1 16.1 0 0 1 12.8 6.4L296 64H152zm184.8 427a15.91 15.91 0 0 1-15.9 14.6H107.9A15.91 15.91 0 0 1 92 465.4L59 96h330z"
+              />
+            </svg>
+          </button>
+        </div>
+        <hr
+          class="sc-dJjZJu dhDoEz"
+        />
+      </section>
+      <section>
+        <label
+          for="toggleIsInitialMarking"
+        >
+          <input
+            id="toggleIsInitialMarking"
+            type="checkbox"
+          />
+          Is initial marking
+        </label>
+      </section>
+    </div>
+  </div>
+</body>
+`;

--- a/src/tests/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-component-test.tsx
+++ b/src/tests/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-component-test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { UMLReachabilityGraphMarking } from '../../../../main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking';
+import { UMLReachabilityGraphMarkingComponent } from '../../../../main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-component';
+
+describe('uml-reachability-graph-marking-component', () => {
+  let element: UMLReachabilityGraphMarking;
+  beforeEach(() => {
+    element = new UMLReachabilityGraphMarking({});
+  });
+
+  it('render the uml-reachability-graph-marking-component', () => {
+    const { baseElement } = render(
+      <svg>
+        <UMLReachabilityGraphMarkingComponent element={element} />
+      </svg>,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('render with isInitialMarking false', () => {
+    element.isInitialMarking = false;
+    const { container } = render(
+      <svg>
+        <UMLReachabilityGraphMarkingComponent element={element} />
+      </svg>,
+    );
+    expect(container.querySelectorAll('polyline')).toHaveLength(0);
+  });
+
+  it('render with isInitialMarking true', () => {
+    element.isInitialMarking = true;
+    const { container } = render(
+      <svg>
+        <UMLReachabilityGraphMarkingComponent element={element} />
+      </svg>,
+    );
+    expect(container.querySelectorAll('polyline')).toHaveLength(1);
+  });
+});

--- a/src/tests/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-update-test.tsx
+++ b/src/tests/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-update-test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import { UMLElement } from '../../../../main/services/uml-element/uml-element';
+import { getRealStore } from '../../../test-utils/test-utils';
+import { wrappedRender } from '../../../test-utils/render';
+import { fireEvent } from '@testing-library/react';
+import { UMLReachabilityGraphMarking } from '../../../../main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking';
+import { UMLReachabilityGraphMarkingUpdate } from '../../../../main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-update';
+
+describe('test reachability graph arc update', () => {
+  const elements: UMLElement[] = [];
+  let reachabilityGraphMarking: UMLReachabilityGraphMarking;
+
+  beforeEach(() => {
+    reachabilityGraphMarking = new UMLReachabilityGraphMarking({
+      id: 'test-id',
+    });
+    elements.push(reachabilityGraphMarking);
+  });
+
+  it('render', () => {
+    const store = getRealStore(undefined, elements);
+
+    const { baseElement } = wrappedRender(<UMLReachabilityGraphMarkingUpdate element={reachabilityGraphMarking} />, {
+      store,
+    });
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('change name', () => {
+    const store = getRealStore(undefined, elements);
+
+    const { getByRole } = wrappedRender(<UMLReachabilityGraphMarkingUpdate element={reachabilityGraphMarking} />, {
+      store,
+    });
+    const nameField = getByRole('textbox');
+    const updatedValue = '0';
+    fireEvent.change(nameField, { target: { value: updatedValue } });
+
+    const updatedElement = store.getState().elements[reachabilityGraphMarking.id] as UMLReachabilityGraphMarking;
+
+    expect(updatedElement.name).toEqual(updatedValue);
+  });
+
+  it('toggle isInitialMarking', () => {
+    const store = getRealStore(undefined, elements);
+
+    const { getAllByRole } = wrappedRender(<UMLReachabilityGraphMarkingUpdate element={reachabilityGraphMarking} />, {
+      store,
+    });
+    const isInitialMarkingField = getAllByRole('checkbox')[0];
+    const updatedValue = true;
+    fireEvent.click(isInitialMarkingField as Element);
+
+    const updatedElement = store.getState().elements[reachabilityGraphMarking.id] as UMLReachabilityGraphMarking;
+
+    expect(updatedElement.isInitialMarking).toEqual(updatedValue);
+  });
+
+  it('delete', () => {
+    const store = getRealStore(undefined, elements);
+
+    const { getAllByRole } = wrappedRender(<UMLReachabilityGraphMarkingUpdate element={reachabilityGraphMarking} />, {
+      store,
+    });
+    const buttons = getAllByRole('button');
+    // delete button
+    buttons[0].click();
+
+    expect(store.getState().elements).not.toContain(reachabilityGraphMarking.id);
+  });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes
- [x] I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This change introduces a new diagram type, namely reachability graphs in the context of Petri nets, a diagram type that is already implemented in Apollon. The final goal is to create a new exercise type in Artemis where students of the GBS (Grundlagen: Betriebssysteme und Systemsoftware) course are asked to construct the reachability graph of a given Petri net, or vice-versa, to construct the Petri net for a given reachability graph. This change resolves #130.

### Description
A new diagram type was added: reachability graphs. They only consist of a single `ElementType`: markings. Markings are connected using arcs, the one and only `RelationshipType` within this diagram. New popups or rather update components have been added for markings and arcs. Two translated strings have been added to the respective translation files. Markings have a two properties (a name and a flag that indicates whether a marking is the initial marking). Arcs only have a name and their direction may be changed in the popup. Tests have been added for both components. The tests cover all changes that are possible in the respective popups.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. Select the new diagram type "Reachability Graph".
2. Draw a set of markings. Assign different "names" to each marking (this actually is not the name of the marking but rather a comma separated list of integers, optionally surrounded by `()`, `[]` or `{}`, but that is irrelevant for testing the functionality). Define one marking as the initial marking (click on a marking and toggle the checkbox).
3. Connect the markings using arcs. Assign different names to each arc.
4. Make sure your graph gets saved correctly and reappears unchanged if you reload the page.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
A reachability graph where a marking is currently selected. It is possible to change the text inside the node and to define a marking as the initial marking. This draws an arrow towards the selected marking, as shown in the top left of the screenshot.
![Screen Shot 2021-05-15 at 21 34 41](https://user-images.githubusercontent.com/44683433/118375995-a5d02b00-b5c5-11eb-99a3-3fdebd40fba4.png)
The same graph in German language. The checkbox defines whether a marking is the initial marking.
![Screen Shot 2021-05-15 at 21 36 31](https://user-images.githubusercontent.com/44683433/118375997-a9fc4880-b5c5-11eb-932f-f7aa9fb7fb07.png)
An arc being edited. Arcs have a name and their direction can be toggled.
![Screen Shot 2021-05-15 at 21 35 05](https://user-images.githubusercontent.com/44683433/118376004-b08ac000-b5c5-11eb-9398-c0c0d7c92eb5.png)
The new graph in the menu on the right. This diagram type only has one type of node/element, namely markings.
![Screen Shot 2021-05-15 at 21 35 28](https://user-images.githubusercontent.com/44683433/118376057-f21b6b00-b5c5-11eb-963a-d8d06b787e2d.png)

