### PR TITLE
`Diagram export`: Fix an issue with exporting diagram

### DIFF
--- a/src/main/scenes/svg.tsx
+++ b/src/main/scenes/svg.tsx
@@ -204,7 +204,7 @@ export class Svg extends Component<Props, State> {
                   width={element.bounds.width}
                   height={element.bounds.height}
                   key={element.id}
-                  className={element.name ? element.name.replace(/[<>]/, '') : ''}
+                  className={element.name ? element.name.replace(/[<>]/g, '') : ''}
                   fill={element.fillColor || theme.color.background}
                 >
                   <ElementComponent key={index} element={element} scale={this.props.options?.scale || 1.0} />


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This PR fixes an issue while exporting the diagram in Apollon.
Issue Number: https://github.com/ls1intum/Apollon/issues/233

### Description

- Element name is used to assign a class name in Apollon
- The issue arises whenever we have more than one "<" or ">" as text in any string inside the model
- The previous regex that was used only removed a single instance of "<" or ">"
- Regex is now updated so that all the instances of "<>" are removed while assigning a class name

### Screenshots
**Before:**
![screen-capture (6) (1)](https://user-images.githubusercontent.com/14681902/174876345-9fd20b3a-7095-4f1e-b5bf-67aa2ffdac91.gif)


**After:**
![screen-capture (5)](https://user-images.githubusercontent.com/14681902/174875687-b3045d9e-77cb-4c41-95f2-4c71c9f8c381.gif)

### Additional Info
This PR will fix the issue while downloading the exported model in Standalone.
Changes included in Release version: 2.10.4-alpha.1

