### PR TITLE
`Component diagrams`: Fix an appearance issue with interface connections

### DIFF
--- a/src/main/packages/common/uml-interface-provided/uml-interface-provided-component.tsx
+++ b/src/main/packages/common/uml-interface-provided/uml-interface-provided-component.tsx
@@ -7,7 +7,7 @@ export const UMLInterfaceProvidedComponent: FunctionComponent<Props> = ({ elemen
     <ThemedPolyline
       points={element.path.map((point) => `${point.x} ${point.y}`).join(',')}
       strokeColor={element.strokeColor}
-      fillColor={element.fillColor}
+      fillColor="none"
     />
   </g>
 );

--- a/src/tests/unit/packages/uml-component-diagram/uml-component-provided-interface/__snapshots__/uml-component-provided-interface-component-test.tsx.snap
+++ b/src/tests/unit/packages/uml-component-diagram/uml-component-provided-interface/__snapshots__/uml-component-provided-interface-component-test.tsx.snap
@@ -6,8 +6,8 @@ exports[`render the uml-component-interface-provided-component 1`] = `
     <svg>
       <g>
         <polyline
-          class="sc-bczRLJ fCdTGt"
-          fill="white"
+          class="sc-bczRLJ gQkeMM"
+          fill="none"
           points="0 0,100 100"
           stroke="black"
         />

--- a/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-provided-interface/__snapshots__/uml-deployment-provided-interface-component-test.tsx.snap
+++ b/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-provided-interface/__snapshots__/uml-deployment-provided-interface-component-test.tsx.snap
@@ -6,8 +6,8 @@ exports[`render the uml-deplyoment-interface-provided-component 1`] = `
     <svg>
       <g>
         <polyline
-          class="sc-bczRLJ fCdTGt"
-          fill="white"
+          class="sc-bczRLJ gQkeMM"
+          fill="none"
           points="0 0,100 100"
           stroke="black"
         />


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
This PR removes the white triangles issue in the interface connection of the component diagram.
Issue Number: https://github.com/ls1intum/Apollon/issues/251

### Steps for Testing
#### In local machine
1. Clone the repo
2. Checkout to `bugfix/component-diagram-interface-fix` branch
3. Run the application by executing `yarn install` followed by `yarn start` commands
4. Select Component Diagram from Diagram Type Menu
5. Add Component and Interface to the canvas and connect them together, as illustrated in the screenshots
6. Observe there are no white triangles on the background of connectors

#### In test server
- Goto [test server](https://test1.apollon.ase.in.tum.de/)
- Create New ComponentDiagram by clicking on File > New > ComponentDiagram
- Add Component and Interface to the canvas and connect them together, as illustrated in the screenshots
- Observe there are no white triangles on the background of connectors

### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/14681902/180644180-57aa1f4e-a363-4ed6-8b9f-1a549b3466bc.png)

#### After
![image](https://user-images.githubusercontent.com/14681902/180644212-fde722fa-f5df-4c4b-9b73-5b90227e0c0c.png)

### Additional Info:
Changes included in [2.11.2-beta.0](https://www.npmjs.com/package/@ls1intum/apollon/v/2.11.2-beta.0)

### Todo:
- [x] Deploy in Test server
