### PR TITLE
`Collaboration`: Highlight user interacting elements in real time collaboration

### DIFF
--- a/docs/source/user/api/typings.d.ts
+++ b/docs/source/user/api/typings.d.ts
@@ -1,6 +1,7 @@
 import { DeepPartial } from 'redux';
 import { Styles } from './components/theme/styles';
 import { UMLDiagramType } from './packages/diagram-type';
+import { UMLElementSelectorType } from './packages/uml-element-selector-type';
 import { UMLElementType } from './packages/uml-element-type';
 import { UMLRelationshipType } from './packages/uml-relationship-type';
 import { ApollonMode, Locale } from './services/editor/editor-types';
@@ -49,6 +50,7 @@ export declare type UMLModelElement = {
     strokeColor?: string;
     textColor?: string;
     assessmentNote?: string;
+    selectedBy?: UMLElementSelectorType;
 };
 export declare type UMLElement = UMLModelElement & {
     type: UMLElementType;

--- a/docs/source/user/api/typings.d.ts
+++ b/docs/source/user/api/typings.d.ts
@@ -50,7 +50,7 @@ export declare type UMLModelElement = {
     strokeColor?: string;
     textColor?: string;
     assessmentNote?: string;
-    selectedBy?: UMLElementSelectorType;
+    selectedBy?: UMLElementSelectorType[];
 };
 export declare type UMLElement = UMLModelElement & {
     type: UMLElementType;

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -78,6 +78,7 @@ class CanvasElementComponent extends Component<Props> {
         ? element.fillColor
         : 'white';
 
+    const selectedBy = element.selectedBy;
     return (
       <svg
         {...props}
@@ -98,6 +99,19 @@ class CanvasElementComponent extends Component<Props> {
             height={element.bounds.height + STROKE}
             fill="none"
             stroke="#0064ff"
+            strokeOpacity="0.2"
+            strokeWidth={STROKE}
+            pointerEvents="none"
+          />
+        )}
+        {selectedBy && (
+          <rect
+            x={-STROKE / 2}
+            y={-STROKE / 2}
+            width={element.bounds.width + STROKE}
+            height={element.bounds.height + STROKE}
+            fill="none"
+            stroke="#232323"
             strokeOpacity="0.2"
             strokeWidth={STROKE}
             pointerEvents="none"

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -105,17 +105,28 @@ class CanvasElementComponent extends Component<Props> {
           />
         )}
         {selectedBy && (
-          <rect
-            x={-STROKE / 2}
-            y={-STROKE / 2}
-            width={element.bounds.width + STROKE}
-            height={element.bounds.height + STROKE}
-            fill="none"
-            stroke="#232323"
-            strokeOpacity="0.2"
-            strokeWidth={STROKE}
-            pointerEvents="none"
-          />
+          <>
+            <rect
+              x={-STROKE / 2}
+              y={-STROKE / 2}
+              width={element.bounds.width + STROKE}
+              height={element.bounds.height + STROKE}
+              fill="none"
+              stroke={selectedBy.color}
+              strokeOpacity="0.2"
+              strokeWidth={STROKE}
+              pointerEvents="none"
+            />
+
+            <g transform="translate(195 0)" pointer-events="none">
+              <circle r="16" fill-opacity="0.8" fill={selectedBy.color}></circle>
+              <text y="5">
+                <tspan text-anchor="middle">{selectedBy.name}</tspan>
+              </text>
+            </g>
+
+          </>
+
         )}
       </svg>
     );

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -133,7 +133,7 @@ class CanvasElementComponent extends Component<Props> {
                       y="5"
                     >
                       <tspan textAnchor="middle">
-                        {selectedBy.name.length < 7 ? selectedBy.name : selectedBy.name.substring(0, 7) + '..'}
+                        {selectedBy.name.length < 8 ? selectedBy.name : selectedBy.name.substring(0, 6) + '..'}
                       </tspan>
                     </text>
                   </g>

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -105,13 +105,12 @@ class CanvasElementComponent extends Component<Props> {
           />
         )}
         {selectedByList.length > 0 && (
-          <>
+          <g>
             {selectedByList.map((selectedBy, index) => {
               const indicatorPosition = 'translate(' + (element.bounds.width + STROKE) + ' ' + index * 32 + ')';
               return (
-                <>
+                <g id={selectedBy.name + '_' + selectedBy.color}>
                   <rect
-                    className={selectedBy.name + '_' + selectedBy.color}
                     x={-STROKE / 2}
                     y={-STROKE / 2}
                     width={element.bounds.width + STROKE}
@@ -125,7 +124,6 @@ class CanvasElementComponent extends Component<Props> {
 
                   <g transform={indicatorPosition} pointerEvents="none">
                     <text
-                      className={selectedBy.name + '_' + selectedBy.color}
                       fillOpacity="0.8"
                       stroke={selectedBy.color}
                       strokeWidth="0.5em"
@@ -139,10 +137,10 @@ class CanvasElementComponent extends Component<Props> {
                       </tspan>
                     </text>
                   </g>
-                </>
+                </g>
               );
             })}
-          </>
+          </g>
         )}
       </svg>
     );

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -111,7 +111,7 @@ class CanvasElementComponent extends Component<Props> {
               return (
                 <>
                   <rect
-                    className={selectedBy.name+'_'+selectedBy.color}
+                    className={selectedBy.name + '_' + selectedBy.color}
                     x={-STROKE / 2}
                     y={-STROKE / 2}
                     width={element.bounds.width + STROKE}
@@ -125,7 +125,7 @@ class CanvasElementComponent extends Component<Props> {
 
                   <g transform={indicatorPosition} pointerEvents="none">
                     <text
-                      className={selectedBy.name+'_'+selectedBy.color}
+                      className={selectedBy.name + '_' + selectedBy.color}
                       fillOpacity="0.8"
                       stroke={selectedBy.color}
                       strokeWidth="0.5em"

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -118,10 +118,10 @@ class CanvasElementComponent extends Component<Props> {
               pointerEvents="none"
             />
 
-            <g transform="translate(195 0)" pointer-events="none">
-              <circle r="16" fill-opacity="0.8" fill={selectedBy.color} />
+            <g transform="translate(195 0)" pointerEvents="none">
+              <circle r="16" fillOpacity="0.8" fill={selectedBy.color} />
               <text y="5">
-                <tspan text-anchor="middle">{selectedBy.name}</tspan>
+                <tspan textAnchor="middle">{selectedBy.name}</tspan>
               </text>
             </g>
           </>

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -104,7 +104,7 @@ class CanvasElementComponent extends Component<Props> {
             pointerEvents="none"
           />
         )}
-        {selectedBy && (
+        {selectedBy && !(hovered || selected) && (
           <>
             <rect
               x={-STROKE / 2}
@@ -124,9 +124,7 @@ class CanvasElementComponent extends Component<Props> {
                 <tspan text-anchor="middle">{selectedBy.name}</tspan>
               </text>
             </g>
-
           </>
-
         )}
       </svg>
     );

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -123,9 +123,18 @@ class CanvasElementComponent extends Component<Props> {
                   />
 
                   <g transform={indicatorPosition} pointerEvents="none">
-                    <circle r="16" fillOpacity="0.8" fill={selectedBy.color} />
-                    <text y="5">
-                      <tspan textAnchor="middle">{selectedBy.name}</tspan>
+                    <text
+                      fillOpacity="0.8"
+                      stroke={selectedBy.color}
+                      strokeWidth="0.5em"
+                      fill="black"
+                      paintOrder="stroke"
+                      strokeLinejoin="round"
+                      y="5"
+                    >
+                      <tspan textAnchor="middle">
+                        {selectedBy.name.length < 7 ? selectedBy.name : selectedBy.name.substring(0, 7) + '..'}
+                      </tspan>
                     </text>
                   </g>
                 </>

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -104,13 +104,14 @@ class CanvasElementComponent extends Component<Props> {
             pointerEvents="none"
           />
         )}
-        {selectedByList.length > 0 && !(hovered || selected) && (
+        {selectedByList.length > 0 && (
           <>
             {selectedByList.map((selectedBy, index) => {
               const indicatorPosition = 'translate(' + (element.bounds.width + STROKE) + ' ' + index * 32 + ')';
               return (
                 <>
                   <rect
+                    className={selectedBy.name+'_'+selectedBy.color}
                     x={-STROKE / 2}
                     y={-STROKE / 2}
                     width={element.bounds.width + STROKE}
@@ -124,6 +125,7 @@ class CanvasElementComponent extends Component<Props> {
 
                   <g transform={indicatorPosition} pointerEvents="none">
                     <text
+                      className={selectedBy.name+'_'+selectedBy.color}
                       fillOpacity="0.8"
                       stroke={selectedBy.color}
                       strokeWidth="0.5em"

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -78,8 +78,7 @@ class CanvasElementComponent extends Component<Props> {
         ? element.fillColor
         : 'white';
 
-    const selectedBy =
-      element.selectedBy && element.selectedBy?.length > 0 ? element.selectedBy[0] : { name: '', color: '' };
+    const selectedByList = element.selectedBy || [];
     return (
       <svg
         {...props}
@@ -105,26 +104,33 @@ class CanvasElementComponent extends Component<Props> {
             pointerEvents="none"
           />
         )}
-        {selectedBy && !(hovered || selected) && (
+        {selectedByList.length > 0 && !(hovered || selected) && (
           <>
-            <rect
-              x={-STROKE / 2}
-              y={-STROKE / 2}
-              width={element.bounds.width + STROKE}
-              height={element.bounds.height + STROKE}
-              fill="none"
-              stroke={selectedBy.color}
-              strokeOpacity="0.2"
-              strokeWidth={STROKE}
-              pointerEvents="none"
-            />
+            {selectedByList.map((selectedBy, index) => {
+              const indicatorPosition = 'translate(' + (element.bounds.width + STROKE) + ' ' + index * 32 + ')';
+              return (
+                <>
+                  <rect
+                    x={-STROKE / 2}
+                    y={-STROKE / 2}
+                    width={element.bounds.width + STROKE}
+                    height={element.bounds.height + STROKE}
+                    fill="none"
+                    stroke={selectedBy.color}
+                    strokeOpacity="0.2"
+                    strokeWidth={STROKE}
+                    pointerEvents="none"
+                  />
 
-            <g transform="translate(195 0)" pointerEvents="none">
-              <circle r="16" fillOpacity="0.8" fill={selectedBy.color} />
-              <text y="5">
-                <tspan textAnchor="middle">{selectedBy.name}</tspan>
-              </text>
-            </g>
+                  <g transform={indicatorPosition} pointerEvents="none">
+                    <circle r="16" fillOpacity="0.8" fill={selectedBy.color} />
+                    <text y="5">
+                      <tspan textAnchor="middle">{selectedBy.name}</tspan>
+                    </text>
+                  </g>
+                </>
+              );
+            })}
           </>
         )}
       </svg>

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -109,7 +109,7 @@ class CanvasElementComponent extends Component<Props> {
             {selectedByList.map((selectedBy, index) => {
               const indicatorPosition = 'translate(' + (element.bounds.width + STROKE) + ' ' + index * 32 + ')';
               return (
-                <g id={selectedBy.name + '_' + selectedBy.color}>
+                <g key={selectedBy.name + '_' + selectedBy.color} id={selectedBy.name + '_' + selectedBy.color}>
                   <rect
                     x={-STROKE / 2}
                     y={-STROKE / 2}
@@ -131,7 +131,7 @@ class CanvasElementComponent extends Component<Props> {
                       width="85px"
                       height="30px"
                       fill={selectedBy.color}
-                    ></rect>
+                    />
                     <text>
                       <tspan textAnchor="middle">
                         {selectedBy.name.length < 8 ? selectedBy.name : selectedBy.name.substring(0, 6) + '..'}

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -119,7 +119,7 @@ class CanvasElementComponent extends Component<Props> {
             />
 
             <g transform="translate(195 0)" pointer-events="none">
-              <circle r="16" fill-opacity="0.8" fill={selectedBy.color}></circle>
+              <circle r="16" fill-opacity="0.8" fill={selectedBy.color} />
               <text y="5">
                 <tspan text-anchor="middle">{selectedBy.name}</tspan>
               </text>

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -78,7 +78,8 @@ class CanvasElementComponent extends Component<Props> {
         ? element.fillColor
         : 'white';
 
-    const selectedBy = element.selectedBy;
+    const selectedBy =
+      element.selectedBy && element.selectedBy?.length > 0 ? element.selectedBy[0] : { name: '', color: '' };
     return (
       <svg
         {...props}

--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -123,15 +123,16 @@ class CanvasElementComponent extends Component<Props> {
                   />
 
                   <g transform={indicatorPosition} pointerEvents="none">
-                    <text
-                      fillOpacity="0.8"
-                      stroke={selectedBy.color}
-                      strokeWidth="0.5em"
-                      fill="black"
-                      paintOrder="stroke"
-                      strokeLinejoin="round"
-                      y="5"
-                    >
+                    <rect
+                      fillOpacity="0.2"
+                      rx="10"
+                      x="-40"
+                      y="-20"
+                      width="85px"
+                      height="30px"
+                      fill={selectedBy.color}
+                    ></rect>
+                    <text>
                       <tspan textAnchor="middle">
                         {selectedBy.name.length < 8 ? selectedBy.name : selectedBy.name.substring(0, 6) + '..'}
                       </tspan>

--- a/src/main/packages/uml-element-selector-type.ts
+++ b/src/main/packages/uml-element-selector-type.ts
@@ -1,0 +1,6 @@
+
+export type UMLElementSelectorType = {
+  elementId: string,
+  name: string,
+  color: string
+};

--- a/src/main/packages/uml-element-selector-type.ts
+++ b/src/main/packages/uml-element-selector-type.ts
@@ -1,6 +1,5 @@
-
 export type UMLElementSelectorType = {
-  elementId: string,
-  name: string,
-  color: string
+  elementId: string;
+  name: string;
+  color: string;
 };

--- a/src/main/services/uml-element/uml-element.ts
+++ b/src/main/services/uml-element/uml-element.ts
@@ -82,7 +82,7 @@ export abstract class UMLElement implements IUMLElement, ILayoutable {
   strokeColor?: string;
   textColor?: string;
   assessmentNote?: string;
-  selectedBy?: UMLElementSelectorType[] = [];
+  selectedBy?: UMLElementSelectorType[];
   resizeFrom: ResizeFrom = ResizeFrom.BOTTOMRIGHT;
 
   constructor(values?: DeepPartial<IUMLElement>) {

--- a/src/main/services/uml-element/uml-element.ts
+++ b/src/main/services/uml-element/uml-element.ts
@@ -1,5 +1,6 @@
 import { DeepPartial } from 'redux';
 import { UMLDiagramType } from '../../packages/diagram-type';
+import { UMLElementSelectorType } from '../../packages/uml-element-selector-type';
 import { UMLElementType } from '../../packages/uml-element-type';
 import { UMLRelationshipType } from '../../packages/uml-relationship-type';
 import * as Apollon from '../../typings';
@@ -32,7 +33,7 @@ export interface IUMLElement {
   textColor?: string;
   /** Note to show for element's assessment */
   assessmentNote?: string;
-  selectedBy?: any;
+  selectedBy?: UMLElementSelectorType;
 }
 
 export const enum ResizeFrom {
@@ -81,7 +82,7 @@ export abstract class UMLElement implements IUMLElement, ILayoutable {
   strokeColor?: string;
   textColor?: string;
   assessmentNote?: string;
-  selectedBy?: any;
+  selectedBy?: UMLElementSelectorType;
   resizeFrom: ResizeFrom = ResizeFrom.BOTTOMRIGHT;
 
   constructor(values?: DeepPartial<IUMLElement>) {

--- a/src/main/services/uml-element/uml-element.ts
+++ b/src/main/services/uml-element/uml-element.ts
@@ -33,7 +33,7 @@ export interface IUMLElement {
   textColor?: string;
   /** Note to show for element's assessment */
   assessmentNote?: string;
-  selectedBy?: UMLElementSelectorType;
+  selectedBy?: UMLElementSelectorType[];
 }
 
 export const enum ResizeFrom {
@@ -82,7 +82,7 @@ export abstract class UMLElement implements IUMLElement, ILayoutable {
   strokeColor?: string;
   textColor?: string;
   assessmentNote?: string;
-  selectedBy?: UMLElementSelectorType;
+  selectedBy?: UMLElementSelectorType[] = [];
   resizeFrom: ResizeFrom = ResizeFrom.BOTTOMRIGHT;
 
   constructor(values?: DeepPartial<IUMLElement>) {

--- a/src/main/services/uml-element/uml-element.ts
+++ b/src/main/services/uml-element/uml-element.ts
@@ -32,6 +32,7 @@ export interface IUMLElement {
   textColor?: string;
   /** Note to show for element's assessment */
   assessmentNote?: string;
+  selectedBy?: any;
 }
 
 export const enum ResizeFrom {
@@ -80,6 +81,7 @@ export abstract class UMLElement implements IUMLElement, ILayoutable {
   strokeColor?: string;
   textColor?: string;
   assessmentNote?: string;
+  selectedBy?: any;
   resizeFrom: ResizeFrom = ResizeFrom.BOTTOMRIGHT;
 
   constructor(values?: DeepPartial<IUMLElement>) {
@@ -111,6 +113,7 @@ export abstract class UMLElement implements IUMLElement, ILayoutable {
       strokeColor: this.strokeColor,
       textColor: this.textColor,
       assessmentNote: this.assessmentNote,
+      selectedBy: this.selectedBy,
     };
   }
 
@@ -126,6 +129,7 @@ export abstract class UMLElement implements IUMLElement, ILayoutable {
     this.strokeColor = values.strokeColor;
     this.textColor = values.textColor;
     this.assessmentNote = values.assessmentNote;
+    this.selectedBy = values.selectedBy;
   }
 
   abstract render(canvas: ILayer): ILayoutable[];

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -52,6 +52,7 @@ export type UMLModelElement = {
   strokeColor?: string;
   textColor?: string;
   assessmentNote?: string;
+  selectedBy?: any;
 };
 
 export type UMLElement = UMLModelElement & {

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -53,7 +53,7 @@ export type UMLModelElement = {
   strokeColor?: string;
   textColor?: string;
   assessmentNote?: string;
-  selectedBy?: UMLElementSelectorType;
+  selectedBy?: UMLElementSelectorType[];
 };
 
 export type UMLElement = UMLModelElement & {

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -1,6 +1,7 @@
 import { DeepPartial } from 'redux';
 import { Styles } from './components/theme/styles';
 import { UMLDiagramType } from './packages/diagram-type';
+import { UMLElementSelectorType } from './packages/uml-element-selector-type';
 import { UMLElementType } from './packages/uml-element-type';
 import { UMLRelationshipType } from './packages/uml-relationship-type';
 import { ApollonMode, Locale } from './services/editor/editor-types';
@@ -52,7 +53,7 @@ export type UMLModelElement = {
   strokeColor?: string;
   textColor?: string;
   assessmentNote?: string;
-  selectedBy?: any;
+  selectedBy?: UMLElementSelectorType;
 };
 
 export type UMLElement = UMLModelElement & {

--- a/src/main/utils/fx/assign.ts
+++ b/src/main/utils/fx/assign.ts
@@ -3,8 +3,8 @@ import { DeepPartial } from 'redux';
 export const assign = <T extends { [key: string]: any }>(target: T, source?: DeepPartial<T>): T => {
   for (const key in source) {
     if (Array.isArray(source[key])) {
-      if(key === 'selectedBy' && target[key] === undefined) {
-        target[key] = [...assign({...target, selectedBy: []}[key], source[key])] as any;
+      if (key === 'selectedBy' && target[key] === undefined) {
+        target[key] = [...assign({ ...target, selectedBy: [] }[key], source[key])] as any;
       } else {
         target[key] = [...assign(target[key], source[key])] as any;
       }

--- a/src/main/utils/fx/assign.ts
+++ b/src/main/utils/fx/assign.ts
@@ -3,7 +3,11 @@ import { DeepPartial } from 'redux';
 export const assign = <T extends { [key: string]: any }>(target: T, source?: DeepPartial<T>): T => {
   for (const key in source) {
     if (Array.isArray(source[key])) {
-      target[key] = [...assign(target[key], source[key])] as any;
+      if(key === 'selectedBy' && target[key] === undefined) {
+        target[key] = [...assign({...target, selectedBy: []}[key], source[key])] as any;
+      } else {
+        target[key] = [...assign(target[key], source[key])] as any;
+      }
     } else if (typeof source[key] === 'object') {
       if (source[key] == null) {
         target[key] = null as any;


### PR DESCRIPTION
# Motivation and Context
This PR enables highlighting user-interacting elements in Real Time Collaboration Mode. 


# Description

- Collaborators are assigned with unique color upon joining Real Time Collaboration Session
- That unique color is then used to highlight the elements they are interacting with, throughout the session for other collaborators.

# Screenshots
![screen-capture (10)](https://user-images.githubusercontent.com/14681902/174491433-d861321c-15ea-486c-aa78-793cb88e4e8a.gif)

# Todos:

- [x] Enable highlighting of elements by multiple users
- [x] Release alpha version (2.10.4-alpha.1)
- [x] Fix issue with displaying own name in highlighted elements

# Additional Info
Changes included in Release version: 2.10.4-alpha.1