### PR TITLE
Fix package size issue

### DIFF
--- a/src/main/packages/common/uml-package/uml-package.ts
+++ b/src/main/packages/common/uml-package/uml-package.ts
@@ -5,7 +5,7 @@ import { computeBoundingBoxForElements, IBoundary } from '../../../utils/geometr
 import { Text } from '../../../utils/svg/text';
 
 export abstract class UMLPackage extends UMLContainer {
-  render(layer: ILayer, children: ILayoutable[] = [], noChildren?: boolean): ILayoutable[] {
+  render(layer: ILayer, children: ILayoutable[] = [], calculateWithoutChildren?: boolean): ILayoutable[] {
     const radix = 10;
     const nameBounds: IBoundary = {
       x: this.bounds.x,
@@ -20,7 +20,7 @@ export abstract class UMLPackage extends UMLContainer {
       return element;
     });
     let bounds = computeBoundingBoxForElements([this, { bounds: nameBounds }, ...absoluteElements]);
-    if (noChildren) {
+    if (calculateWithoutChildren) {
       bounds = computeBoundingBoxForElements([this, { bounds: nameBounds }]);
     }
     const relativeElements = absoluteElements.map((element) => {

--- a/src/main/packages/common/uml-package/uml-package.ts
+++ b/src/main/packages/common/uml-package/uml-package.ts
@@ -5,7 +5,7 @@ import { computeBoundingBoxForElements, IBoundary } from '../../../utils/geometr
 import { Text } from '../../../utils/svg/text';
 
 export abstract class UMLPackage extends UMLContainer {
-  render(layer: ILayer, children: ILayoutable[] = []): ILayoutable[] {
+  render(layer: ILayer, children: ILayoutable[] = [], noChildren?: boolean): ILayoutable[] {
     const radix = 10;
     const nameBounds: IBoundary = {
       x: this.bounds.x,
@@ -19,7 +19,10 @@ export abstract class UMLPackage extends UMLContainer {
       element.bounds.y += this.bounds.y;
       return element;
     });
-    const bounds = computeBoundingBoxForElements([this, { bounds: nameBounds }, ...absoluteElements]);
+    let bounds = computeBoundingBoxForElements([this, { bounds: nameBounds }, ...absoluteElements]);
+    if (noChildren) {
+      bounds = computeBoundingBoxForElements([this, { bounds: nameBounds }]);
+    }
     const relativeElements = absoluteElements.map((element) => {
       element.bounds.x -= this.bounds.x;
       element.bounds.y -= this.bounds.y;

--- a/src/main/scenes/svg.tsx
+++ b/src/main/scenes/svg.tsx
@@ -91,7 +91,7 @@ const getInitialState = ({ model, options }: Props): State => {
       [],
     );
 
-    const [root, ...updates] = element.render(layer, children) as UMLElement[];
+    const [root, ...updates] = element.render(layer, children, true) as UMLElement[];
     updates.map((x) => {
       const original = apollonChildren.find((y) => y.id === x.id);
       if (!original) {


### PR DESCRIPTION
### Description
When there are two container type elements like package, activity side by side, the size of the right one was getting bigger unnecessarily, this PR fixes this issue. 

### Steps for Testing
Create a model with two container type element with normal elements inside then export it.

### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/16825065/128213621-1d7595cf-0056-4298-ac1a-4bde2f292564.png)
#### After
![image](https://user-images.githubusercontent.com/16825065/128214585-e124ef74-d722-4e22-933f-9705ebcb37c1.png)


