### PR TITLE
Bugfix: Boundary of some elements cease to exist while resizing

### DIFF
--- a/src/main/packages/common/uml-package/uml-package.ts
+++ b/src/main/packages/common/uml-package/uml-package.ts
@@ -1,27 +1,21 @@
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
 import { UMLContainer } from '../../../services/uml-container/uml-container';
-import { computeBoundingBoxForElements, IBoundary } from '../../../utils/geometry/boundary';
-import { Text } from '../../../utils/svg/text';
+import { computeBoundingBoxForElements } from '../../../utils/geometry/boundary';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 
 export abstract class UMLPackage extends UMLContainer {
   render(layer: ILayer, children: ILayoutable[] = [], calculateWithoutChildren?: boolean): ILayoutable[] {
-    const radix = 10;
-    const nameBounds: IBoundary = {
-      x: this.bounds.x,
-      y: this.bounds.y,
-      width: Math.round((Text.size(layer, this.name, { fontWeight: 'bold' }).width + 20) / radix) * radix,
-      height: 20,
-    };
+    const calculatedNamedBounds = calculateNameBounds(this, layer);
 
     const absoluteElements = children.map((element) => {
       element.bounds.x += this.bounds.x;
       element.bounds.y += this.bounds.y;
       return element;
     });
-    let bounds = computeBoundingBoxForElements([this, { bounds: nameBounds }, ...absoluteElements]);
+    let bounds = computeBoundingBoxForElements([{ bounds: calculatedNamedBounds }, ...absoluteElements]);
     if (calculateWithoutChildren) {
-      bounds = computeBoundingBoxForElements([this, { bounds: nameBounds }]);
+      bounds = calculatedNamedBounds;
     }
     const relativeElements = absoluteElements.map((element) => {
       element.bounds.x -= this.bounds.x;

--- a/src/main/packages/flowchart/flowchart-decision/flowchart-decision.tsx
+++ b/src/main/packages/flowchart/flowchart-decision/flowchart-decision.tsx
@@ -9,8 +9,7 @@ export class FlowchartDecision extends UMLElement {
   type: UMLElementType = FlowchartElementType.FlowchartDecision;
 
   render(canvas: ILayer): ILayoutable[] {
-    const namedBounds = calculateNameBounds(this, canvas);
-    this.bounds = namedBounds;
+    this.bounds = calculateNameBounds(this, canvas);
     return [this];
   }
 }

--- a/src/main/packages/flowchart/flowchart-decision/flowchart-decision.tsx
+++ b/src/main/packages/flowchart/flowchart-decision/flowchart-decision.tsx
@@ -2,12 +2,15 @@ import { FlowchartElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
 import { UMLElement } from '../../../services/uml-element/uml-element';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
 
 export class FlowchartDecision extends UMLElement {
   type: UMLElementType = FlowchartElementType.FlowchartDecision;
 
   render(canvas: ILayer): ILayoutable[] {
+    const namedBounds = calculateNameBounds(this, canvas);
+    this.bounds = namedBounds;
     return [this];
   }
 }

--- a/src/main/packages/flowchart/flowchart-function-call/flowchart-function-call.tsx
+++ b/src/main/packages/flowchart/flowchart-function-call/flowchart-function-call.tsx
@@ -9,8 +9,7 @@ export class FlowchartFunctionCall extends UMLElement {
   type: UMLElementType = FlowchartElementType.FlowchartFunctionCall;
 
   render(canvas: ILayer): ILayoutable[] {
-    const namedBounds = calculateNameBounds(this, canvas);
-    this.bounds = namedBounds;
+    this.bounds = calculateNameBounds(this, canvas);
     return [this];
   }
 }

--- a/src/main/packages/flowchart/flowchart-function-call/flowchart-function-call.tsx
+++ b/src/main/packages/flowchart/flowchart-function-call/flowchart-function-call.tsx
@@ -2,12 +2,15 @@ import { FlowchartElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
 import { UMLElement } from '../../../services/uml-element/uml-element';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
 
 export class FlowchartFunctionCall extends UMLElement {
   type: UMLElementType = FlowchartElementType.FlowchartFunctionCall;
 
   render(canvas: ILayer): ILayoutable[] {
+    const namedBounds = calculateNameBounds(this, canvas);
+    this.bounds = namedBounds;
     return [this];
   }
 }

--- a/src/main/packages/flowchart/flowchart-input-output/flowchart-input-output.tsx
+++ b/src/main/packages/flowchart/flowchart-input-output/flowchart-input-output.tsx
@@ -9,8 +9,7 @@ export class FlowchartInputOutput extends UMLElement {
   type: UMLElementType = FlowchartElementType.FlowchartInputOutput;
 
   render(canvas: ILayer): ILayoutable[] {
-    const namedBounds = calculateNameBounds(this, canvas);
-    this.bounds = namedBounds;
+    this.bounds = calculateNameBounds(this, canvas);
     return [this];
   }
 }

--- a/src/main/packages/flowchart/flowchart-input-output/flowchart-input-output.tsx
+++ b/src/main/packages/flowchart/flowchart-input-output/flowchart-input-output.tsx
@@ -2,12 +2,15 @@ import { FlowchartElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
 import { UMLElement } from '../../../services/uml-element/uml-element';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
 
 export class FlowchartInputOutput extends UMLElement {
   type: UMLElementType = FlowchartElementType.FlowchartInputOutput;
 
   render(canvas: ILayer): ILayoutable[] {
+    const namedBounds = calculateNameBounds(this, canvas);
+    this.bounds = namedBounds;
     return [this];
   }
 }

--- a/src/main/packages/flowchart/flowchart-process/flowchart-process.tsx
+++ b/src/main/packages/flowchart/flowchart-process/flowchart-process.tsx
@@ -9,8 +9,7 @@ export class FlowchartProcess extends UMLElement {
   type: UMLElementType = FlowchartElementType.FlowchartProcess;
 
   render(canvas: ILayer): ILayoutable[] {
-    const namedBounds = calculateNameBounds(this, canvas);
-    this.bounds = namedBounds;
+    this.bounds = calculateNameBounds(this, canvas);
     return [this];
   }
 }

--- a/src/main/packages/flowchart/flowchart-process/flowchart-process.tsx
+++ b/src/main/packages/flowchart/flowchart-process/flowchart-process.tsx
@@ -2,12 +2,15 @@ import { FlowchartElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
 import { UMLElement } from '../../../services/uml-element/uml-element';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
 
 export class FlowchartProcess extends UMLElement {
   type: UMLElementType = FlowchartElementType.FlowchartProcess;
 
   render(canvas: ILayer): ILayoutable[] {
+    const namedBounds = calculateNameBounds(this, canvas);
+    this.bounds = namedBounds;
     return [this];
   }
 }

--- a/src/main/packages/flowchart/flowchart-terminal/flowchart-terminal.tsx
+++ b/src/main/packages/flowchart/flowchart-terminal/flowchart-terminal.tsx
@@ -2,12 +2,15 @@ import { FlowchartElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
 import { UMLElement } from '../../../services/uml-element/uml-element';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
 
 export class FlowchartTerminal extends UMLElement {
   type: UMLElementType = FlowchartElementType.FlowchartTerminal;
 
   render(canvas: ILayer): ILayoutable[] {
+    const namedBounds = calculateNameBounds(this, canvas);
+    this.bounds = namedBounds;
     return [this];
   }
 }

--- a/src/main/packages/flowchart/flowchart-terminal/flowchart-terminal.tsx
+++ b/src/main/packages/flowchart/flowchart-terminal/flowchart-terminal.tsx
@@ -9,8 +9,7 @@ export class FlowchartTerminal extends UMLElement {
   type: UMLElementType = FlowchartElementType.FlowchartTerminal;
 
   render(canvas: ILayer): ILayoutable[] {
-    const namedBounds = calculateNameBounds(this, canvas);
-    this.bounds = namedBounds;
+    this.bounds = calculateNameBounds(this, canvas);
     return [this];
   }
 }

--- a/src/main/packages/syntax-tree/syntax-tree-nonterminal/syntax-tree-nonterminal.ts
+++ b/src/main/packages/syntax-tree/syntax-tree-nonterminal/syntax-tree-nonterminal.ts
@@ -2,12 +2,15 @@ import { SyntaxTreeElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
 import { UMLElement } from '../../../services/uml-element/uml-element';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
 
 export class SyntaxTreeNonterminal extends UMLElement {
   type: UMLElementType = SyntaxTreeElementType.SyntaxTreeNonterminal;
 
   render(canvas: ILayer): ILayoutable[] {
+    const namedBounds = calculateNameBounds(this, canvas);
+    this.bounds = namedBounds;
     return [this];
   }
 }

--- a/src/main/packages/syntax-tree/syntax-tree-nonterminal/syntax-tree-nonterminal.ts
+++ b/src/main/packages/syntax-tree/syntax-tree-nonterminal/syntax-tree-nonterminal.ts
@@ -9,8 +9,7 @@ export class SyntaxTreeNonterminal extends UMLElement {
   type: UMLElementType = SyntaxTreeElementType.SyntaxTreeNonterminal;
 
   render(canvas: ILayer): ILayoutable[] {
-    const namedBounds = calculateNameBounds(this, canvas);
-    this.bounds = namedBounds;
+    this.bounds = calculateNameBounds(this, canvas);
     return [this];
   }
 }

--- a/src/main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal.ts
+++ b/src/main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal.ts
@@ -2,12 +2,15 @@ import { SyntaxTreeElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
 import { UMLElement } from '../../../services/uml-element/uml-element';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
 
 export class SyntaxTreeTerminal extends UMLElement {
   type: UMLElementType = SyntaxTreeElementType.SyntaxTreeTerminal;
 
   render(canvas: ILayer): ILayoutable[] {
+    const namedBounds = calculateNameBounds(this, canvas);
+    this.bounds = namedBounds;
     return [this];
   }
 }

--- a/src/main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal.ts
+++ b/src/main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal.ts
@@ -9,8 +9,7 @@ export class SyntaxTreeTerminal extends UMLElement {
   type: UMLElementType = SyntaxTreeElementType.SyntaxTreeTerminal;
 
   render(canvas: ILayer): ILayoutable[] {
-    const namedBounds = calculateNameBounds(this, canvas);
-    this.bounds = namedBounds;
+    this.bounds = calculateNameBounds(this, canvas);
     return [this];
   }
 }

--- a/src/main/packages/uml-activity-diagram/uml-activity-action-node/uml-activity-action-node.ts
+++ b/src/main/packages/uml-activity-diagram/uml-activity-action-node/uml-activity-action-node.ts
@@ -10,8 +10,7 @@ export class UMLActivityActionNode extends UMLElement {
   type: UMLElementType = ActivityElementType.ActivityActionNode;
 
   render(canvas: ILayer): ILayoutable[] {
-    const namedBounds = calculateNameBounds(this, canvas);
-    this.bounds = namedBounds;
+    this.bounds = calculateNameBounds(this, canvas);
     return [this];
   }
 }

--- a/src/main/packages/uml-activity-diagram/uml-activity-action-node/uml-activity-action-node.ts
+++ b/src/main/packages/uml-activity-diagram/uml-activity-action-node/uml-activity-action-node.ts
@@ -2,6 +2,7 @@ import { ActivityElementType, ActivityRelationshipType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
 import { UMLElement } from '../../../services/uml-element/uml-element';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
 
 export class UMLActivityActionNode extends UMLElement {
@@ -9,6 +10,8 @@ export class UMLActivityActionNode extends UMLElement {
   type: UMLElementType = ActivityElementType.ActivityActionNode;
 
   render(canvas: ILayer): ILayoutable[] {
+    const namedBounds = calculateNameBounds(this, canvas);
+    this.bounds = namedBounds;
     return [this];
   }
 }

--- a/src/main/packages/uml-activity-diagram/uml-activity-merge-node/uml-activity-merge-node.ts
+++ b/src/main/packages/uml-activity-diagram/uml-activity-merge-node/uml-activity-merge-node.ts
@@ -3,6 +3,7 @@ import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
 import { UMLElement } from '../../../services/uml-element/uml-element';
 import { IBoundary } from '../../../utils/geometry/boundary';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
 
 export class UMLActivityMergeNode extends UMLElement {
@@ -12,6 +13,8 @@ export class UMLActivityMergeNode extends UMLElement {
   bounds: IBoundary = { ...this.bounds };
 
   render(canvas: ILayer): ILayoutable[] {
+    const namedBounds = calculateNameBounds(this, canvas);
+    this.bounds = namedBounds;
     return [this];
   }
 }

--- a/src/main/packages/uml-activity-diagram/uml-activity-merge-node/uml-activity-merge-node.ts
+++ b/src/main/packages/uml-activity-diagram/uml-activity-merge-node/uml-activity-merge-node.ts
@@ -13,8 +13,7 @@ export class UMLActivityMergeNode extends UMLElement {
   bounds: IBoundary = { ...this.bounds };
 
   render(canvas: ILayer): ILayoutable[] {
-    const namedBounds = calculateNameBounds(this, canvas);
-    this.bounds = namedBounds;
+    this.bounds = calculateNameBounds(this, canvas);
     return [this];
   }
 }

--- a/src/main/packages/uml-activity-diagram/uml-activity-object-node/uml-activity-object-node.ts
+++ b/src/main/packages/uml-activity-diagram/uml-activity-object-node/uml-activity-object-node.ts
@@ -11,8 +11,7 @@ export class UMLActivityObjectNode extends UMLElement {
   type: UMLElementType = ActivityElementType.ActivityObjectNode;
 
   render(canvas: ILayer): ILayoutable[] {
-    const namedBounds = calculateNameBounds(this, canvas);
-    this.bounds = namedBounds;
+    this.bounds = calculateNameBounds(this, canvas);
     return [this];
   }
 }

--- a/src/main/packages/uml-activity-diagram/uml-activity-object-node/uml-activity-object-node.ts
+++ b/src/main/packages/uml-activity-diagram/uml-activity-object-node/uml-activity-object-node.ts
@@ -2,6 +2,7 @@ import { ActivityElementType, ActivityRelationshipType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
 import { UMLElement } from '../../../services/uml-element/uml-element';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
 
 export class UMLActivityObjectNode extends UMLElement {
@@ -10,6 +11,8 @@ export class UMLActivityObjectNode extends UMLElement {
   type: UMLElementType = ActivityElementType.ActivityObjectNode;
 
   render(canvas: ILayer): ILayoutable[] {
+    const namedBounds = calculateNameBounds(this, canvas);
+    this.bounds = namedBounds;
     return [this];
   }
 }

--- a/src/main/packages/uml-deployment-diagram/uml-deployment-artifact/uml-deployment-artifact.ts
+++ b/src/main/packages/uml-deployment-diagram/uml-deployment-artifact/uml-deployment-artifact.ts
@@ -26,8 +26,7 @@ export class UMLDeploymentArtifact extends UMLElement {
 
   render(layer: ILayer): ILayoutable[] {
     this.bounds.height = Math.max(this.bounds.height, 40);
-    const namedBounds = calculateNameBounds(this, layer);
-    this.bounds = namedBounds;
+    this.bounds = calculateNameBounds(this, layer);
     return [this];
   }
 }

--- a/src/main/packages/uml-deployment-diagram/uml-deployment-artifact/uml-deployment-artifact.ts
+++ b/src/main/packages/uml-deployment-diagram/uml-deployment-artifact/uml-deployment-artifact.ts
@@ -5,6 +5,7 @@ import { ILayoutable } from '../../../services/layouter/layoutable';
 import { IUMLElement, UMLElement } from '../../../services/uml-element/uml-element';
 import { assign } from '../../../utils/fx/assign';
 import { IBoundary } from '../../../utils/geometry/boundary';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
 
 export class UMLDeploymentArtifact extends UMLElement {
@@ -25,6 +26,8 @@ export class UMLDeploymentArtifact extends UMLElement {
 
   render(layer: ILayer): ILayoutable[] {
     this.bounds.height = Math.max(this.bounds.height, 40);
+    const namedBounds = calculateNameBounds(this, layer);
+    this.bounds = namedBounds;
     return [this];
   }
 }

--- a/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking.ts
+++ b/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking.ts
@@ -36,8 +36,7 @@ export class UMLReachabilityGraphMarking extends UMLElement {
   }
 
   render(canvas: ILayer): ILayoutable[] {
-    const namedBounds = calculateNameBounds(this, canvas);
-    this.bounds = namedBounds;
+    this.bounds = calculateNameBounds(this, canvas);
     return [this];
   }
 }

--- a/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking.ts
+++ b/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking.ts
@@ -5,6 +5,7 @@ import { UMLElementType } from '../../uml-element-type';
 import * as Apollon from '../../../typings';
 import { ReachabilityGraphElementType } from '..';
 import { DeepPartial } from 'redux';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 
 export class UMLReachabilityGraphMarking extends UMLElement {
   type: UMLElementType = ReachabilityGraphElementType.ReachabilityGraphMarking;
@@ -35,6 +36,8 @@ export class UMLReachabilityGraphMarking extends UMLElement {
   }
 
   render(canvas: ILayer): ILayoutable[] {
+    const namedBounds = calculateNameBounds(this, canvas);
+    this.bounds = namedBounds;
     return [this];
   }
 }

--- a/src/main/packages/uml-use-case-diagram/uml-use-case/uml-use-case.ts
+++ b/src/main/packages/uml-use-case-diagram/uml-use-case/uml-use-case.ts
@@ -9,8 +9,7 @@ export class UMLUseCase extends UMLElement {
   type: UMLElementType = UseCaseElementType.UseCase;
 
   render(canvas: ILayer): ILayoutable[] {
-    const namedBounds = calculateNameBounds(this, canvas);
-    this.bounds = namedBounds;
+    this.bounds = calculateNameBounds(this, canvas);
     return [this];
   }
 }

--- a/src/main/packages/uml-use-case-diagram/uml-use-case/uml-use-case.ts
+++ b/src/main/packages/uml-use-case-diagram/uml-use-case/uml-use-case.ts
@@ -2,12 +2,15 @@ import { UseCaseElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
 import { UMLElement } from '../../../services/uml-element/uml-element';
+import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
 
 export class UMLUseCase extends UMLElement {
   type: UMLElementType = UseCaseElementType.UseCase;
 
   render(canvas: ILayer): ILayoutable[] {
+    const namedBounds = calculateNameBounds(this, canvas);
+    this.bounds = namedBounds;
     return [this];
   }
 }

--- a/src/main/utils/name-bounds.ts
+++ b/src/main/utils/name-bounds.ts
@@ -1,0 +1,16 @@
+import { ILayer } from '../services/layouter/layer';
+import { IBoundary, computeBoundingBoxForElements } from '../utils/geometry/boundary';
+import { Text } from '../utils/svg/text';
+
+export function calculateNameBounds(element: any, layer: ILayer) {
+  const radix = 10;
+
+  const nameBounds: IBoundary = {
+    x: element.bounds.x,
+    y: element.bounds.y,
+    width: Math.round((Text.size(layer, element.name, { fontWeight: 'bold' }).width + 20) / radix) * radix,
+    height: 20,
+  };
+
+  return computeBoundingBoxForElements([element, { bounds: nameBounds }]);
+}

--- a/src/main/utils/name-bounds.ts
+++ b/src/main/utils/name-bounds.ts
@@ -9,7 +9,7 @@ export function calculateNameBounds(element: any, layer: ILayer): IBoundary {
     x: element.bounds.x,
     y: element.bounds.y,
     width: Math.round((Text.size(layer, element.name, { fontWeight: 'bold' }).width + 20) / radix) * radix,
-    height: 20,
+    height: Math.round((Text.size(layer, element.name, { fontWeight: 'bold' }).height + 20) / radix) * radix,
   };
 
   return computeBoundingBoxForElements([element, { bounds: nameBounds }]);

--- a/src/main/utils/name-bounds.ts
+++ b/src/main/utils/name-bounds.ts
@@ -2,7 +2,7 @@ import { ILayer } from '../services/layouter/layer';
 import { IBoundary, computeBoundingBoxForElements } from '../utils/geometry/boundary';
 import { Text } from '../utils/svg/text';
 
-export function calculateNameBounds(element: any, layer: ILayer) {
+export function calculateNameBounds(element: any, layer: ILayer): IBoundary {
   const radix = 10;
 
   const nameBounds: IBoundary = {


### PR DESCRIPTION
…ments

### Checklist
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
To specify the named bounds so that the issue with vanishing element boundary, while resizing is resolved.
Issue Number: https://github.com/ls1intum/Apollon/issues/208

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
1. Open Apollon
2. Select Activity Diagram from Diagram Type
3. Drag Activity Action node to the canvas and start reducing its width/height
4. Observe that the element now no longer vanishes while its side is reduced as it used to (see: https://github.com/ls1intum/Apollon/issues/208 ).

### Screenshots
![screen-capture-_7_](https://user-images.githubusercontent.com/14681902/159334230-b114c927-c4af-4a21-ac04-b3cf63bfefae.gif)

