### PR TITLE
`Development`: Add id's

### DIFF
--- a/src/main/components/assessment/assessment.tsx
+++ b/src/main/components/assessment/assessment.tsx
@@ -61,9 +61,6 @@ class AssessmentComponent extends Component<Props, State> {
   render() {
     const { elements } = this.state;
 
-    /*
-     * The id selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
-     */
     return (
       <div ref={this.container} id="modeling-assessment-container">
         {elements.map((element) => (

--- a/src/main/components/assessment/assessment.tsx
+++ b/src/main/components/assessment/assessment.tsx
@@ -62,8 +62,8 @@ class AssessmentComponent extends Component<Props, State> {
     const { elements } = this.state;
 
     /*
-    * The data-cy selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
-    */
+     * The data-cy selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
+     */
     return (
       <div ref={this.container} data-cy="modeling-assessment-container">
         {elements.map((element) => (

--- a/src/main/components/assessment/assessment.tsx
+++ b/src/main/components/assessment/assessment.tsx
@@ -65,7 +65,7 @@ class AssessmentComponent extends Component<Props, State> {
      * The data-cy selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
      */
     return (
-      <div ref={this.container} data-cy="modeling-assessment-container">
+      <div ref={this.container} id="modeling-assessment-container">
         {elements.map((element) => (
           <AssessmentSection key={element.id} element={element} />
         ))}

--- a/src/main/components/assessment/assessment.tsx
+++ b/src/main/components/assessment/assessment.tsx
@@ -62,7 +62,7 @@ class AssessmentComponent extends Component<Props, State> {
     const { elements } = this.state;
 
     /*
-     * The data-cy selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
+     * The id selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
      */
     return (
       <div ref={this.container} id="modeling-assessment-container">

--- a/src/main/components/assessment/assessment.tsx
+++ b/src/main/components/assessment/assessment.tsx
@@ -61,8 +61,11 @@ class AssessmentComponent extends Component<Props, State> {
   render() {
     const { elements } = this.state;
 
+    /*
+    * The data-cy selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
+    */
     return (
-      <div ref={this.container}>
+      <div ref={this.container} data-cy="modeling-assessment-container">
         {elements.map((element) => (
           <AssessmentSection key={element.id} element={element} />
         ))}

--- a/src/main/components/canvas/canvas.tsx
+++ b/src/main/components/canvas/canvas.tsx
@@ -52,11 +52,12 @@ export class CanvasComponent extends Component<Props> implements Omit<ILayer, 'l
     const { diagram, isStatic } = this.props;
 
     /*
-    * The data-cy selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
-    */
+     * The data-cy selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
+     */
     return (
       <Droppable>
-        <CanvasContainer data-cy="modeling-editor-canvas"
+        <CanvasContainer
+          data-cy="modeling-editor-canvas"
           width={diagram.bounds.width}
           height={diagram.bounds.height}
           isStatic={isStatic}

--- a/src/main/components/canvas/canvas.tsx
+++ b/src/main/components/canvas/canvas.tsx
@@ -51,9 +51,6 @@ export class CanvasComponent extends Component<Props> implements Omit<ILayer, 'l
   render() {
     const { diagram, isStatic } = this.props;
 
-    /*
-     * The id selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
-     */
     return (
       <Droppable>
         <CanvasContainer

--- a/src/main/components/canvas/canvas.tsx
+++ b/src/main/components/canvas/canvas.tsx
@@ -52,7 +52,7 @@ export class CanvasComponent extends Component<Props> implements Omit<ILayer, 'l
     const { diagram, isStatic } = this.props;
 
     /*
-     * The data-cy selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
+     * The id selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
      */
     return (
       <Droppable>

--- a/src/main/components/canvas/canvas.tsx
+++ b/src/main/components/canvas/canvas.tsx
@@ -57,7 +57,7 @@ export class CanvasComponent extends Component<Props> implements Omit<ILayer, 'l
     return (
       <Droppable>
         <CanvasContainer
-          data-cy="modeling-editor-canvas"
+          id="modeling-editor-canvas"
           width={diagram.bounds.width}
           height={diagram.bounds.height}
           isStatic={isStatic}

--- a/src/main/components/canvas/canvas.tsx
+++ b/src/main/components/canvas/canvas.tsx
@@ -51,9 +51,12 @@ export class CanvasComponent extends Component<Props> implements Omit<ILayer, 'l
   render() {
     const { diagram, isStatic } = this.props;
 
+    /*
+    * The data-cy selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
+    */
     return (
       <Droppable>
-        <CanvasContainer
+        <CanvasContainer data-cy="modeling-editor-canvas"
           width={diagram.bounds.width}
           height={diagram.bounds.height}
           isStatic={isStatic}

--- a/src/main/components/sidebar/sidebar-component.tsx
+++ b/src/main/components/sidebar/sidebar-component.tsx
@@ -46,8 +46,11 @@ class SidebarComponent extends Component<Props> {
   render() {
     if (this.props.readonly || this.props.mode === ApollonMode.Assessment) return null;
 
+    /*
+     * The data-cy selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
+     */
     return (
-      <Container scale={this.props.scale}>
+      <Container scale={this.props.scale} data-cy="modeling-editor-sidebar">
         {this.props.mode === ApollonMode.Exporting && (
           <Switch value={this.props.view} onChange={this.props.changeView} color="primary">
             <Switch.Item value={ApollonView.Modelling}>{this.props.translate('views.modelling')}</Switch.Item>

--- a/src/main/components/sidebar/sidebar-component.tsx
+++ b/src/main/components/sidebar/sidebar-component.tsx
@@ -47,7 +47,7 @@ class SidebarComponent extends Component<Props> {
     if (this.props.readonly || this.props.mode === ApollonMode.Assessment) return null;
 
     /*
-     * The data-cy selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
+     * The id selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
      */
     return (
       <Container scale={this.props.scale} id="modeling-editor-sidebar">

--- a/src/main/components/sidebar/sidebar-component.tsx
+++ b/src/main/components/sidebar/sidebar-component.tsx
@@ -45,6 +45,7 @@ const enhance = compose<ComponentClass<OwnProps>>(
 class SidebarComponent extends Component<Props> {
   render() {
     if (this.props.readonly || this.props.mode === ApollonMode.Assessment) return null;
+
     return (
       <Container scale={this.props.scale} id="modeling-editor-sidebar">
         {this.props.mode === ApollonMode.Exporting && (

--- a/src/main/components/sidebar/sidebar-component.tsx
+++ b/src/main/components/sidebar/sidebar-component.tsx
@@ -45,10 +45,6 @@ const enhance = compose<ComponentClass<OwnProps>>(
 class SidebarComponent extends Component<Props> {
   render() {
     if (this.props.readonly || this.props.mode === ApollonMode.Assessment) return null;
-
-    /*
-     * The id selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
-     */
     return (
       <Container scale={this.props.scale} id="modeling-editor-sidebar">
         {this.props.mode === ApollonMode.Exporting && (

--- a/src/main/components/sidebar/sidebar-component.tsx
+++ b/src/main/components/sidebar/sidebar-component.tsx
@@ -50,7 +50,7 @@ class SidebarComponent extends Component<Props> {
      * The data-cy selector is added for the github.com/ls1intum/Artemis cypress e2e tests to find the object more easily
      */
     return (
-      <Container scale={this.props.scale} data-cy="modeling-editor-sidebar">
+      <Container scale={this.props.scale} id="modeling-editor-sidebar">
         {this.props.mode === ApollonMode.Exporting && (
           <Switch value={this.props.view} onChange={this.props.changeView} color="primary">
             <Switch.Item value={ApollonView.Modelling}>{this.props.translate('views.modelling')}</Switch.Item>

--- a/src/tests/components/update-pane/__snapshots__/update-pane-test.tsx.snap
+++ b/src/tests/components/update-pane/__snapshots__/update-pane-test.tsx.snap
@@ -406,7 +406,7 @@ exports[`test update pane render with element 1`] = `
       >
         <svg
           class="c2"
-          data-cy="modeling-editor-canvas"
+          id="modeling-editor-canvas"
           height="640"
           tabindex="-1"
           width="840"
@@ -932,7 +932,7 @@ exports[`test update pane render with relationship 1`] = `
       >
         <svg
           class="c2"
-          data-cy="modeling-editor-canvas"
+          id="modeling-editor-canvas"
           height="640"
           tabindex="-1"
           width="840"

--- a/src/tests/components/update-pane/__snapshots__/update-pane-test.tsx.snap
+++ b/src/tests/components/update-pane/__snapshots__/update-pane-test.tsx.snap
@@ -406,8 +406,8 @@ exports[`test update pane render with element 1`] = `
       >
         <svg
           class="c2"
-          id="modeling-editor-canvas"
           height="640"
+          id="modeling-editor-canvas"
           tabindex="-1"
           width="840"
         />
@@ -932,8 +932,8 @@ exports[`test update pane render with relationship 1`] = `
       >
         <svg
           class="c2"
-          id="modeling-editor-canvas"
           height="640"
+          id="modeling-editor-canvas"
           tabindex="-1"
           width="840"
         />

--- a/src/tests/components/update-pane/__snapshots__/update-pane-test.tsx.snap
+++ b/src/tests/components/update-pane/__snapshots__/update-pane-test.tsx.snap
@@ -406,6 +406,7 @@ exports[`test update pane render with element 1`] = `
       >
         <svg
           class="c2"
+          data-cy="modeling-editor-canvas"
           height="640"
           tabindex="-1"
           width="840"
@@ -931,6 +932,7 @@ exports[`test update pane render with relationship 1`] = `
       >
         <svg
           class="c2"
+          data-cy="modeling-editor-canvas"
           height="640"
           tabindex="-1"
           width="840"


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? --> The https://github.com/ls1intum/Artemis cypress e2e tests are having a tough time finding good stable selectors for all of the Apollon components. To avoid having to use unstable selectors we want to add some now. 
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail --> The selectors i added are 
id="modeling-assessment-container"
id="modeling-editor-canvas"
id="modeling-editor-sidebar"

These idswill not affect the apollon editor at all but will help test the components functionality with cypress.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
You can try out the apollon editor and see that nothing has changed. Alternatively you can check the code and see that the ids are not selected at all by apollon code.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![Screenshot (13)](https://user-images.githubusercontent.com/56715566/142622552-d520735f-2f75-4ac8-a057-66e6540c6b0e.png)
![Screenshot (10)](https://user-images.githubusercontent.com/56715566/142622561-ac286a15-b6cd-4ca4-9fd8-1f6351321fd7.png)
![Screenshot (11)](https://user-images.githubusercontent.com/56715566/142622565-bb268d65-fff5-40a3-adc7-79ab8677f830.png)

