### PR TITLE
[BUGFIX #129] Fix position of label on Usecase and PetriNet Diagram

### DIFF
--- a/src/main/packages/uml-petri-net/uml-petri-net-arc/uml-petri-net-arc-component.tsx
+++ b/src/main/packages/uml-petri-net/uml-petri-net-arc/uml-petri-net-arc-component.tsx
@@ -34,6 +34,7 @@ export const UMLPetriNetArcComponent: SFC<Props> = ({ element }) => {
       />
       {displayMultiplicity && (
         <Text
+          dy="20px"
           noX
           noY
           fill={element.textColor}

--- a/src/main/packages/uml-use-case-diagram/uml-use-case-association/uml-use-case-association-component.tsx
+++ b/src/main/packages/uml-use-case-diagram/uml-use-case-association/uml-use-case-association-component.tsx
@@ -19,6 +19,7 @@ export const UMLUseCaseAssociationComponent: SFC<Props> = ({ element }) => {
     `}
       />
       <Text
+        dy="20px"
         noX
         noY
         fill={element.textColor}

--- a/src/tests/packages/uml-petri-diagram/uml-petri-net-arc/__snapshots__/uml-petri-net-arc-component-test.tsx.snap
+++ b/src/tests/packages/uml-petri-diagram/uml-petri-net-arc/__snapshots__/uml-petri-net-arc-component-test.tsx.snap
@@ -29,6 +29,7 @@ exports[`render the uml-petri-net-arc-component 1`] = `
         />
         <text
           dominant-baseline="middle"
+          dy="20px"
           font-weight="bold"
           pointer-events="none"
           text-anchor="middle"

--- a/src/tests/packages/uml-use-case-diagram/uml-use-case-association/__snapshots__/uml-use-case-association-component-test.tsx.snap
+++ b/src/tests/packages/uml-use-case-diagram/uml-use-case-association/__snapshots__/uml-use-case-association-component-test.tsx.snap
@@ -14,6 +14,7 @@ exports[`render the uml-use-case-association 1`] = `
         />
         <text
           dominant-baseline="middle"
+          dy="20px"
           font-weight="bold"
           pointer-events="none"
           text-anchor="middle"


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
Label of connectors of Usecase and PetriNet diagrams are now not overlapped by the line.
_Fix for issue https://github.com/ls1intum/Apollon/issues/129_

### Description
Added attribute dy on Text tag, that shifted labels by specified pixel, hence not causing it to overlap by connector. 

### Steps for Testing
See Screenshots

### Screenshots
**Before:**
<img width="328" alt="Screen Shot 2021-11-20 at 10 47 34 PM" src="https://user-images.githubusercontent.com/14681902/142742111-43780b1e-57d8-474a-b3b0-748c9d0f0126.png">

**After:**
<img width="461" alt="Screen Shot 2021-11-20 at 10 45 45 PM" src="https://user-images.githubusercontent.com/14681902/142742123-6703c54e-746f-4729-a668-2295ab20a8bf.png">

