### PR TITLE
``Development``: Fix issue with darkmode adaptation of Standalone elements

### DIFF
--- a/src/main/components/create-pane/create-pane-styles.ts
+++ b/src/main/components/create-pane/create-pane-styles.ts
@@ -5,5 +5,5 @@ export const Separator = styled.div`
   text-align: center;
   margin: 1rem 0;
   height: 2px;
-  background-color: black;
+  background-color: ${(props) => props.theme.color.primaryContrast};
 `;

--- a/src/main/components/style-pane/color-selector.tsx
+++ b/src/main/components/style-pane/color-selector.tsx
@@ -23,9 +23,9 @@ const ColorContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  background-color: white;
+  background-color: ${(props) => props.theme.color.background};
   width: 100%;
-  margin-bottom: 10px;
+  padding-bottom: 10px;
 `;
 
 const Flex = styled.div`

--- a/src/main/components/style-pane/style-pane-styles.ts
+++ b/src/main/components/style-pane/style-pane-styles.ts
@@ -11,7 +11,7 @@ export const Container = styled.div`
   align-items: center;
   margin: 10px 0;
   background-color: white;
-  border: 1px solid lightgray;
+  border: 1px solid ${(props) => props.theme.color.gray};
 `;
 
 export const Color = styled.button.attrs<Props>({})<Props>`
@@ -27,7 +27,7 @@ export const Color = styled.button.attrs<Props>({})<Props>`
     content: '';
     width: 2px;
     height: 100%;
-    background: black;
+    background: ${(props) => props.theme.color.primaryContrast};
     position: absolute;
     top: 0;
     left: 50%;
@@ -46,6 +46,8 @@ export const Row = styled.div`
   padding: 16px;
   /* border-bottom: 1px solid #353d47; */
   font-weight: bold;
+  background-color: ${(props) => props.theme.color.background};
+  color: ${(props) => props.theme.color.primaryContrast};
   &:last-of-type {
     border-bottom: none;
   }
@@ -53,7 +55,7 @@ export const Row = styled.div`
 
 export const Divider = styled.div`
   width: 100%;
-  background: #353d47;
+  background: ${(props) => props.theme.color.backgroundVariant};
   height: 1px;
 `;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes


### Motivation and Context
Color selector and elements separators of Apollon were not adapted for dark mode.

### Description
This PR fixes the issue with an adaptation of dark mode in the Color selector and elements separator of Apollon.

### Screenshots
**1. Separator (Before)**
![image](https://user-images.githubusercontent.com/14681902/172685517-b949267c-f443-47ca-af5b-3a8f0dbc857e.png)
**2. Separator (After)**
![image](https://user-images.githubusercontent.com/14681902/172685808-3bc4ce41-5f71-4ebf-8a42-07b176a17637.png)
**3. Color Selector (Before)**
![image](https://user-images.githubusercontent.com/14681902/172689385-55305b26-68f1-49eb-89da-843229fbeed0.png)
**4. Color Selector (After)**
![image](https://user-images.githubusercontent.com/14681902/172689305-67f90269-38d4-4569-87bf-9e4ef3e1e617.png)

