### PR TITLE
`Development`: Fix issue with styling of interactive elements

### DIFF
--- a/src/main/components/uml-element/canvas-element.tsx
+++ b/src/main/components/uml-element/canvas-element.tsx
@@ -76,7 +76,7 @@ class CanvasElementComponent extends Component<Props> {
         ? element.highlight
         : element.fillColor
         ? element.fillColor
-        : 'white';
+        : theme.color.background;
 
     const selectedByList = element.selectedBy || [];
     return (
@@ -87,7 +87,7 @@ class CanvasElementComponent extends Component<Props> {
         fillOpacity={moving ? 0.7 : undefined}
         fill={highlight}
       >
-        <ElementComponent scale={props.scale} element={UMLElementRepository.get(element)}>
+        <ElementComponent fillColor={highlight} scale={props.scale} element={UMLElementRepository.get(element)}>
           {elements}
         </ElementComponent>
         {children}

--- a/src/main/packages/common/color-legend/color-legend-component.tsx
+++ b/src/main/packages/common/color-legend/color-legend-component.tsx
@@ -3,13 +3,13 @@ import { Multiline } from '../../../utils/svg/multiline';
 import { ColorLegend } from './color-legend';
 import { ThemedPath } from '../../../components/theme/themedComponents';
 
-export const ColorLegendComponent: FunctionComponent<Props> = ({ element }) => (
+export const ColorLegendComponent: FunctionComponent<Props> = ({ element, fillColor }) => (
   <g>
     <ThemedPath
       d={`M 0 0 L ${element.bounds.width - 15} 0 L ${element.bounds.width} 15 L ${element.bounds.width} ${
         element.bounds.height
       } L 0 ${element.bounds.height} L 0 0 Z`}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
       strokeColor={element.strokeColor}
       strokeWidth="1.2"
       strokeMiterlimit="10"
@@ -37,4 +37,5 @@ export const ColorLegendComponent: FunctionComponent<Props> = ({ element }) => (
 
 export interface Props {
   element: ColorLegend;
+  fillColor?: string;
 }

--- a/src/main/packages/common/uml-classifier/uml-classifier-component.tsx
+++ b/src/main/packages/common/uml-classifier/uml-classifier-component.tsx
@@ -3,11 +3,11 @@ import { Text } from '../../../components/controls/text/text';
 import { UMLClassifier } from './uml-classifier';
 import { ThemedPath, ThemedRect } from '../../../components/theme/themedComponents';
 
-export const UMLClassifierComponent: FunctionComponent<Props> = ({ element, scale, children }) => {
+export const UMLClassifierComponent: FunctionComponent<Props> = ({ element, scale, children, fillColor }) => {
   return (
     <g>
       <ThemedRect
-        fillColor={element.fillColor}
+        fillColor={fillColor || element.fillColor}
         strokeColor="none"
         width="100%"
         height={element.stereotype ? 50 * scale : 40 * scale}
@@ -57,4 +57,5 @@ export const UMLClassifierComponent: FunctionComponent<Props> = ({ element, scal
 interface Props {
   element: UMLClassifier;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/common/uml-classifier/uml-classifier-member-component.tsx
+++ b/src/main/packages/common/uml-classifier/uml-classifier-member-component.tsx
@@ -5,10 +5,10 @@ import { ModelState } from '../../../components/store/model-state';
 import { UMLClassifierMember } from './uml-classifier-member';
 import { ThemedRect } from '../../../components/theme/themedComponents';
 
-export const UMLClassifierMemberComponent: FunctionComponent<Props> = ({ element, scale }) => {
+export const UMLClassifierMemberComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => {
   return (
     <g>
-      <ThemedRect fillColor={element.fillColor} strokeColor="none" width="100%" height="100%" />
+      <ThemedRect fillColor={fillColor || element.fillColor} strokeColor="none" width="100%" height="100%" />
       <Text x={10 * scale} fill={element.textColor} fontWeight="normal" textAnchor="start">
         {element.name}
       </Text>
@@ -19,4 +19,5 @@ export const UMLClassifierMemberComponent: FunctionComponent<Props> = ({ element
 interface Props {
   element: UMLClassifierMember;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/common/uml-component/uml-component-component.tsx
+++ b/src/main/packages/common/uml-component/uml-component-component.tsx
@@ -3,9 +3,14 @@ import { Text } from '../../../components/controls/text/text';
 import { UMLComponent } from './uml-component';
 import { ThemedPath, ThemedRect } from '../../../components/theme/themedComponents';
 
-export const UMLComponentComponent: FunctionComponent<Props> = ({ element, children, scale }) => (
+export const UMLComponentComponent: FunctionComponent<Props> = ({ element, children, scale, fillColor }) => (
   <g data-cy="uml-component">
-    <ThemedRect width="100%" height="100%" strokeColor={element.strokeColor} fillColor={element.fillColor} />
+    <ThemedRect
+      width="100%"
+      height="100%"
+      strokeColor={element.strokeColor}
+      fillColor={fillColor || element.fillColor}
+    />
     <Text fill={element.textColor} y={`${25 * scale}px`} dominantBaseline="auto">
       {element.name}
     </Text>
@@ -13,7 +18,7 @@ export const UMLComponentComponent: FunctionComponent<Props> = ({ element, child
       <ThemedPath
         style={{ transform: `scale(${scale})` }}
         d="M 4.8 0 L 24 0 L 24 24 L 4.8 24 L 4.8 19.2 L 0 19.2 L 0 14.4 L 4.8 14.4 L 4.8 9.6 L 0 9.6 L 0 4.8 L 4.8 4.8 Z"
-        fillColor={element.fillColor}
+        fillColor={fillColor || element.fillColor}
         strokeColor={element.strokeColor}
         strokeWidth="1.2"
         strokeMiterlimit="10"
@@ -34,4 +39,5 @@ export const UMLComponentComponent: FunctionComponent<Props> = ({ element, child
 interface Props {
   element: UMLComponent;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/common/uml-interface/uml-interface-component.tsx
+++ b/src/main/packages/common/uml-interface/uml-interface-component.tsx
@@ -3,7 +3,7 @@ import { Text } from '../../../components/controls/text/text';
 import { UMLInterface } from './uml-interface';
 import { ThemedCircle } from '../../../components/theme/themedComponents';
 
-export const UMLInterfaceComponent: FunctionComponent<Props> = ({ element, scale }) => (
+export const UMLInterfaceComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => (
   <g>
     <ThemedCircle
       cx={`${10 * scale}px`}
@@ -11,6 +11,7 @@ export const UMLInterfaceComponent: FunctionComponent<Props> = ({ element, scale
       r={10 * scale}
       strokeColor={element.strokeColor}
       strokeWidth={2 * scale}
+      fillColor={fillColor || element.fillColor}
     />
     <Text noY x={`${25 * scale}px`} dominantBaseline="auto" textAnchor="start" fill={element.textColor}>
       {element.name}
@@ -21,4 +22,5 @@ export const UMLInterfaceComponent: FunctionComponent<Props> = ({ element, scale
 interface Props {
   element: UMLInterface;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/components.ts
+++ b/src/main/packages/components.ts
@@ -50,7 +50,7 @@ import { ColorLegendComponent } from './common/color-legend/color-legend-compone
 
 export const Components: {
   [key in UMLElementType | UMLRelationshipType]:
-    | FunctionComponent<{ element: any; scale: number }>
+    | FunctionComponent<{ element: any; scale: number; fillColor?: string }>
     | ConnectedComponent<FunctionComponent<any>, { element: any; scale: number }>;
 } = {
   [UMLElementType.Package]: UMLClassPackageComponent,

--- a/src/main/packages/flowchart/flowchart-decision/flowchart-decision-component.tsx
+++ b/src/main/packages/flowchart/flowchart-decision/flowchart-decision-component.tsx
@@ -3,14 +3,14 @@ import { FlowchartComponent } from '../flowchart-element/flowchart-component';
 import { FlowchartDecision } from './flowchart-decision';
 import { ThemedPolyline } from '../../../components/theme/themedComponents';
 
-export const FlowchartDecisionComponent: FunctionComponent<Props> = ({ element, scale }) => (
+export const FlowchartDecisionComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => (
   <FlowchartComponent element={element} scale={scale}>
     <ThemedPolyline
       points={`${element.bounds.width / 2} 0, ${element.bounds.width} ${element.bounds.height / 2}, ${
         element.bounds.width / 2
       } ${element.bounds.height}, 0 ${element.bounds.height / 2}, ${element.bounds.width / 2} 0`}
       strokeColor={element.strokeColor}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
     />
   </FlowchartComponent>
 );
@@ -18,4 +18,5 @@ export const FlowchartDecisionComponent: FunctionComponent<Props> = ({ element, 
 export interface Props {
   element: FlowchartDecision;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/flowchart/flowchart-function-call/flowchart-function-call-component.tsx
+++ b/src/main/packages/flowchart/flowchart-function-call/flowchart-function-call-component.tsx
@@ -3,10 +3,10 @@ import { FlowchartComponent } from '../flowchart-element/flowchart-component';
 import { FlowchartFunctionCall } from './flowchart-function-call';
 import { ThemedRect } from '../../../components/theme/themedComponents';
 
-export const FlowchartFunctionCallComponent: FunctionComponent<Props> = ({ element, scale }) => (
+export const FlowchartFunctionCallComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => (
   <FlowchartComponent element={element} scale={scale}>
     <ThemedRect
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
       width={10 * scale}
       height="100%"
       strokeColor={element.strokeColor}
@@ -17,14 +17,14 @@ export const FlowchartFunctionCallComponent: FunctionComponent<Props> = ({ eleme
       height="100%"
       strokeColor={element.strokeColor}
       x={10 * scale}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
     />
     <ThemedRect
       width={10 * scale}
       height="100%"
       strokeColor={element.strokeColor}
       x={element.bounds.width - 10 * scale}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
     />
   </FlowchartComponent>
 );
@@ -32,4 +32,5 @@ export const FlowchartFunctionCallComponent: FunctionComponent<Props> = ({ eleme
 export interface Props {
   element: FlowchartFunctionCall;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/flowchart/flowchart-input-output/flowchart-input-output-component.tsx
+++ b/src/main/packages/flowchart/flowchart-input-output/flowchart-input-output-component.tsx
@@ -3,14 +3,14 @@ import { FlowchartComponent } from '../flowchart-element/flowchart-component';
 import { FlowchartInputOutput } from './flowchart-input-output';
 import { ThemedPolyline } from '../../../components/theme/themedComponents';
 
-export const FlowchartInputOutputComponent: FunctionComponent<Props> = ({ element, scale }) => (
+export const FlowchartInputOutputComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => (
   <FlowchartComponent element={element} scale={scale}>
     <ThemedPolyline
       points={`${1.1 * element.bounds.width} 0, ${0.9 * element.bounds.width} ${element.bounds.height}, ${
         -0.1 * element.bounds.width
       } ${element.bounds.height}, ${0.1 * element.bounds.width} 0, ${1.1 * element.bounds.width} 0`}
       strokeColor={element.strokeColor}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
     />
   </FlowchartComponent>
 );
@@ -18,4 +18,5 @@ export const FlowchartInputOutputComponent: FunctionComponent<Props> = ({ elemen
 export interface Props {
   element: FlowchartInputOutput;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/flowchart/flowchart-process/flowchart-process-component.tsx
+++ b/src/main/packages/flowchart/flowchart-process/flowchart-process-component.tsx
@@ -3,13 +3,19 @@ import { FlowchartComponent } from '../flowchart-element/flowchart-component';
 import { FlowchartProcess } from './flowchart-process';
 import { ThemedRect } from '../../../components/theme/themedComponents';
 
-export const FlowchartProcessComponent: FunctionComponent<Props> = ({ element, scale }) => (
+export const FlowchartProcessComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => (
   <FlowchartComponent element={element} scale={scale}>
-    <ThemedRect width="100%" height="100%" strokeColor={element.strokeColor} fillColor={element.fillColor} />
+    <ThemedRect
+      width="100%"
+      height="100%"
+      strokeColor={element.strokeColor}
+      fillColor={fillColor || element.fillColor}
+    />
   </FlowchartComponent>
 );
 
 export interface Props {
   element: FlowchartProcess;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/flowchart/flowchart-terminal/flowchart-terminal-component.tsx
+++ b/src/main/packages/flowchart/flowchart-terminal/flowchart-terminal-component.tsx
@@ -3,10 +3,10 @@ import { FlowchartComponent } from '../flowchart-element/flowchart-component';
 import { FlowchartTerminal } from './flowchart-terminal';
 import { ThemedRect } from '../../../components/theme/themedComponents';
 
-export const FlowchartTerminalComponent: FunctionComponent<Props> = ({ element, scale }) => (
+export const FlowchartTerminalComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => (
   <FlowchartComponent element={element} scale={scale}>
     <ThemedRect
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
       rx={10 * scale}
       ry={10 * scale}
       width="100%"
@@ -19,4 +19,5 @@ export const FlowchartTerminalComponent: FunctionComponent<Props> = ({ element, 
 export interface Props {
   element: FlowchartTerminal;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/syntax-tree/syntax-tree-nonterminal/syntax-tree-nonterminal-component.tsx
+++ b/src/main/packages/syntax-tree/syntax-tree-nonterminal/syntax-tree-nonterminal-component.tsx
@@ -3,7 +3,7 @@ import { Multiline } from '../../../utils/svg/multiline';
 import { SyntaxTreeNonterminal } from './syntax-tree-nonterminal';
 import { ThemedRect } from '../../../components/theme/themedComponents';
 
-export const SyntaxTreeNonterminalComponent: FunctionComponent<Props> = ({ element, scale }) => (
+export const SyntaxTreeNonterminalComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => (
   <g>
     <ThemedRect
       rx={10 * scale}
@@ -11,7 +11,7 @@ export const SyntaxTreeNonterminalComponent: FunctionComponent<Props> = ({ eleme
       width="100%"
       height="100%"
       strokeColor={element.strokeColor}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
     />
     <Multiline
       x={element.bounds.width / 2}
@@ -31,4 +31,5 @@ export const SyntaxTreeNonterminalComponent: FunctionComponent<Props> = ({ eleme
 export interface Props {
   element: SyntaxTreeNonterminal;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal-component.tsx
+++ b/src/main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal-component.tsx
@@ -3,9 +3,14 @@ import { Multiline } from '../../../utils/svg/multiline';
 import { SyntaxTreeTerminal } from './syntax-tree-terminal';
 import { ThemedRect } from '../../../components/theme/themedComponents';
 
-export const SyntaxTreeTerminalComponent: FunctionComponent<Props> = ({ element, scale }) => (
+export const SyntaxTreeTerminalComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => (
   <g>
-    <ThemedRect width="100%" height="100%" strokeColor={element.strokeColor} fillColor={element.fillColor} />
+    <ThemedRect
+      width="100%"
+      height="100%"
+      strokeColor={element.strokeColor}
+      fillColor={fillColor || element.fillColor}
+    />
     <Multiline
       x={element.bounds.width / 2}
       y={element.bounds.height / 2}
@@ -24,4 +29,5 @@ export const SyntaxTreeTerminalComponent: FunctionComponent<Props> = ({ element,
 export interface Props {
   element: SyntaxTreeTerminal;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/uml-activity-diagram/uml-activity-action-node/uml-activity-action-node-component.tsx
+++ b/src/main/packages/uml-activity-diagram/uml-activity-action-node/uml-activity-action-node-component.tsx
@@ -3,7 +3,7 @@ import { Multiline } from '../../../utils/svg/multiline';
 import { UMLActivityActionNode } from './uml-activity-action-node';
 import { ThemedRect } from '../../../components/theme/themedComponents';
 
-export const UMLActivityActionNodeComponent: FunctionComponent<Props> = ({ element, scale }) => (
+export const UMLActivityActionNodeComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => (
   <g>
     <ThemedRect
       rx={10 * scale}
@@ -11,7 +11,7 @@ export const UMLActivityActionNodeComponent: FunctionComponent<Props> = ({ eleme
       width="100%"
       height="100%"
       strokeColor={element.strokeColor}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
     />
     <Multiline
       x={element.bounds.width / 2}
@@ -29,4 +29,5 @@ export const UMLActivityActionNodeComponent: FunctionComponent<Props> = ({ eleme
 interface Props {
   element: UMLActivityActionNode;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/uml-activity-diagram/uml-activity-merge-node/uml-activity-merge-node-component.tsx
+++ b/src/main/packages/uml-activity-diagram/uml-activity-merge-node/uml-activity-merge-node-component.tsx
@@ -3,14 +3,14 @@ import { Multiline } from '../../../utils/svg/multiline';
 import { UMLActivityMergeNode } from './uml-activity-merge-node';
 import { ThemedPolyline } from '../../../components/theme/themedComponents';
 
-export const UMLActivityMergeNodeComponent: FunctionComponent<Props> = ({ element }) => (
+export const UMLActivityMergeNodeComponent: FunctionComponent<Props> = ({ element, fillColor }) => (
   <g>
     <ThemedPolyline
       points={`${element.bounds.width / 2} 0, ${element.bounds.width} ${element.bounds.height / 2}, ${
         element.bounds.width / 2
       } ${element.bounds.height}, 0 ${element.bounds.height / 2}, ${element.bounds.width / 2} 0`}
       strokeColor={element.strokeColor}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
     />
     <Multiline
       x={element.bounds.width / 2}
@@ -27,4 +27,5 @@ export const UMLActivityMergeNodeComponent: FunctionComponent<Props> = ({ elemen
 
 interface Props {
   element: UMLActivityMergeNode;
+  fillColor?: string;
 }

--- a/src/main/packages/uml-activity-diagram/uml-activity-object-node/uml-activity-object-node-component.tsx
+++ b/src/main/packages/uml-activity-diagram/uml-activity-object-node/uml-activity-object-node-component.tsx
@@ -3,9 +3,14 @@ import { Multiline } from '../../../utils/svg/multiline';
 import { UMLActivityObjectNode } from './uml-activity-object-node';
 import { ThemedRect } from '../../../components/theme/themedComponents';
 
-export const UMLActivityObjectNodeComponent: FunctionComponent<Props> = ({ element }) => (
+export const UMLActivityObjectNodeComponent: FunctionComponent<Props> = ({ element, fillColor }) => (
   <g>
-    <ThemedRect width="100%" height="100%" fillColor={element.fillColor} strokeColor={element.strokeColor} />
+    <ThemedRect
+      width="100%"
+      height="100%"
+      fillColor={fillColor || element.fillColor}
+      strokeColor={element.strokeColor}
+    />
     <Multiline
       x={element.bounds.width / 2}
       y={element.bounds.height / 2}
@@ -21,4 +26,5 @@ export const UMLActivityObjectNodeComponent: FunctionComponent<Props> = ({ eleme
 
 interface Props {
   element: UMLActivityObjectNode;
+  fillColor?: string;
 }

--- a/src/main/packages/uml-activity-diagram/uml-activity/uml-activity-component.tsx
+++ b/src/main/packages/uml-activity-diagram/uml-activity/uml-activity-component.tsx
@@ -3,7 +3,7 @@ import { Text } from '../../../components/controls/text/text';
 import { UMLActivity } from './uml-activity';
 import { ThemedRect } from '../../../components/theme/themedComponents';
 
-export const UMLActivityComponent: FunctionComponent<Props> = ({ element, children, scale }) => (
+export const UMLActivityComponent: FunctionComponent<Props> = ({ element, children, scale, fillColor }) => (
   <g>
     <ThemedRect
       rx={10 * scale}
@@ -11,7 +11,7 @@ export const UMLActivityComponent: FunctionComponent<Props> = ({ element, childr
       width="100%"
       height="100%"
       strokeColor={element.strokeColor}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
     />
     <Text y={20 * scale} fill={element.textColor}>
       {element.name}
@@ -23,4 +23,5 @@ export const UMLActivityComponent: FunctionComponent<Props> = ({ element, childr
 interface Props {
   element: UMLActivity;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/uml-class-diagram/uml-class-package/uml-class-package-component.tsx
+++ b/src/main/packages/uml-class-diagram/uml-class-package/uml-class-package-component.tsx
@@ -2,20 +2,20 @@ import React, { FunctionComponent } from 'react';
 import { UMLClassPackage } from './uml-class-package';
 import { ThemedRect, ThemedPath } from '../../../components/theme/themedComponents';
 
-export const UMLClassPackageComponent: FunctionComponent<Props> = ({ element, children, scale }) => (
+export const UMLClassPackageComponent: FunctionComponent<Props> = ({ element, children, scale, fillColor }) => (
   <g>
     <ThemedPath
       style={{ transform: `scale(${scale})` }}
       d={`M 0 10 V 0 H 40 V 10`}
       strokeColor={element.strokeColor}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
     />
     <ThemedRect
       y={10 * scale}
       width="100%"
       height={element.bounds.height - 10 * scale}
       strokeColor={element.strokeColor}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
     />
     <text
       x="50%"
@@ -35,4 +35,5 @@ export const UMLClassPackageComponent: FunctionComponent<Props> = ({ element, ch
 interface Props {
   element: UMLClassPackage;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/uml-deployment-diagram/uml-deployment-artifact/uml-deployment-artifact-component.tsx
+++ b/src/main/packages/uml-deployment-diagram/uml-deployment-artifact/uml-deployment-artifact-component.tsx
@@ -3,16 +3,21 @@ import { Text } from '../../../components/controls/text/text';
 import { UMLDeploymentArtifact } from './uml-deployment-artifact';
 import { ThemedPath, ThemedRect } from '../../../components/theme/themedComponents';
 
-export const UMLDeploymentArtifactComponent: FunctionComponent<Props> = ({ element, scale }) => (
+export const UMLDeploymentArtifactComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => (
   <g>
-    <ThemedRect width="100%" height="100%" strokeColor={element.strokeColor} fillColor={element.fillColor} />
+    <ThemedRect
+      width="100%"
+      height="100%"
+      strokeColor={element.strokeColor}
+      fillColor={fillColor || element.fillColor}
+    />
     <Text y={28 * scale} dominantBaseline="auto" fill={element.textColor}>
       {element.name}
     </Text>
     <g transform={`translate(${element.bounds.width - 26 * scale}, ${7 * scale}) scale(${scale})`}>
       <ThemedPath
         d="M 0 0 L 13 0 L 19.2 7.25 L 19.2 24 L 0 24 L 0 0 Z"
-        fillColor={element.fillColor}
+        fillColor={fillColor || element.fillColor}
         strokeColor={element.strokeColor}
         strokeWidth="1.2"
         strokeMiterlimit="10"
@@ -31,4 +36,5 @@ export const UMLDeploymentArtifactComponent: FunctionComponent<Props> = ({ eleme
 interface Props {
   element: UMLDeploymentArtifact;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/uml-deployment-diagram/uml-deployment-node/uml-deployment-node-component.tsx
+++ b/src/main/packages/uml-deployment-diagram/uml-deployment-node/uml-deployment-node-component.tsx
@@ -3,20 +3,20 @@ import { Text } from '../../../components/controls/text/text';
 import { UMLDeploymentNode } from './uml-deployment-node';
 import { ThemedPath, ThemedRect } from '../../../components/theme/themedComponents';
 
-export const UMLDeploymentNodeComponent: FunctionComponent<Props> = ({ element, children, scale }) => (
+export const UMLDeploymentNodeComponent: FunctionComponent<Props> = ({ element, children, scale, fillColor }) => (
   <g>
     <g>
       <ThemedPath
         d={`M 0 ${8 * scale} l ${8 * scale} -${8 * scale} H ${element.bounds.width} l -${8 * scale} ${8 * scale} Z`}
         strokeColor={element.strokeColor}
-        fillColor={element.fillColor}
+        fillColor={fillColor || element.fillColor}
       />
       <ThemedPath
         d={`M ${element.bounds.width} 0 V ${element.bounds.height - 8 * scale} l -${8 * scale} ${8 * scale} V ${
           8 * scale
         } Z`}
         strokeColor={element.strokeColor}
-        fillColor={element.fillColor}
+        fillColor={fillColor || element.fillColor}
       />
       <ThemedRect
         x="0"
@@ -24,7 +24,7 @@ export const UMLDeploymentNodeComponent: FunctionComponent<Props> = ({ element, 
         width={element.bounds.width - 8 * scale}
         height={element.bounds.height - 9 * scale}
         strokeColor={element.strokeColor}
-        fillColor={element.fillColor}
+        fillColor={fillColor || element.fillColor}
       />
     </g>
     <Text y={30 * scale} fill={element.textColor}>
@@ -44,4 +44,5 @@ export const UMLDeploymentNodeComponent: FunctionComponent<Props> = ({ element, 
 interface Props {
   element: UMLDeploymentNode;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/uml-petri-net/uml-petri-net-place/uml-petri-net-place-component.tsx
+++ b/src/main/packages/uml-petri-net/uml-petri-net-place/uml-petri-net-place-component.tsx
@@ -52,7 +52,15 @@ export const UMLPetriNetPlaceComponent: FunctionComponent<Props> = ({ element, s
   }
   return (
     <g>
-      <ThemedCircle cx="50%" cy="50%" r={radius} strokeColor={element.strokeColor} strokeWidth={2} fillColor={fillColor || element.fillColor} fillOpacity={1} />
+      <ThemedCircle
+        cx="50%"
+        cy="50%"
+        r={radius}
+        strokeColor={element.strokeColor}
+        strokeWidth={2}
+        fillColor={fillColor || element.fillColor}
+        fillOpacity={1}
+      />
       {!displayTokenAsNumber &&
         tokenPositions.map((position, index) => (
           <ThemedCircleContrast

--- a/src/main/packages/uml-petri-net/uml-petri-net-place/uml-petri-net-place-component.tsx
+++ b/src/main/packages/uml-petri-net/uml-petri-net-place/uml-petri-net-place-component.tsx
@@ -34,7 +34,7 @@ const calculatePositions = (amountOfTokens: number, outerRadius: number, scale: 
   return positions;
 };
 
-export const UMLPetriNetPlaceComponent: FunctionComponent<Props> = ({ element, scale }) => {
+export const UMLPetriNetPlaceComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => {
   // radius of the outer circle
   const radius = Math.min(element.bounds.width, element.bounds.height) / 2;
   const displayTokenAsNumber = element.amountOfTokens > 0 && element.amountOfTokens > maxAmountCircles;
@@ -52,7 +52,7 @@ export const UMLPetriNetPlaceComponent: FunctionComponent<Props> = ({ element, s
   }
   return (
     <g>
-      <ThemedCircle cx="50%" cy="50%" r={radius} strokeColor={element.strokeColor} strokeWidth={2} fillOpacity={1} />
+      <ThemedCircle cx="50%" cy="50%" r={radius} strokeColor={element.strokeColor} strokeWidth={2} fillColor={fillColor || element.fillColor} fillOpacity={1} />
       {!displayTokenAsNumber &&
         tokenPositions.map((position, index) => (
           <ThemedCircleContrast
@@ -81,4 +81,5 @@ export const UMLPetriNetPlaceComponent: FunctionComponent<Props> = ({ element, s
 interface Props {
   element: UMLPetriNetPlace;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/uml-petri-net/uml-petri-net-transition/uml-petri-net-transition-component.tsx
+++ b/src/main/packages/uml-petri-net/uml-petri-net-transition/uml-petri-net-transition-component.tsx
@@ -3,7 +3,7 @@ import { Text } from '../../../components/controls/text/text';
 import { UMLPetriNetTransition } from './uml-petri-net-transition';
 import { ThemedRect } from '../../../components/theme/themedComponents';
 
-export const UMLPetriNetTransitionComponent: FunctionComponent<Props> = ({ element, scale }) => (
+export const UMLPetriNetTransitionComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => (
   <g>
     <Text y={-15 * scale} fill={element.textColor}>
       {element.name}
@@ -12,7 +12,7 @@ export const UMLPetriNetTransitionComponent: FunctionComponent<Props> = ({ eleme
       width={element.bounds.width}
       height={element.bounds.height}
       strokeColor={element.strokeColor}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
       strokeWidth={2 * scale}
       fillOpacity={1}
     />
@@ -22,4 +22,5 @@ export const UMLPetriNetTransitionComponent: FunctionComponent<Props> = ({ eleme
 interface Props {
   element: UMLPetriNetTransition;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-component.tsx
+++ b/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-component.tsx
@@ -3,7 +3,7 @@ import { UMLReachabilityGraphMarking } from './uml-reachability-graph-marking';
 import { Multiline } from '../../../utils/svg/multiline';
 import { ThemedRect, ThemedPath, ThemedPolyline } from '../../../components/theme/themedComponents';
 
-export const UMLReachabilityGraphMarkingComponent: FunctionComponent<Props> = ({ element, scale }) => (
+export const UMLReachabilityGraphMarkingComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => (
   <g>
     <ThemedRect
       rx={10 * scale}
@@ -11,7 +11,7 @@ export const UMLReachabilityGraphMarkingComponent: FunctionComponent<Props> = ({
       width="100%"
       height="100%"
       strokeColor={element.strokeColor}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
     />
     <Multiline
       x={element.bounds.width / 2}
@@ -58,4 +58,5 @@ export const UMLReachabilityGraphMarkingComponent: FunctionComponent<Props> = ({
 interface Props {
   element: UMLReachabilityGraphMarking;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/uml-use-case-diagram/uml-use-case-actor/uml-use-case-actor-component.tsx
+++ b/src/main/packages/uml-use-case-diagram/uml-use-case-actor/uml-use-case-actor-component.tsx
@@ -3,7 +3,7 @@ import { Text } from '../../../components/controls/text/text';
 import { UMLUseCaseActor } from './uml-use-case-actor';
 import { ThemedCircle, ThemedLine } from '../../../components/theme/themedComponents';
 
-export const UMLUseCaseActorComponent: FunctionComponent<Props> = ({ element, scale }) => (
+export const UMLUseCaseActorComponent: FunctionComponent<Props> = ({ element, scale, fillColor }) => (
   <g>
     <rect width="100%" height="100%" fill="none" />
     <g stroke={element.strokeColor || 'black'} strokeWidth={2}>
@@ -11,7 +11,7 @@ export const UMLUseCaseActorComponent: FunctionComponent<Props> = ({ element, sc
         cx={45 * scale}
         cy={25 * scale}
         r={15 * scale}
-        fillColor={element.fillColor}
+        fillColor={fillColor || element.fillColor}
         strokeColor={element.fillColor}
       />
       <ThemedLine x1={45 * scale} y1={40 * scale} x2={45 * scale} y2={80 * scale} strokeColor={element.fillColor} />
@@ -28,4 +28,5 @@ export const UMLUseCaseActorComponent: FunctionComponent<Props> = ({ element, sc
 interface Props {
   element: UMLUseCaseActor;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/uml-use-case-diagram/uml-use-case-system/uml-use-case-system-component.tsx
+++ b/src/main/packages/uml-use-case-diagram/uml-use-case-system/uml-use-case-system-component.tsx
@@ -3,9 +3,14 @@ import { Text } from '../../../components/controls/text/text';
 import { UMLUseCaseSystem } from './uml-use-case-system';
 import { ThemedRect } from '../../../components/theme/themedComponents';
 
-export const UMLUseCaseSystemComponent: FunctionComponent<Props> = ({ element, children, scale }) => (
+export const UMLUseCaseSystemComponent: FunctionComponent<Props> = ({ element, children, scale, fillColor }) => (
   <g>
-    <ThemedRect width="100%" height="100%" strokeColor={element.strokeColor} />
+    <ThemedRect
+      width="100%"
+      height="100%"
+      fillColor={fillColor || element.fillColor}
+      strokeColor={element.strokeColor}
+    />
     <Text fill={element.textColor} y={16 * scale}>
       {element.name}
     </Text>
@@ -16,4 +21,5 @@ export const UMLUseCaseSystemComponent: FunctionComponent<Props> = ({ element, c
 interface Props {
   element: UMLUseCaseSystem;
   scale: number;
+  fillColor?: string;
 }

--- a/src/main/packages/uml-use-case-diagram/uml-use-case/uml-use-case-component.tsx
+++ b/src/main/packages/uml-use-case-diagram/uml-use-case/uml-use-case-component.tsx
@@ -3,7 +3,7 @@ import { Text } from '../../../components/controls/text/text';
 import { UMLUseCase } from './uml-use-case';
 import { ThemedEllipse } from '../../../components/theme/themedComponents';
 
-export const UMLUseCaseComponent: FunctionComponent<Props> = ({ element }) => (
+export const UMLUseCaseComponent: FunctionComponent<Props> = ({ element, fillColor }) => (
   <g>
     <ThemedEllipse
       cx="50%"
@@ -11,7 +11,7 @@ export const UMLUseCaseComponent: FunctionComponent<Props> = ({ element }) => (
       rx="50%"
       ry="50%"
       strokeColor={element.strokeColor}
-      fillColor={element.fillColor}
+      fillColor={fillColor || element.fillColor}
     />
     <Text fill={element.textColor}>{element.name}</Text>
   </g>
@@ -19,4 +19,5 @@ export const UMLUseCaseComponent: FunctionComponent<Props> = ({ element }) => (
 
 interface Props {
   element: UMLUseCase;
+  fillColor?: string;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
This PR fixes issues with the styling of elements in interactive mode.
This feature is used in Artemis while creating a drag/drop Model Quiz.

### Description
Elements are now highlighted accordingly while hovering/selecting elements in interactive mode.

### Steps for Testing
1. Clone the repo
2. Checkout to `bugfix/interactive-elements-fix` branch
3. Start the application by executing `yarn install` followed by `yarn start` command.
4. Insert few elements in the canvas and switch to interactive mode by clicking on "interactive" button (as illustrated in screenshot section)
5. Make sure that all the elements are highlighted properly while hovering and selecting/deselecting them.


### Screenshots
#### Before
![screen-capture (17)](https://user-images.githubusercontent.com/14681902/184962696-e34b1690-d4c5-47ce-b234-cfc8e41aef14.gif)

#### After
![screen-capture (18)](https://user-images.githubusercontent.com/14681902/184962735-159598b2-3066-4903-b73a-527afc28b61f.gif)

