### PR TITLE
fix: ThemedLine in dark mode

### DIFF
--- a/src/main/components/theme/themedComponents.ts
+++ b/src/main/components/theme/themedComponents.ts
@@ -96,11 +96,9 @@ export const ThemedEllipse = styled.ellipse.attrs(
   stroke: ${(props) => props.strokeColor || props.theme.color.primaryContrast};
 `;
 
-export const ThemedLine = styled.line.attrs(
-  (props: { strokeColor: string | undefined }) => ({
-    strokeColor: props.strokeColor,
-    stroke: props.strokeColor || 'black',
-  }),
-)`
+export const ThemedLine = styled.line.attrs((props: { strokeColor: string | undefined }) => ({
+  strokeColor: props.strokeColor,
+  stroke: props.strokeColor || 'black',
+}))`
   stroke: ${(props) => props.strokeColor || props.theme.color.primaryContrast};
 `;

--- a/src/main/components/theme/themedComponents.ts
+++ b/src/main/components/theme/themedComponents.ts
@@ -96,8 +96,11 @@ export const ThemedEllipse = styled.ellipse.attrs(
   stroke: ${(props) => props.strokeColor || props.theme.color.primaryContrast};
 `;
 
-export const ThemedLine = styled.line.attrs((props: { strokeColor: string | undefined }) => ({
-  strokeColor: props.strokeColor || 'black',
-}))`
+export const ThemedLine = styled.line.attrs(
+  (props: { strokeColor: string | undefined }) => ({
+    strokeColor: props.strokeColor,
+    stroke: props.strokeColor || 'black',
+  }),
+)`
   stroke: ${(props) => props.strokeColor || props.theme.color.primaryContrast};
 `;

--- a/src/tests/packages/uml-use-case-diagram/uml-use-case-actor/__snapshots__/uml-use-case-actor-component-test.tsx.snap
+++ b/src/tests/packages/uml-use-case-diagram/uml-use-case-actor/__snapshots__/uml-use-case-actor-component-test.tsx.snap
@@ -23,28 +23,32 @@ exports[`render the uml-use-case-actor-component 1`] = `
             stroke="black"
           />
           <line
-            class="sc-furwcr cvegVF"
+            class="sc-furwcr TUFlT"
+            stroke="black"
             x1="45"
             x2="45"
             y1="40"
             y2="80"
           />
           <line
-            class="sc-furwcr cvegVF"
+            class="sc-furwcr TUFlT"
+            stroke="black"
             x1="15"
             x2="75"
             y1="55"
             y2="55"
           />
           <line
-            class="sc-furwcr cvegVF"
+            class="sc-furwcr TUFlT"
+            stroke="black"
             x1="45"
             x2="15"
             y1="80"
             y2="110"
           />
           <line
-            class="sc-furwcr cvegVF"
+            class="sc-furwcr TUFlT"
+            stroke="black"
             x1="45"
             x2="75"
             y1="80"


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

This fixes the stroke Color of the ThemedLine, which didn't change color in the newly introduced dark mode.
In the context of the Component Actor in the Use Case Diagram the change looks like this:

Before:
<img width="102" alt="Screenshot 2022-05-08 at 12 06 15" src="https://user-images.githubusercontent.com/43829743/167291386-cd4f0a6b-df32-43dc-b03e-11f51fc773b1.png">


After:
<img width="100" alt="Screenshot 2022-05-08 at 12 02 31" src="https://user-images.githubusercontent.com/43829743/167291332-5faa74c2-09d9-4c91-bbfa-61e98f8e9593.png">

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Darkmode is great, but only if it looks right.

### Description
<!-- Describe your changes in detail -->
Changed the props `strokeColor` and `stroke` to match the ThemedCircle, which already had the right colors.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Open the use case diagram and see the changes :)

