### PR TITLE
``Development``: Fix issue with Associations in UML Diagram (Dark Mode)

### DIFF
--- a/src/main/packages/common/uml-association/uml-association-component.tsx
+++ b/src/main/packages/common/uml-association/uml-association-component.tsx
@@ -37,7 +37,7 @@ const Marker = {
       orient="auto"
       markerUnits="strokeWidth"
     >
-      <ThemedPath d="M0,15 L15,22 L30,15 L15,8 z" fillColor="white" strokeColor={color} />
+      <ThemedPath d="M0,15 L15,22 L30,15 L15,8 z" fillColor={color} strokeColor={color} />
     </marker>
   ),
   RhombusFilled: (id: string, color?: string, scale: number = 1.0) => (


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
This PR fixes the issue with the color of associations in dark/light mode of Apollon. Composition Association is now displayed correctly.
Issue Number: https://github.com/ls1intum/Apollon/issues/225


### Steps for Testing
1. Make a composition association and aggregation association
2. Switch to dark/light mode
3. See the corrected form

### Screenshots
Light Mode:
![image](https://user-images.githubusercontent.com/14681902/167271385-a2d5949e-f0b6-4ed1-b658-4c3f90ab1ba8.png)
Dark Mode: 
![image](https://user-images.githubusercontent.com/14681902/167271394-d3ded9fe-af34-417f-9ae1-0825ba890c03.png)

