### PR TITLE
`Activity diagrams`: Allow multiple drag/drop points for fork nodes

### DIFF
--- a/src/main/components/uml-element/connectable/connectable.tsx
+++ b/src/main/components/uml-element/connectable/connectable.tsx
@@ -159,14 +159,16 @@ export const connectable = (
           {props.children}
           {(hovered || selected || connecting || reconnecting) && (
             <>
-              <Handle
-                ports={ports}
-                direction={Direction.Up}
-                onPointerDown={this.onPointerDown}
-                onPointerUp={this.onPointerUp}
-                alternativePortVisualization={features.alternativePortVisualization}
-                scale={scale}
-              />
+              {this.props.type !== 'ActivityForkNode' && (
+                <Handle
+                  ports={ports}
+                  direction={Direction.Up}
+                  onPointerDown={this.onPointerDown}
+                  onPointerUp={this.onPointerUp}
+                  alternativePortVisualization={features.alternativePortVisualization}
+                  scale={scale}
+                />
+              )}
               <Handle
                 ports={ports}
                 direction={Direction.Right}
@@ -175,14 +177,18 @@ export const connectable = (
                 alternativePortVisualization={features.alternativePortVisualization}
                 scale={scale}
               />
-              <Handle
-                ports={ports}
-                direction={Direction.Down}
-                onPointerDown={this.onPointerDown}
-                onPointerUp={this.onPointerUp}
-                alternativePortVisualization={features.alternativePortVisualization}
-                scale={scale}
-              />
+
+              {this.props.type !== 'ActivityForkNode' && (
+                <Handle
+                  ports={ports}
+                  direction={Direction.Down}
+                  onPointerDown={this.onPointerDown}
+                  onPointerUp={this.onPointerUp}
+                  alternativePortVisualization={features.alternativePortVisualization}
+                  scale={scale}
+                />
+              )}
+
               <Handle
                 ports={ports}
                 direction={Direction.Left}
@@ -191,22 +197,26 @@ export const connectable = (
                 alternativePortVisualization={features.alternativePortVisualization}
                 scale={scale}
               />
-              <Handle
-                ports={ports}
-                direction={Direction.Upright}
-                onPointerDown={this.onPointerDown}
-                onPointerUp={this.onPointerUp}
-                alternativePortVisualization={features.alternativePortVisualization}
-                scale={scale}
-              />
-              <Handle
-                ports={ports}
-                direction={Direction.Upleft}
-                onPointerDown={this.onPointerDown}
-                onPointerUp={this.onPointerUp}
-                alternativePortVisualization={features.alternativePortVisualization}
-                scale={scale}
-              />
+              {this.props.type === 'ActivityForkNode' && (
+                <>
+                  <Handle
+                    ports={ports}
+                    direction={Direction.Upright}
+                    onPointerDown={this.onPointerDown}
+                    onPointerUp={this.onPointerUp}
+                    alternativePortVisualization={features.alternativePortVisualization}
+                    scale={scale}
+                  />
+                  <Handle
+                    ports={ports}
+                    direction={Direction.Upleft}
+                    onPointerDown={this.onPointerDown}
+                    onPointerUp={this.onPointerUp}
+                    alternativePortVisualization={features.alternativePortVisualization}
+                    scale={scale}
+                  />
+                </>
+              )}
             </>
           )}
         </WrappedComponent>

--- a/src/main/components/uml-element/connectable/connectable.tsx
+++ b/src/main/components/uml-element/connectable/connectable.tsx
@@ -197,7 +197,7 @@ export const connectable = (
                 alternativePortVisualization={features.alternativePortVisualization}
                 scale={scale}
               />
-              {this.props.type === 'ActivityForkNode' && (
+              {this.props.type === 'ActivityForkNode' && this.props.element.bounds.height > 120 && (
                 <>
                   <Handle
                     ports={ports}

--- a/src/main/components/uml-element/connectable/connectable.tsx
+++ b/src/main/components/uml-element/connectable/connectable.tsx
@@ -100,7 +100,7 @@ const Handle = styled((props) => {
   rotate:
     direction === Direction.Up
       ? 0
-      : direction === Direction.Right || direction === Direction.Upright
+      : direction === Direction.Right || direction === Direction.Upright || direction === Direction.Downright
       ? 90
       : direction === Direction.Down
       ? 180
@@ -210,6 +210,22 @@ export const connectable = (
                   <Handle
                     ports={ports}
                     direction={Direction.Upleft}
+                    onPointerDown={this.onPointerDown}
+                    onPointerUp={this.onPointerUp}
+                    alternativePortVisualization={features.alternativePortVisualization}
+                    scale={scale}
+                  />
+                  <Handle
+                    ports={ports}
+                    direction={Direction.Downright}
+                    onPointerDown={this.onPointerDown}
+                    onPointerUp={this.onPointerUp}
+                    alternativePortVisualization={features.alternativePortVisualization}
+                    scale={scale}
+                  />
+                  <Handle
+                    ports={ports}
+                    direction={Direction.Downleft}
                     onPointerDown={this.onPointerDown}
                     onPointerUp={this.onPointerUp}
                     alternativePortVisualization={features.alternativePortVisualization}

--- a/src/main/components/uml-element/connectable/connectable.tsx
+++ b/src/main/components/uml-element/connectable/connectable.tsx
@@ -98,11 +98,11 @@ const Handle = styled((props) => {
   x: `${ports[direction].x}px`,
   y: `${ports[direction].y}px`,
   rotate:
-    direction === Direction.Up
+    direction === Direction.Up || direction === Direction.Topright || direction === Direction.Topleft
       ? 0
       : direction === Direction.Right || direction === Direction.Upright || direction === Direction.Downright
       ? 90
-      : direction === Direction.Down
+      : direction === Direction.Down || direction === Direction.Bottomright || direction === Direction.Bottomleft
       ? 180
       : -90,
 }))<{ rotate: number }>`
@@ -169,15 +169,16 @@ export const connectable = (
                   scale={scale}
                 />
               )}
-              <Handle
-                ports={ports}
-                direction={Direction.Right}
-                onPointerDown={this.onPointerDown}
-                onPointerUp={this.onPointerUp}
-                alternativePortVisualization={features.alternativePortVisualization}
-                scale={scale}
-              />
-
+              {this.props.type !== 'ActivityForkNodeHorizontal' && (
+                <Handle
+                  ports={ports}
+                  direction={Direction.Right}
+                  onPointerDown={this.onPointerDown}
+                  onPointerUp={this.onPointerUp}
+                  alternativePortVisualization={features.alternativePortVisualization}
+                  scale={scale}
+                />
+              )}
               {this.props.type !== 'ActivityForkNode' && (
                 <Handle
                   ports={ports}
@@ -189,14 +190,17 @@ export const connectable = (
                 />
               )}
 
-              <Handle
-                ports={ports}
-                direction={Direction.Left}
-                onPointerDown={this.onPointerDown}
-                onPointerUp={this.onPointerUp}
-                alternativePortVisualization={features.alternativePortVisualization}
-                scale={scale}
-              />
+              {this.props.type !== 'ActivityForkNodeHorizontal' && (
+                <Handle
+                  ports={ports}
+                  direction={Direction.Left}
+                  onPointerDown={this.onPointerDown}
+                  onPointerUp={this.onPointerUp}
+                  alternativePortVisualization={features.alternativePortVisualization}
+                  scale={scale}
+                />
+              )}
+
               {this.props.type === 'ActivityForkNode' && this.props.element.bounds.height > 120 && (
                 <>
                   <Handle
@@ -226,6 +230,43 @@ export const connectable = (
                   <Handle
                     ports={ports}
                     direction={Direction.Downleft}
+                    onPointerDown={this.onPointerDown}
+                    onPointerUp={this.onPointerUp}
+                    alternativePortVisualization={features.alternativePortVisualization}
+                    scale={scale}
+                  />
+                </>
+              )}
+
+              {this.props.type === 'ActivityForkNodeHorizontal' && this.props.element.bounds.width > 120 && (
+                <>
+                  <Handle
+                    ports={ports}
+                    direction={Direction.Topright}
+                    onPointerDown={this.onPointerDown}
+                    onPointerUp={this.onPointerUp}
+                    alternativePortVisualization={features.alternativePortVisualization}
+                    scale={scale}
+                  />
+                  <Handle
+                    ports={ports}
+                    direction={Direction.Topleft}
+                    onPointerDown={this.onPointerDown}
+                    onPointerUp={this.onPointerUp}
+                    alternativePortVisualization={features.alternativePortVisualization}
+                    scale={scale}
+                  />
+                  <Handle
+                    ports={ports}
+                    direction={Direction.Bottomright}
+                    onPointerDown={this.onPointerDown}
+                    onPointerUp={this.onPointerUp}
+                    alternativePortVisualization={features.alternativePortVisualization}
+                    scale={scale}
+                  />
+                  <Handle
+                    ports={ports}
+                    direction={Direction.Bottomleft}
                     onPointerDown={this.onPointerDown}
                     onPointerUp={this.onPointerUp}
                     alternativePortVisualization={features.alternativePortVisualization}
@@ -281,6 +322,10 @@ export const connectable = (
           [Direction.Downright]: new Point(1, 0.75),
           [Direction.Upleft]: new Point(0, 0.25),
           [Direction.Downleft]: new Point(0, 0.75),
+          [Direction.Topright]: new Point(0.75, 0),
+          [Direction.Bottomright]: new Point(0.75, 1),
+          [Direction.Topleft]: new Point(0.25, 0),
+          [Direction.Bottomleft]: new Point(0.25, 1),
         };
 
         const ports = getPortsForElement(this.props.element);

--- a/src/main/components/uml-element/connectable/connectable.tsx
+++ b/src/main/components/uml-element/connectable/connectable.tsx
@@ -98,7 +98,13 @@ const Handle = styled((props) => {
   x: `${ports[direction].x}px`,
   y: `${ports[direction].y}px`,
   rotate:
-    direction === Direction.Up ? 0 : direction === Direction.Right ? 90 : direction === Direction.Down ? 180 : -90,
+    direction === Direction.Up
+      ? 0
+      : direction === Direction.Right || direction === Direction.Upright
+      ? 90
+      : direction === Direction.Down
+      ? 180
+      : -90,
 }))<{ rotate: number }>`
   cursor: crosshair;
   pointer-events: all;
@@ -185,6 +191,22 @@ export const connectable = (
                 alternativePortVisualization={features.alternativePortVisualization}
                 scale={scale}
               />
+              <Handle
+                ports={ports}
+                direction={Direction.Upright}
+                onPointerDown={this.onPointerDown}
+                onPointerUp={this.onPointerUp}
+                alternativePortVisualization={features.alternativePortVisualization}
+                scale={scale}
+              />
+              <Handle
+                ports={ports}
+                direction={Direction.Upleft}
+                onPointerDown={this.onPointerDown}
+                onPointerUp={this.onPointerUp}
+                alternativePortVisualization={features.alternativePortVisualization}
+                scale={scale}
+              />
             </>
           )}
         </WrappedComponent>
@@ -229,6 +251,10 @@ export const connectable = (
           [Direction.Right]: new Point(1, 0.5),
           [Direction.Down]: new Point(0.5, 1),
           [Direction.Left]: new Point(0, 0.5),
+          [Direction.Upright]: new Point(1, 0.25),
+          [Direction.Downright]: new Point(1, 0.75),
+          [Direction.Upleft]: new Point(0, 0.25),
+          [Direction.Downleft]: new Point(0, 0.75),
         };
 
         const ports = getPortsForElement(this.props.element);

--- a/src/main/packages/common/uml-association/uml-association-component.tsx
+++ b/src/main/packages/common/uml-association/uml-association-component.tsx
@@ -95,6 +95,12 @@ export const layoutTextForUMLAssociation = (location: IUMLElementPort['direction
         dy: position === 'TOP' ? -10 : 21,
         textAnchor: 'end',
       };
+    // TODO: fix this
+    default:
+      return {
+        dy: position === 'TOP' ? -10 : 21,
+        textAnchor: 'start',
+      };
   }
 };
 

--- a/src/main/packages/common/uml-association/uml-association-component.tsx
+++ b/src/main/packages/common/uml-association/uml-association-component.tsx
@@ -80,6 +80,8 @@ export const layoutTextForUMLAssociation = (location: IUMLElementPort['direction
         textAnchor: position === 'TOP' ? 'end' : 'start',
       };
     case Direction.Right:
+    case Direction.Upright:
+    case Direction.Downright:
       return {
         dy: position === 'TOP' ? -10 : 21,
         textAnchor: 'start',
@@ -91,15 +93,11 @@ export const layoutTextForUMLAssociation = (location: IUMLElementPort['direction
         textAnchor: position === 'TOP' ? 'end' : 'start',
       };
     case Direction.Left:
+    case Direction.Upleft:
+    case Direction.Downleft:
       return {
         dy: position === 'TOP' ? -10 : 21,
         textAnchor: 'end',
-      };
-    // TODO: fix this
-    default:
-      return {
-        dy: position === 'TOP' ? -10 : 21,
-        textAnchor: 'start',
       };
   }
 };

--- a/src/main/packages/common/uml-association/uml-association-component.tsx
+++ b/src/main/packages/common/uml-association/uml-association-component.tsx
@@ -75,6 +75,8 @@ const Marker = {
 export const layoutTextForUMLAssociation = (location: IUMLElementPort['direction'], position: 'TOP' | 'BOTTOM') => {
   switch (location) {
     case Direction.Up:
+    case Direction.Topright:
+    case Direction.Topleft:
       return {
         dx: position === 'TOP' ? -5 : 5,
         textAnchor: position === 'TOP' ? 'end' : 'start',
@@ -87,6 +89,8 @@ export const layoutTextForUMLAssociation = (location: IUMLElementPort['direction
         textAnchor: 'start',
       };
     case Direction.Down:
+    case Direction.Bottomright:
+    case Direction.Bottomleft:
       return {
         dx: position === 'TOP' ? -5 : 5,
         dy: 10,

--- a/src/main/packages/components.ts
+++ b/src/main/packages/components.ts
@@ -6,6 +6,7 @@ import { UMLActivityActionNodeComponent } from './uml-activity-diagram/uml-activ
 import { UMLActivityControlFlowComponent } from './uml-activity-diagram/uml-activity-control-flow/uml-activity-control-flow-component';
 import { UMLActivityFinalNodeComponent } from './uml-activity-diagram/uml-activity-final-node/uml-activity-final-node-component';
 import { UMLActivityForkNodeComponent } from './uml-activity-diagram/uml-activity-fork-node/uml-activity-fork-node-component';
+import { UMLActivityForkNodeHorizontalComponent } from './uml-activity-diagram/uml-activity-fork-node-horizontal/uml-activity-fork-node-horizontal-component';
 import { UMLActivityInitialNodeComponent } from './uml-activity-diagram/uml-activity-initial-node/uml-activity-initial-node-component';
 import { UMLActivityMergeNodeComponent } from './uml-activity-diagram/uml-activity-merge-node/uml-activity-merge-node-component';
 import { UMLActivityObjectNodeComponent } from './uml-activity-diagram/uml-activity-object-node/uml-activity-object-node-component';
@@ -66,6 +67,7 @@ export const Components: {
   [UMLElementType.ActivityActionNode]: UMLActivityActionNodeComponent,
   [UMLElementType.ActivityFinalNode]: UMLActivityFinalNodeComponent,
   [UMLElementType.ActivityForkNode]: UMLActivityForkNodeComponent,
+  [UMLElementType.ActivityForkNodeHorizontal]: UMLActivityForkNodeHorizontalComponent,
   [UMLElementType.ActivityInitialNode]: UMLActivityInitialNodeComponent,
   [UMLElementType.ActivityMergeNode]: UMLActivityMergeNodeComponent,
   [UMLElementType.ActivityObjectNode]: UMLActivityObjectNodeComponent,

--- a/src/main/packages/popups.ts
+++ b/src/main/packages/popups.ts
@@ -44,6 +44,7 @@ export const Popups: { [key in UMLElementType | UMLRelationshipType]: ComponentT
   [UMLElementType.ActivityActionNode]: DefaultPopup,
   [UMLElementType.ActivityFinalNode]: DefaultPopup,
   [UMLElementType.ActivityForkNode]: DefaultPopup,
+  [UMLElementType.ActivityForkNodeHorizontal]: DefaultPopup,
   [UMLElementType.ActivityInitialNode]: DefaultPopup,
   [UMLElementType.ActivityMergeNode]: UMLActivityMergeNodeUpdate,
   [UMLElementType.ActivityObjectNode]: DefaultPopup,

--- a/src/main/packages/uml-activity-diagram/activity-preview.ts
+++ b/src/main/packages/uml-activity-diagram/activity-preview.ts
@@ -3,6 +3,7 @@ import { UMLElement } from '../../services/uml-element/uml-element';
 import { ComposePreview } from '../compose-preview';
 import { UMLActivityActionNode } from './uml-activity-action-node/uml-activity-action-node';
 import { UMLActivityFinalNode } from './uml-activity-final-node/uml-activity-final-node';
+import { UMLActivityForkNodeHorizontal } from './uml-activity-fork-node-horizontal/uml-activity-fork-node-horizontal';
 import { UMLActivityForkNode } from './uml-activity-fork-node/uml-activity-fork-node';
 import { UMLActivityInitialNode } from './uml-activity-initial-node/uml-activity-initial-node';
 import { UMLActivityMergeNode } from './uml-activity-merge-node/uml-activity-merge-node';
@@ -17,6 +18,8 @@ export const composeActivityPreview: ComposePreview = (
   const elements: UMLElement[] = [];
   UMLActivityForkNode.defaultWidth = 20 * scale;
   UMLActivityForkNode.defaultHeight = 60 * scale;
+  UMLActivityForkNodeHorizontal.defaultWidth = 60 * scale;
+  UMLActivityForkNodeHorizontal.defaultHeight = 20 * scale;
   // Activity
   const activity = new UMLActivity({ name: translate('packages.ActivityDiagram.Activity') });
   activity.bounds = {
@@ -73,6 +76,10 @@ export const composeActivityPreview: ComposePreview = (
   // Activity Fork Node
   const activityForkNode = new UMLActivityForkNode();
   elements.push(activityForkNode);
+
+  // Activity Fork Node Horizontal
+  const activityForkNodeHorizontal = new UMLActivityForkNodeHorizontal();
+  elements.push(activityForkNodeHorizontal);
 
   return elements;
 };

--- a/src/main/packages/uml-activity-diagram/index.ts
+++ b/src/main/packages/uml-activity-diagram/index.ts
@@ -3,6 +3,7 @@ export const ActivityElementType = {
   ActivityActionNode: 'ActivityActionNode',
   ActivityFinalNode: 'ActivityFinalNode',
   ActivityForkNode: 'ActivityForkNode',
+  ActivityForkNodeHorizontal: 'ActivityForkNodeHorizontal',
   ActivityInitialNode: 'ActivityInitialNode',
   ActivityMergeNode: 'ActivityMergeNode',
   ActivityObjectNode: 'ActivityObjectNode',

--- a/src/main/packages/uml-activity-diagram/uml-activity-fork-node-horizontal/uml-activity-fork-node-horizontal-component.tsx
+++ b/src/main/packages/uml-activity-diagram/uml-activity-fork-node-horizontal/uml-activity-fork-node-horizontal-component.tsx
@@ -1,0 +1,42 @@
+import React, { ComponentType, FunctionComponent } from 'react';
+import { UMLActivityForkNodeHorizontal } from './uml-activity-fork-node-horizontal';
+import { withTheme, withThemeProps } from '../../../components/theme/styles';
+import { compose } from 'redux';
+import { connect, ConnectedComponent } from 'react-redux';
+import { ModelState } from '../../../components/store/model-state';
+import { ApollonView } from '../../../services/editor/editor-types';
+import { ThemedRectContrast } from '../../../components/theme/themedComponents';
+
+type OwnProps = {
+  element: UMLActivityForkNodeHorizontal;
+};
+
+type StateProps = { interactive: boolean; interactable: boolean };
+
+type DispatchProps = {};
+
+type Props = OwnProps & StateProps & DispatchProps & withThemeProps;
+
+const enhance = compose<ConnectedComponent<ComponentType<Props>, OwnProps>>(
+  withTheme,
+  connect<StateProps, DispatchProps, OwnProps, ModelState>((state, props) => ({
+    interactive: state.interactive.includes(props.element.id),
+    interactable: state.editor.view === ApollonView.Exporting || state.editor.view === ApollonView.Highlight,
+  })),
+);
+
+const UMLActivityForkNodeHorizontalC: FunctionComponent<Props> = ({ element, interactive, interactable, theme }) => {
+  return (
+    <g>
+      <ThemedRectContrast
+        width={element.bounds.width}
+        height={element.bounds.height}
+        strokeColor="none"
+        fillColor={interactive && interactable ? theme.interactive.normal : element.fillColor}
+        fillOpacity={1}
+      />
+    </g>
+  );
+};
+
+export const UMLActivityForkNodeHorizontalComponent = enhance(UMLActivityForkNodeHorizontalC);

--- a/src/main/packages/uml-activity-diagram/uml-activity-fork-node-horizontal/uml-activity-fork-node-horizontal.ts
+++ b/src/main/packages/uml-activity-diagram/uml-activity-fork-node-horizontal/uml-activity-fork-node-horizontal.ts
@@ -1,0 +1,31 @@
+import { ActivityElementType, ActivityRelationshipType } from '..';
+import { ILayer } from '../../../services/layouter/layer';
+import { ILayoutable } from '../../../services/layouter/layoutable';
+import { IUMLElement, UMLElement } from '../../../services/uml-element/uml-element';
+import { UMLElementFeatures } from '../../../services/uml-element/uml-element-features';
+import { IBoundary } from '../../../utils/geometry/boundary';
+import { UMLElementType } from '../../uml-element-type';
+import { DeepPartial } from 'redux';
+
+export class UMLActivityForkNodeHorizontal extends UMLElement {
+  static supportedRelationships = [ActivityRelationshipType.ActivityControlFlow];
+  static features: UMLElementFeatures = { ...UMLElement.features, updatable: false };
+  static defaultWidth = 60;
+  static defaultHeight = 20;
+
+  type: UMLElementType = ActivityElementType.ActivityForkNodeHorizontal;
+  bounds: IBoundary = {
+    ...this.bounds,
+  };
+
+  constructor(values?: DeepPartial<IUMLElement>) {
+    super(values);
+    this.bounds.width = (values && values.bounds && values.bounds.width) || UMLActivityForkNodeHorizontal.defaultWidth;
+    this.bounds.height = UMLActivityForkNodeHorizontal.defaultHeight;
+  }
+
+  render(layer: ILayer): ILayoutable[] {
+    this.bounds.width = Math.max(this.bounds.width, UMLActivityForkNodeHorizontal.defaultWidth);
+    return [this];
+  }
+}

--- a/src/main/packages/uml-elements.ts
+++ b/src/main/packages/uml-elements.ts
@@ -1,6 +1,7 @@
 import { UMLActivityActionNode } from './uml-activity-diagram/uml-activity-action-node/uml-activity-action-node';
 import { UMLActivityFinalNode } from './uml-activity-diagram/uml-activity-final-node/uml-activity-final-node';
 import { UMLActivityForkNode } from './uml-activity-diagram/uml-activity-fork-node/uml-activity-fork-node';
+import { UMLActivityForkNodeHorizontal } from './uml-activity-diagram/uml-activity-fork-node-horizontal/uml-activity-fork-node-horizontal';
 import { UMLActivityInitialNode } from './uml-activity-diagram/uml-activity-initial-node/uml-activity-initial-node';
 import { UMLActivityMergeNode } from './uml-activity-diagram/uml-activity-merge-node/uml-activity-merge-node';
 import { UMLActivityObjectNode } from './uml-activity-diagram/uml-activity-object-node/uml-activity-object-node';
@@ -55,6 +56,7 @@ export const UMLElements = {
   [UMLElementType.ActivityActionNode]: UMLActivityActionNode,
   [UMLElementType.ActivityObjectNode]: UMLActivityObjectNode,
   [UMLElementType.ActivityForkNode]: UMLActivityForkNode,
+  [UMLElementType.ActivityForkNodeHorizontal]: UMLActivityForkNodeHorizontal,
   [UMLElementType.ActivityMergeNode]: UMLActivityMergeNode,
   [UMLElementType.UseCase]: UMLUseCase,
   [UMLElementType.UseCaseActor]: UMLUseCaseActor,

--- a/src/main/services/uml-element/uml-element-port.ts
+++ b/src/main/services/uml-element/uml-element-port.ts
@@ -3,6 +3,10 @@ export enum Direction {
   Right = 'Right',
   Down = 'Down',
   Left = 'Left',
+  Upright = 'Upright',
+  Upleft = 'Upleft',
+  Downright = 'Downright',
+  Downleft = 'Downleft',
 }
 
 export interface IUMLElementPort {
@@ -20,6 +24,14 @@ export function getOppositeDirection(direction: Direction): Direction {
       return Direction.Left;
     case Direction.Up:
       return Direction.Down;
+    case Direction.Upright:
+      return Direction.Upleft;
+    case Direction.Downright:
+      return Direction.Downleft;
+    case Direction.Upleft:
+      return Direction.Upright;
+    case Direction.Downleft:
+      return Direction.Downright;
     default:
       throw Error(`Could not determine opposite direction for direction of ${direction}`);
   }

--- a/src/main/services/uml-element/uml-element-port.ts
+++ b/src/main/services/uml-element/uml-element-port.ts
@@ -7,6 +7,10 @@ export enum Direction {
   Upleft = 'Upleft',
   Downright = 'Downright',
   Downleft = 'Downleft',
+  Topright = 'Topright',
+  Topleft = 'Topleft',
+  Bottomright = 'Bottomright',
+  Bottomleft = 'Bottomleft',
 }
 
 export interface IUMLElementPort {
@@ -32,6 +36,14 @@ export function getOppositeDirection(direction: Direction): Direction {
       return Direction.Upright;
     case Direction.Downleft:
       return Direction.Downright;
+    case Direction.Topright:
+      return Direction.Topleft;
+    case Direction.Bottomright:
+      return Direction.Bottomleft;
+    case Direction.Topleft:
+      return Direction.Topright;
+    case Direction.Bottomleft:
+      return Direction.Bottomright;
     default:
       throw Error(`Could not determine opposite direction for direction of ${direction}`);
   }

--- a/src/main/services/uml-element/uml-element.ts
+++ b/src/main/services/uml-element/uml-element.ts
@@ -51,6 +51,10 @@ export const getPortsForElement = (element: IUMLElement): { [key in Direction]: 
     [Direction.Downright]: new Point(element.bounds.width, (3 * element.bounds.height) / 4),
     [Direction.Upleft]: new Point(0, element.bounds.height / 4),
     [Direction.Downleft]: new Point(0, (3 * element.bounds.height) / 4),
+    [Direction.Topright]: new Point((3 * element.bounds.width) / 4, 0),
+    [Direction.Bottomright]: new Point((3 * element.bounds.width) / 4, element.bounds.height),
+    [Direction.Topleft]: new Point(element.bounds.width / 4, 0),
+    [Direction.Bottomleft]: new Point(element.bounds.width / 4, element.bounds.height),
   };
 };
 

--- a/src/main/services/uml-element/uml-element.ts
+++ b/src/main/services/uml-element/uml-element.ts
@@ -47,6 +47,10 @@ export const getPortsForElement = (element: IUMLElement): { [key in Direction]: 
     [Direction.Right]: new Point(element.bounds.width, element.bounds.height / 2),
     [Direction.Down]: new Point(element.bounds.width / 2, element.bounds.height),
     [Direction.Left]: new Point(0, element.bounds.height / 2),
+    [Direction.Upright]: new Point(element.bounds.width, element.bounds.height / 4),
+    [Direction.Downright]: new Point(element.bounds.width, (3 * element.bounds.height) / 4),
+    [Direction.Upleft]: new Point(0, element.bounds.height / 4),
+    [Direction.Downleft]: new Point(0, (3 * element.bounds.height) / 4),
   };
 };
 

--- a/src/main/services/uml-relationship/connection.ts
+++ b/src/main/services/uml-relationship/connection.ts
@@ -101,6 +101,12 @@ export class Connection {
       case Direction.Upleft:
         startPointOnMarginBox = startPointOnMarginBox.add(-ENTITY_MARGIN, 0);
         break;
+      case Direction.Downright:
+        startPointOnMarginBox = startPointOnMarginBox.add(ENTITY_MARGIN, 0);
+        break;
+      case Direction.Downleft:
+        startPointOnMarginBox = startPointOnMarginBox.add(-ENTITY_MARGIN, 0);
+        break;
     }
     let endPointOnMarginBox: Point = targetPortPosition.clone();
     switch (target.direction) {
@@ -120,6 +126,12 @@ export class Connection {
         endPointOnMarginBox = endPointOnMarginBox.add(-ENTITY_MARGIN, 0);
         break;
       case Direction.Upright:
+        endPointOnMarginBox = endPointOnMarginBox.add(ENTITY_MARGIN, 0);
+        break;
+      case Direction.Downleft:
+        endPointOnMarginBox = endPointOnMarginBox.add(-ENTITY_MARGIN, 0);
+        break;
+      case Direction.Downright:
         endPointOnMarginBox = endPointOnMarginBox.add(ENTITY_MARGIN, 0);
         break;
     }
@@ -640,6 +652,16 @@ function determineCornerQueue(
       break;
 
     case Direction.Upleft:
+      clockwiseCornerQueue = [tl, tr, br, bl];
+      counterClockwiseCornerQueue = [bl, br, tr, tl];
+      break;
+
+    case Direction.Downright:
+      clockwiseCornerQueue = [br, bl, tl, tr];
+      counterClockwiseCornerQueue = [tr, tl, bl, br];
+      break;
+
+    case Direction.Downleft:
       clockwiseCornerQueue = [tl, tr, br, bl];
       counterClockwiseCornerQueue = [bl, br, tr, tl];
       break;

--- a/src/main/services/uml-relationship/connection.ts
+++ b/src/main/services/uml-relationship/connection.ts
@@ -84,6 +84,8 @@ export class Connection {
     let startPointOnMarginBox: Point = sourcePortPosition.clone();
     switch (source.direction) {
       case Direction.Up:
+      case Direction.Topright:
+      case Direction.Topleft:
         startPointOnMarginBox = startPointOnMarginBox.add(0, -ENTITY_MARGIN);
         break;
       case Direction.Right:
@@ -92,6 +94,8 @@ export class Connection {
         startPointOnMarginBox = startPointOnMarginBox.add(ENTITY_MARGIN, 0);
         break;
       case Direction.Down:
+      case Direction.Bottomright:
+      case Direction.Bottomleft:
         startPointOnMarginBox = startPointOnMarginBox.add(0, ENTITY_MARGIN);
         break;
       case Direction.Left:
@@ -103,6 +107,8 @@ export class Connection {
     let endPointOnMarginBox: Point = targetPortPosition.clone();
     switch (target.direction) {
       case Direction.Up:
+      case Direction.Topright:
+      case Direction.Topleft:
         endPointOnMarginBox = endPointOnMarginBox.add(0, -ENTITY_MARGIN);
         break;
       case Direction.Right:
@@ -111,6 +117,8 @@ export class Connection {
         endPointOnMarginBox = endPointOnMarginBox.add(ENTITY_MARGIN, 0);
         break;
       case Direction.Down:
+      case Direction.Bottomright:
+      case Direction.Bottomleft:
         endPointOnMarginBox = endPointOnMarginBox.add(0, ENTITY_MARGIN);
         break;
       case Direction.Left:
@@ -611,40 +619,28 @@ function determineCornerQueue(
   // when starting at the selected edge of the rectangle
   switch (edge) {
     case Direction.Up:
+    case Direction.Topright:
+    case Direction.Topleft:
       clockwiseCornerQueue = [tr, br, bl, tl];
       counterClockwiseCornerQueue = [tl, bl, br, tr];
       break;
 
     case Direction.Right:
-      clockwiseCornerQueue = [br, bl, tl, tr];
-      counterClockwiseCornerQueue = [tr, tl, bl, br];
-      break;
-
-    case Direction.Down:
-      clockwiseCornerQueue = [bl, tl, tr, br];
-      counterClockwiseCornerQueue = [br, tr, tl, bl];
-      break;
-
-    case Direction.Left:
-      clockwiseCornerQueue = [tl, tr, br, bl];
-      counterClockwiseCornerQueue = [bl, br, tr, tl];
-      break;
-
     case Direction.Upright:
-      clockwiseCornerQueue = [br, bl, tl, tr];
-      counterClockwiseCornerQueue = [tr, tl, bl, br];
-      break;
-
-    case Direction.Upleft:
-      clockwiseCornerQueue = [tl, tr, br, bl];
-      counterClockwiseCornerQueue = [bl, br, tr, tl];
-      break;
-
     case Direction.Downright:
       clockwiseCornerQueue = [br, bl, tl, tr];
       counterClockwiseCornerQueue = [tr, tl, bl, br];
       break;
 
+    case Direction.Down:
+    case Direction.Bottomright:
+    case Direction.Bottomleft:
+      clockwiseCornerQueue = [bl, tl, tr, br];
+      counterClockwiseCornerQueue = [br, tr, tl, bl];
+      break;
+
+    case Direction.Left:
+    case Direction.Upleft:
     case Direction.Downleft:
       clockwiseCornerQueue = [tl, tr, br, bl];
       counterClockwiseCornerQueue = [bl, br, tr, tl];

--- a/src/main/services/uml-relationship/connection.ts
+++ b/src/main/services/uml-relationship/connection.ts
@@ -87,23 +87,15 @@ export class Connection {
         startPointOnMarginBox = startPointOnMarginBox.add(0, -ENTITY_MARGIN);
         break;
       case Direction.Right:
+      case Direction.Upright:
+      case Direction.Downright:
         startPointOnMarginBox = startPointOnMarginBox.add(ENTITY_MARGIN, 0);
         break;
       case Direction.Down:
         startPointOnMarginBox = startPointOnMarginBox.add(0, ENTITY_MARGIN);
         break;
       case Direction.Left:
-        startPointOnMarginBox = startPointOnMarginBox.add(-ENTITY_MARGIN, 0);
-        break;
-      case Direction.Upright:
-        startPointOnMarginBox = startPointOnMarginBox.add(ENTITY_MARGIN, 0);
-        break;
       case Direction.Upleft:
-        startPointOnMarginBox = startPointOnMarginBox.add(-ENTITY_MARGIN, 0);
-        break;
-      case Direction.Downright:
-        startPointOnMarginBox = startPointOnMarginBox.add(ENTITY_MARGIN, 0);
-        break;
       case Direction.Downleft:
         startPointOnMarginBox = startPointOnMarginBox.add(-ENTITY_MARGIN, 0);
         break;
@@ -114,25 +106,17 @@ export class Connection {
         endPointOnMarginBox = endPointOnMarginBox.add(0, -ENTITY_MARGIN);
         break;
       case Direction.Right:
+      case Direction.Upright:
+      case Direction.Downright:
         endPointOnMarginBox = endPointOnMarginBox.add(ENTITY_MARGIN, 0);
         break;
       case Direction.Down:
         endPointOnMarginBox = endPointOnMarginBox.add(0, ENTITY_MARGIN);
         break;
       case Direction.Left:
-        endPointOnMarginBox = endPointOnMarginBox.add(-ENTITY_MARGIN, 0);
-        break;
       case Direction.Upleft:
-        endPointOnMarginBox = endPointOnMarginBox.add(-ENTITY_MARGIN, 0);
-        break;
-      case Direction.Upright:
-        endPointOnMarginBox = endPointOnMarginBox.add(ENTITY_MARGIN, 0);
-        break;
       case Direction.Downleft:
         endPointOnMarginBox = endPointOnMarginBox.add(-ENTITY_MARGIN, 0);
-        break;
-      case Direction.Downright:
-        endPointOnMarginBox = endPointOnMarginBox.add(ENTITY_MARGIN, 0);
         break;
     }
 

--- a/src/main/services/uml-relationship/connection.ts
+++ b/src/main/services/uml-relationship/connection.ts
@@ -95,6 +95,12 @@ export class Connection {
       case Direction.Left:
         startPointOnMarginBox = startPointOnMarginBox.add(-ENTITY_MARGIN, 0);
         break;
+      case Direction.Upright:
+        startPointOnMarginBox = startPointOnMarginBox.add(ENTITY_MARGIN, 0);
+        break;
+      case Direction.Upleft:
+        startPointOnMarginBox = startPointOnMarginBox.add(-ENTITY_MARGIN, 0);
+        break;
     }
     let endPointOnMarginBox: Point = targetPortPosition.clone();
     switch (target.direction) {
@@ -109,6 +115,12 @@ export class Connection {
         break;
       case Direction.Left:
         endPointOnMarginBox = endPointOnMarginBox.add(-ENTITY_MARGIN, 0);
+        break;
+      case Direction.Upleft:
+        endPointOnMarginBox = endPointOnMarginBox.add(-ENTITY_MARGIN, 0);
+        break;
+      case Direction.Upright:
+        endPointOnMarginBox = endPointOnMarginBox.add(ENTITY_MARGIN, 0);
         break;
     }
 
@@ -618,6 +630,16 @@ function determineCornerQueue(
       break;
 
     case Direction.Left:
+      clockwiseCornerQueue = [tl, tr, br, bl];
+      counterClockwiseCornerQueue = [bl, br, tr, tl];
+      break;
+
+    case Direction.Upright:
+      clockwiseCornerQueue = [br, bl, tl, tr];
+      counterClockwiseCornerQueue = [tr, tl, bl, br];
+      break;
+
+    case Direction.Upleft:
       clockwiseCornerQueue = [tl, tr, br, bl];
       counterClockwiseCornerQueue = [bl, br, tr, tl];
       break;


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
This PR allows users to have multiple drag/drop points (handles) for Activity Fork Nodes. 
Issue Number: https://github.com/ls1intum/Apollon/issues/240

### Description
Previously parallelism (illustrated below) in Activity Diagrams was not possible, as a fork could only have one incoming/outgoing arrow on the side. 
<img width="284" alt="image (4)" src="https://user-images.githubusercontent.com/14681902/176431283-153e3ce8-75f2-4fea-847f-0fcf80d5f4ee.png">

A possible workaround is illustrated below but was very bad. 
<img width="500" alt="image (5)" src="https://user-images.githubusercontent.com/14681902/176431049-cc5bec35-fc45-4051-9686-a9299dba20c7.png">

Now with this PR, we allow users to have multiple drag/drop points and hence achieve parallelism in Activity Diagrams.
### Screenshots
![screen-capture-_6_](https://user-images.githubusercontent.com/14681902/176432287-f6d7c5f3-8aad-44f6-acc5-d5464e07b2d5.gif)


### Steps for Testing

- [x] Release alpha version in npm
- [x] Deploy in Test Server

### Additional Info:
Changes included in Release version: 2.10.4-alpha.2