### PR TITLE
`Development`: Disable manual layout waypoints in readonly mode

### DIFF
--- a/src/main/components/uml-element/canvas-relationship.tsx
+++ b/src/main/components/uml-element/canvas-relationship.tsx
@@ -26,6 +26,7 @@ type StateProps = {
   relationship: IUMLRelationship;
   mode: ApollonMode;
   scale: number;
+  readonly: boolean;
 };
 
 type DispatchProps = {
@@ -61,6 +62,7 @@ const enhance = compose<ComponentClass<OwnProps>>(
       relationship: state.elements[props.id] as IUMLRelationship,
       mode: state.editor.mode as ApollonMode,
       scale: state.editor.scale || 1.0,
+      readonly: state.editor.readonly || false,
     }),
     {
       startwaypointslayout: UMLRelationshipRepository.startWaypointsLayout,
@@ -85,6 +87,7 @@ export class CanvasRelationshipComponent extends Component<Props, State> {
       theme,
       mode,
       scale,
+      readonly,
       startwaypointslayout,
       endwaypointslayout,
       ...props
@@ -131,8 +134,8 @@ export class CanvasRelationshipComponent extends Component<Props, State> {
         {midPoints.map((point, index) => {
           return (
             <circle
-              visibility={interactive || interactable ? 'hidden' : undefined}
-              pointerEvents={interactive || interactable ? 'none' : 'all'}
+              visibility={interactive || interactable || readonly ? 'hidden' : undefined}
+              pointerEvents={interactive || interactable || readonly ? 'none' : 'all'}
               style={{ cursor: 'grab' }}
               key={props.id + '_' + point.mpX + '_' + point.mpY}
               cx={point.mpX}


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes


### Motivation and Context
This PR restricts users to layout connections of diagrams manually while in read-only mode.

### Description
Issue Number: https://github.com/ls1intum/Apollon/issues/259

### Steps for Testing
1. Clone the repo
2. Checkout to branch `bugfix/disable-manual-waypoint-readonly-mode`
3. Start the application by executing `yarn install` followed by `yarn start`
4. Insert any two elements and connect them in the canvas.
5. Click on read-only mode from side menu bar
6. Hover on the connector and make sure that manual layout waypoint is not visible

### Screenshots
![screen-capture (11)](https://user-images.githubusercontent.com/14681902/185896199-232ed8d8-d635-4a0a-831b-db00694729d0.gif)



