### PR TITLE
Setting drop info with grading instruction instead of instruction id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ls1intum/apollon",
-  "version": "2.7.1",
+  "version": "2.7.2-beta.0",
   "description": "A UML diagram editor.",
   "keywords": [],
   "homepage": "https://github.com/ls1intum/apollon#readme",

--- a/src/main/components/uml-element/assessable/assessable.tsx
+++ b/src/main/components/uml-element/assessable/assessable.tsx
@@ -154,7 +154,7 @@ export const assessable = (
         const { id: elementId, assessment } = this.props;
         const score = instruction.credits;
         const feedback = instruction.feedback;
-        const dropInfo = { instructionId: instruction.id };
+        const dropInfo = { instruction };
         this.props.assess(elementId, { ...assessment, score, feedback, dropInfo }, 'DROPPED');
         this.props.updateStart(elementId);
       }


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

We introduced `dropInfo` for the assessment object with this [PR](https://github.com/ls1intum/Apollon/pull/165). We only passed grading instruction for this property. After dropping the grading instruction into UML element feedback, we only know `instructionId` in Artemis side. This cause  a problem to calculate the total score in the client side. Because, grading instructions have `usage count`. since we only passes the `grading instruction id`, the `usage count` returns `undefined` during the calculation. My solution is setting the `dropInfo` with instruction itself. Then, Artemis can calculate the total score for all feedback elements properly. 

This PR will fix the [issue](https://github.com/ls1intum/Artemis/issues/3633) with additional [bugfix ](https://github.com/ls1intum/Artemis/pull/3708) on Artemis side.

