### PR TITLE
`Development`: Restrict users from inserting more than 100 characters

### DIFF
--- a/src/main/components/controls/textfield/textfield.tsx
+++ b/src/main/components/controls/textfield/textfield.tsx
@@ -61,6 +61,7 @@ export class Textfield<T extends TextfieldValue> extends Component<Props<T>, Sta
     return (
       <StyledTextfield
         as={props.multiline ? 'textarea' : 'input'}
+        maxLength={props.multiline ? 1000 : 100}
         key={this.state.key}
         {...props}
         size={size}

--- a/src/main/components/controls/textfield/textfield.tsx
+++ b/src/main/components/controls/textfield/textfield.tsx
@@ -61,7 +61,7 @@ export class Textfield<T extends TextfieldValue> extends Component<Props<T>, Sta
     return (
       <StyledTextfield
         as={props.multiline ? 'textarea' : 'input'}
-        maxLength={props.multiline ? 1000 : 100}
+        maxLength={props.multiline ? undefined : 100}
         key={this.state.key}
         {...props}
         size={size}

--- a/src/tests/unit/components/update-pane/__snapshots__/update-pane-test.tsx.snap
+++ b/src/tests/unit/components/update-pane/__snapshots__/update-pane-test.tsx.snap
@@ -431,6 +431,7 @@ exports[`test update pane render with element 1`] = `
               >
                 <input
                   class="c7 c8"
+                  maxlength="100"
                   value=""
                 />
                 <button
@@ -493,6 +494,7 @@ exports[`test update pane render with element 1`] = `
               >
                 <input
                   class="c7 c18"
+                  maxlength="100"
                   value=""
                 />
                 <button
@@ -515,6 +517,7 @@ exports[`test update pane render with element 1`] = `
               </div>
               <input
                 class="c7 c19"
+                maxlength="100"
                 value=""
               />
             </section>
@@ -532,6 +535,7 @@ exports[`test update pane render with element 1`] = `
               >
                 <input
                   class="c7 c18"
+                  maxlength="100"
                   value=""
                 />
                 <button
@@ -554,6 +558,7 @@ exports[`test update pane render with element 1`] = `
               </div>
               <input
                 class="c7 c19"
+                maxlength="100"
                 value=""
               />
             </section>
@@ -1030,6 +1035,7 @@ exports[`test update pane render with relationship 1`] = `
                 </span>
                 <input
                   class="c16 c17"
+                  maxlength="100"
                   style="min-width: 0;"
                   value=""
                 />
@@ -1045,6 +1051,7 @@ exports[`test update pane render with relationship 1`] = `
                 </span>
                 <input
                   class="c16 c18"
+                  maxlength="100"
                   value=""
                 />
               </div>
@@ -1067,6 +1074,7 @@ exports[`test update pane render with relationship 1`] = `
                 </span>
                 <input
                   class="c16 c17"
+                  maxlength="100"
                   style="min-width: 0;"
                   value=""
                 />
@@ -1082,6 +1090,7 @@ exports[`test update pane render with relationship 1`] = `
                 </span>
                 <input
                   class="c16 c18"
+                  maxlength="100"
                   value=""
                 />
               </div>

--- a/src/tests/unit/packages/common/default-element-popup/__snapshots__/default-element-popup-test.tsx.snap
+++ b/src/tests/unit/packages/common/default-element-popup/__snapshots__/default-element-popup-test.tsx.snap
@@ -11,6 +11,7 @@ exports[`test default element popup render 1`] = `
           >
             <input
               class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+              maxLength="100"
             />
             <button
               class="sc-fLlhyt sc-bBrHrO isqEak bBoMhO"

--- a/src/tests/unit/packages/common/uml-classifier-update/__snapshots__/uml-classifier-update-test.tsx.snap
+++ b/src/tests/unit/packages/common/uml-classifier-update/__snapshots__/uml-classifier-update-test.tsx.snap
@@ -10,6 +10,7 @@ exports[`test class association popup render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             value=""
           />
           <button
@@ -72,6 +73,7 @@ exports[`test class association popup render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs cgvUiD"
+            maxlength="100"
             value="attribute"
           />
           <button
@@ -94,6 +96,7 @@ exports[`test class association popup render 1`] = `
         </div>
         <input
           class="sc-ezWOiH sc-bZkfAO wLKMs dnbWxS"
+          maxlength="100"
           value=""
         />
       </section>
@@ -111,6 +114,7 @@ exports[`test class association popup render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs cgvUiD"
+            maxlength="100"
             value="classMethod"
           />
           <button
@@ -133,6 +137,7 @@ exports[`test class association popup render 1`] = `
         </div>
         <input
           class="sc-ezWOiH sc-bZkfAO wLKMs dnbWxS"
+          maxlength="100"
           value=""
         />
       </section>

--- a/src/tests/unit/packages/flowchart/flowchart-decision/__snapshots__/flowchart-decision-update-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-decision/__snapshots__/flowchart-decision-update-test.tsx.snap
@@ -10,6 +10,7 @@ exports[`test flowchart decision update render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             placeholder="Decision"
             value=""
           />

--- a/src/tests/unit/packages/flowchart/flowchart-flowline/__snapshots__/flowchart-flowline-update-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-flowline/__snapshots__/flowchart-flowline-update-test.tsx.snap
@@ -54,6 +54,7 @@ exports[`test flowchart flowline update render 1`] = `
       <section>
         <input
           class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+          maxlength="100"
           value="FlowchartFlowline"
         />
       </section>

--- a/src/tests/unit/packages/flowchart/flowchart-function-call/__snapshots__/flowchart-function-call-update-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-function-call/__snapshots__/flowchart-function-call-update-test.tsx.snap
@@ -10,6 +10,7 @@ exports[`test flowchart function call update render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             placeholder="Decision"
             value=""
           />

--- a/src/tests/unit/packages/flowchart/flowchart-input-output/__snapshots__/flowchart-input-output-update-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-input-output/__snapshots__/flowchart-input-output-update-test.tsx.snap
@@ -10,6 +10,7 @@ exports[`test flowchart input output update render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             placeholder="Decision"
             value=""
           />

--- a/src/tests/unit/packages/flowchart/flowchart-process/__snapshots__/flowchart-process-update-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-process/__snapshots__/flowchart-process-update-test.tsx.snap
@@ -10,6 +10,7 @@ exports[`test flowchart input output update render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             placeholder="Decision"
             value=""
           />

--- a/src/tests/unit/packages/flowchart/flowchart-terminal/__snapshots__/flowchart-terminal-update-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-terminal/__snapshots__/flowchart-terminal-update-test.tsx.snap
@@ -10,6 +10,7 @@ exports[`test flowchart input output update render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             placeholder="Decision"
             value=""
           />

--- a/src/tests/unit/packages/uml-class-diagram/class-association-popup/__snapshots__/class-association-popup-test.tsx.snap
+++ b/src/tests/unit/packages/uml-class-diagram/class-association-popup/__snapshots__/class-association-popup-test.tsx.snap
@@ -81,6 +81,7 @@ exports[`test class association popup render 1`] = `
           </span>
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs cgvUiD"
+            maxlength="100"
             style="min-width: 0;"
             value=""
           />
@@ -96,6 +97,7 @@ exports[`test class association popup render 1`] = `
           </span>
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             value=""
           />
         </div>
@@ -118,6 +120,7 @@ exports[`test class association popup render 1`] = `
           </span>
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs cgvUiD"
+            maxlength="100"
             style="min-width: 0;"
             value=""
           />
@@ -133,6 +136,7 @@ exports[`test class association popup render 1`] = `
           </span>
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             value=""
           />
         </div>

--- a/src/tests/unit/packages/uml-communication-diagram/uml-communication-link/__snapshots__/uml-communication-link-popup-test.tsx.snap
+++ b/src/tests/unit/packages/uml-communication-diagram/uml-communication-link/__snapshots__/uml-communication-link-popup-test.tsx.snap
@@ -52,6 +52,7 @@ exports[`test communication link popup render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs cgvUiD"
+            maxlength="100"
             value="CommunicationSourceLinkMessage0"
           />
           <button
@@ -94,6 +95,7 @@ exports[`test communication link popup render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs cgvUiD"
+            maxlength="100"
             value="CommunicationSourceLinkMessage1"
           />
           <button
@@ -136,6 +138,7 @@ exports[`test communication link popup render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs cgvUiD"
+            maxlength="100"
             value="CommunicationSourceLinkMessage2"
           />
           <button
@@ -178,6 +181,7 @@ exports[`test communication link popup render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs cgvUiD"
+            maxlength="100"
             value="CommunicationTargetLinkMessage0"
           />
           <button
@@ -220,6 +224,7 @@ exports[`test communication link popup render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs cgvUiD"
+            maxlength="100"
             value="CommunicationTargetLinkMessage1"
           />
           <button
@@ -262,6 +267,7 @@ exports[`test communication link popup render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs cgvUiD"
+            maxlength="100"
             value="CommunicationTargetLinkMessage2"
           />
           <button
@@ -301,6 +307,7 @@ exports[`test communication link popup render 1`] = `
         </div>
         <input
           class="sc-ezWOiH sc-bZkfAO wLKMs dnbWxS"
+          maxlength="100"
           value=""
         />
       </section>

--- a/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-node/uml-deployment-node-popup/__snapshots__/deployment-node-popup-test.tsx.snap
+++ b/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-node/uml-deployment-node-popup/__snapshots__/deployment-node-popup-test.tsx.snap
@@ -10,6 +10,7 @@ exports[`test deployment node popup render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             value=""
           />
           <button
@@ -40,6 +41,7 @@ exports[`test deployment node popup render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             value="node"
           />
         </div>

--- a/src/tests/unit/packages/uml-object-diagram/uml-object-name/__snapshots__/uml-object-name-test.tsx.snap
+++ b/src/tests/unit/packages/uml-object-diagram/uml-object-name/__snapshots__/uml-object-name-test.tsx.snap
@@ -10,6 +10,7 @@ exports[`render the uml-object-name-component 1`] = `
         >
           <input
             class="sc-eCYdqJ sc-jSMfEi fXFLDy bixmYE"
+            maxlength="100"
             value="TestObjectComponent"
           />
           <button
@@ -42,6 +43,7 @@ exports[`render the uml-object-name-component 1`] = `
         </h1>
         <input
           class="sc-eCYdqJ sc-jSMfEi fXFLDy fcZlWn"
+          maxlength="100"
           value=""
         />
       </section>
@@ -56,6 +58,7 @@ exports[`render the uml-object-name-component 1`] = `
         </h1>
         <input
           class="sc-eCYdqJ sc-jSMfEi fXFLDy fcZlWn"
+          maxlength="100"
           value=""
         />
       </section>

--- a/src/tests/unit/packages/uml-petri-diagram/uml-petri-net-arc/__snapshots__/uml-petri-net-arc-update-test.tsx.snap
+++ b/src/tests/unit/packages/uml-petri-diagram/uml-petri-net-arc/__snapshots__/uml-petri-net-arc-update-test.tsx.snap
@@ -10,6 +10,7 @@ exports[`test petri net arc update render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             value="UMLClassBidirectional"
           />
           <button

--- a/src/tests/unit/packages/uml-petri-diagram/uml-petri-net-place/__snapshots__/uml-petri-net-place-update-test.tsx.snap
+++ b/src/tests/unit/packages/uml-petri-diagram/uml-petri-net-place/__snapshots__/uml-petri-net-place-update-test.tsx.snap
@@ -10,6 +10,7 @@ exports[`test petri net arc update render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             value=""
           />
           <button
@@ -46,6 +47,7 @@ exports[`test petri net arc update render 1`] = `
           </span>
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             style="min-width: 0;"
             type="number"
             value="0"
@@ -68,6 +70,7 @@ exports[`test petri net arc update render 1`] = `
           >
             <input
               class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+              maxlength="100"
               type="number"
               value="Infinity"
             />

--- a/src/tests/unit/packages/uml-reachability-graph/uml-reachability-graph-arc/__snapshots__/uml-reachability-graph-arc-update-test.tsx.snap
+++ b/src/tests/unit/packages/uml-reachability-graph/uml-reachability-graph-arc/__snapshots__/uml-reachability-graph-arc-update-test.tsx.snap
@@ -10,6 +10,7 @@ exports[`test reachability graph arc update render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             value="UMLClassBidirectional"
           />
           <button

--- a/src/tests/unit/packages/uml-reachability-graph/uml-reachability-graph-marking/__snapshots__/uml-reachability-graph-marking-update-test.tsx.snap
+++ b/src/tests/unit/packages/uml-reachability-graph/uml-reachability-graph-marking/__snapshots__/uml-reachability-graph-marking-update-test.tsx.snap
@@ -10,6 +10,7 @@ exports[`test reachability graph arc update render 1`] = `
         >
           <input
             class="sc-ezWOiH sc-bZkfAO wLKMs gTZQoR"
+            maxlength="100"
             value=""
           />
           <button


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes


### Motivation and Context
This PR fixes the issue mentioned in [Testing Session](https://confluence.ase.in.tum.de/display/ArTEMiS/Testing+Session+11.07.2022) regarding the stretching of diagrams when input text is long. [Findings > Assigned Issues > Issue Nr: 24]. 

### Description
This PR restricts users from inserting more than 100 characters in the application's input fields (except for the assessment feedback field).


### Steps for Testing
#### In test Server:
1. Goto [test server](https://test1.apollon.ase.in.tum.de/)
2. Insert any element in canvas and try setting its name (or attributes/methods) with more than 100 characters.
3. Observe that the application stops taking input once 100 characters are inserted.

#### In local machine:
1. Clone the repo
4. Checkout to branch `bugfix/input-length-restriction`
5. Run the application by executing `yarn install` followed by `yarn start` command.
6. Insert any element in canvas and try setting its name (or attributes/methods) with more than 100 characters.
7. Observe that the application stops taking input once 100 characters are inserted.



### Screenshots
![screen-capture (15)](https://user-images.githubusercontent.com/14681902/182205230-78b90ece-6ce3-4ff8-89d2-a4ccad567b36.gif)
#### PS: For illustration purposes, the restriction length in the video is set to 10. 

#### Additional Info:
Changes released in [v2.11.3-beta.1](https://www.npmjs.com/package/@ls1intum/apollon/v/2.11.3-beta.1)