### PR TITLE
Fix for #87

### DIFF
--- a/src/main/components/uml-element/connectable/connectable.tsx
+++ b/src/main/components/uml-element/connectable/connectable.tsx
@@ -196,36 +196,47 @@ export const connectable = (
         return;
       }
 
-      // calculate event position relative to object position in %
-      const nodeRect = node.getBoundingClientRect();
+      let direction;
 
-      const relEventPosition = {
-        x: (event.clientX - nodeRect.left) / nodeRect.width,
-        y: (event.clientY - nodeRect.top) / nodeRect.height,
-      };
+      // if available, we can get the direction from the event target
+      if (event.target instanceof SVGElement && event.target.parentElement != null
+          && event.target.parentElement.hasAttribute('direction')) {
+        direction = event.target.parentElement.getAttribute('direction') as Direction;
+      }
 
-      // relative port locations in %
-      const relativePortLocation: { [key in Direction]: Point } = {
-        [Direction.Up]: new Point(0.5, 0),
-        [Direction.Right]: new Point(1, 0.5),
-        [Direction.Down]: new Point(0.5, 1),
-        [Direction.Left]: new Point(0, 0.5),
-      };
+      // otherwise get the direction the old way
+      if (direction == null) {
+        // calculate event position relative to object position in %
+        const nodeRect = node.getBoundingClientRect();
 
-      const ports = getPortsForElement(this.props.element);
+        const relEventPosition = {
+          x: (event.clientX - nodeRect.left) / nodeRect.width,
+          y: (event.clientY - nodeRect.top) / nodeRect.height,
+        };
 
-      // calculate the distances to all handles
-      const distances = Object.entries(ports).map(([key, value]) => ({
-        key,
-        distance: Math.sqrt(
-          Math.pow(relativePortLocation[key as Direction].x - relEventPosition.x, 2) +
-            Math.pow(relativePortLocation[key as Direction].y - relEventPosition.y, 2),
-        ),
-      }));
+        // relative port locations in %
+        const relativePortLocation: { [key in Direction]: Point } = {
+          [Direction.Up]: new Point(0.5, 0),
+          [Direction.Right]: new Point(1, 0.5),
+          [Direction.Down]: new Point(0.5, 1),
+          [Direction.Left]: new Point(0, 0.5),
+        };
 
-      // use handle with min distance to connect to
-      const minDistance = Math.min(...distances.map((value) => value.distance));
-      const direction = distances.filter((value) => minDistance === value.distance)[0].key as Direction;
+        const ports = getPortsForElement(this.props.element);
+
+        // calculate the distances to all handles
+        const distances = Object.entries(ports).map(([key, value]) => ({
+          key,
+          distance: Math.sqrt(
+            Math.pow(relativePortLocation[key as Direction].x - relEventPosition.x, 2) +
+              Math.pow(relativePortLocation[key as Direction].y - relEventPosition.y, 2),
+          ),
+        }));
+
+        // use handle with min distance to connect to
+        const minDistance = Math.min(...distances.map((value) => value.distance));
+        direction = distances.filter((value) => minDistance === value.distance)[0].key as Direction;
+      }
 
       if (this.props.connecting) {
         this.props.connect({ element: this.props.id, direction });


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I wanted to address the Firefox problem #87 and made a fix for it.

### Description
<!-- Describe your changes in detail -->
We can use `PointerEvent.target` to get the element the user dragged the connection to.
If we drag the connection over the connectors on the side of an UML element, we can get the connectors direction attribute.
This fixes the problem in Firefox as well.

I inserted an if statement to check if the element we dragged the connection to has a direction attribute, if it does, use that, if it doesn't, use the old way.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Open up Apollon in Firefox and add two classes.
2. You can now connect them correctly if you use the connectors.