### PR TITLE
`Development`: Enhance appearance of required interface connector

### DIFF
--- a/src/main/packages/common/uml-interface-required/uml-interface-required-component.tsx
+++ b/src/main/packages/common/uml-interface-required/uml-interface-required-component.tsx
@@ -4,7 +4,7 @@ import { ModelState } from '../../../components/store/model-state';
 import { UMLInterfaceRequired } from './uml-interface-required';
 import { Direction, getOppositeDirection } from '../../../services/uml-element/uml-element-port';
 import { Point } from '../../../utils/geometry/point';
-import { REQUIRED_INTERFACE_MARKER_SIZE } from './uml-interface-requires-constants';
+import { REQUIRED_INTERFACE_MARKER_SIZE, REQUIRED_INTERFACE_MARKER_TYPE } from './uml-interface-requires-constants';
 import { ThemedPath, ThemedPolyline } from '../../../components/theme/themedComponents';
 
 type OwnProps = {
@@ -14,6 +14,7 @@ type OwnProps = {
 type StateProps = {
   hasOppositeRequiredInterface: boolean;
   currentRequiredInterfaces: UMLInterfaceRequired[];
+  currentAllInterfaces: any;
 };
 type DispatchProps = {};
 
@@ -39,11 +40,14 @@ const enhance = connect<StateProps, DispatchProps, OwnProps, ModelState>((state,
     currentRequiredInterfaces: requiredInterfaces.filter(
       (element) => element.target.element === props.element.target.element,
     ),
+    currentAllInterfaces: state.diagram.ownedRelationships
+      .map((relationshipId) => state.elements[relationshipId])
+      .filter((element: any) => element.target.element === props.element.target.element),
   };
 }, {});
 
 const UMLInterfaceRequiredC: FunctionComponent<Props> = (props: Props) => {
-  const { element, hasOppositeRequiredInterface, currentRequiredInterfaces, scale } = props;
+  const { element, hasOppositeRequiredInterface, currentRequiredInterfaces, currentAllInterfaces, scale } = props;
 
   // offset for last point in paragraph, so that line ends at marker
   let offset: Point;
@@ -66,15 +70,20 @@ const UMLInterfaceRequiredC: FunctionComponent<Props> = (props: Props) => {
     let path = '';
     switch (currentRequiredInterfaces.length) {
       case 1:
-        path = `M 13 -13.5 a 13 13 0 0 0 0 27`;
+        path =
+          currentAllInterfaces.length === currentRequiredInterfaces.length
+            ? REQUIRED_INTERFACE_MARKER_TYPE.Semicircle
+            : REQUIRED_INTERFACE_MARKER_TYPE.Threequarterscircle;
         break;
 
       case 2:
-        path = hasOppositeRequiredInterface ? `M 8 -12.5 a 13 13 0 0 0 0 25` : `M 2 -8 a 13 13 0 0 0 0 16`;
+        path = hasOppositeRequiredInterface
+          ? REQUIRED_INTERFACE_MARKER_TYPE.Threequarterscircle
+          : REQUIRED_INTERFACE_MARKER_TYPE.Quartercircle;
         break;
 
       default:
-        path = `M 2 -8 a 13 13 0 0 0 0 16`;
+        path = REQUIRED_INTERFACE_MARKER_TYPE.Quartercircle;
         break;
     }
 

--- a/src/main/packages/common/uml-interface-required/uml-interface-required-component.tsx
+++ b/src/main/packages/common/uml-interface-required/uml-interface-required-component.tsx
@@ -13,6 +13,7 @@ type OwnProps = {
 };
 type StateProps = {
   hasOppositeRequiredInterface: boolean;
+  currentRequiredInterfaces: UMLInterfaceRequired[];
 };
 type DispatchProps = {};
 
@@ -35,11 +36,14 @@ const enhance = connect<StateProps, DispatchProps, OwnProps, ModelState>((state,
           otherRequiredInterface.target.direction.valueOf() ===
             getOppositeDirection(props.element.target.direction).valueOf(),
       ),
+    currentRequiredInterfaces: requiredInterfaces.filter(
+      (element) => element.target.element === props.element.target.element,
+    ),
   };
 }, {});
 
 const UMLInterfaceRequiredC: FunctionComponent<Props> = (props: Props) => {
-  const { element, hasOppositeRequiredInterface, scale } = props;
+  const { element, hasOppositeRequiredInterface, currentRequiredInterfaces, scale } = props;
 
   // offset for last point in paragraph, so that line ends at marker
   let offset: Point;
@@ -58,6 +62,25 @@ const UMLInterfaceRequiredC: FunctionComponent<Props> = (props: Props) => {
       break;
   }
 
+  const calculatePath = () => {
+    let path = '';
+    switch (currentRequiredInterfaces.length) {
+      case 1:
+        path = `M 13 -13.5 a 13 13 0 0 0 0 27`;
+        break;
+
+      case 2:
+        path = hasOppositeRequiredInterface ? `M 8 -12.5 a 13 13 0 0 0 0 25` : `M 2 -8 a 13 13 0 0 0 0 16`;
+        break;
+
+      default:
+        path = `M 2 -8 a 13 13 0 0 0 0 16`;
+        break;
+    }
+
+    return path;
+  };
+
   return (
     <g>
       <marker
@@ -71,16 +94,7 @@ const UMLInterfaceRequiredC: FunctionComponent<Props> = (props: Props) => {
         markerUnits="strokeWidth"
       >
         {/*M -> Move to, A -> Arc radiusX, radiusY, x-axis-rotation, bow-flag, endpointX,endpointY */}
-        <ThemedPath
-          d={`M ${Math.floor(REQUIRED_INTERFACE_MARKER_SIZE / 2) - (hasOppositeRequiredInterface ? 5 : 0)} -${
-            (REQUIRED_INTERFACE_MARKER_SIZE - (hasOppositeRequiredInterface ? 2 : 0)) / 2
-          } a ${Math.floor(REQUIRED_INTERFACE_MARKER_SIZE / 2)},${Math.floor(
-            REQUIRED_INTERFACE_MARKER_SIZE / 2,
-          )} 0 0 0 0,${REQUIRED_INTERFACE_MARKER_SIZE - (hasOppositeRequiredInterface ? 2 : 0)}`}
-          fillColor="none"
-          strokeColor={element.strokeColor}
-          strokeWidth={2 * scale}
-        />
+        <ThemedPath d={calculatePath()} fillColor="none" strokeColor={element.strokeColor} strokeWidth={2 * scale} />
       </marker>
       <ThemedPolyline
         points={element.path

--- a/src/main/packages/common/uml-interface-required/uml-interface-requires-constants.ts
+++ b/src/main/packages/common/uml-interface-required/uml-interface-requires-constants.ts
@@ -1,1 +1,7 @@
 export const REQUIRED_INTERFACE_MARKER_SIZE = 27;
+
+export const enum REQUIRED_INTERFACE_MARKER_TYPE {
+  Semicircle = `M 13 -13.5 a 13 13 0 0 0 0 27`,
+  Threequarterscircle = `M 8 -12.5 a 13 13 0 0 0 0 25`,
+  Quartercircle = `M 2 -8 a 13 13 0 0 0 0 16`,
+}

--- a/src/tests/unit/packages/uml-component-diagram/uml-component-required-interface/__snapshots__/uml-component-required-interface-component-test.tsx.snap
+++ b/src/tests/unit/packages/uml-component-diagram/uml-component-required-interface/__snapshots__/uml-component-required-interface-component-test.tsx.snap
@@ -17,7 +17,7 @@ exports[`render the uml-component-required-interface-component 1`] = `
         >
           <path
             class="sc-gsnTZi iAPApG"
-            d="M 13 -13.5 a 13,13 0 0 0 0,27"
+            d="M 2 -8 a 13 13 0 0 0 0 16"
             fill="none"
             stroke="black"
             stroke-width="2"

--- a/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-required-interface/__snapshots__/uml-deployment-required-interface-component-test.tsx.snap
+++ b/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-required-interface/__snapshots__/uml-deployment-required-interface-component-test.tsx.snap
@@ -17,7 +17,7 @@ exports[`render the uml-deplyoment-required-interface-component 1`] = `
         >
           <path
             class="sc-gsnTZi iAPApG"
-            d="M 13 -13.5 a 13,13 0 0 0 0,27"
+            d="M 2 -8 a 13 13 0 0 0 0 16"
             fill="none"
             stroke="black"
             stroke-width="2"


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
- When an interface had multiple connectors, there used to be overlapping segments among the marker
- This PR fixes that issue and the marker of the required connector is adjusted accordingly based on the number of connectors connected to an interface, without any overlapping segments.

### Description
Implemented logic, for the case of :
- 1 connector,  marker takes 50% (is semi-circle)
- 2 connectors: 
     if connectors are opposite of each other, it takes ~40% percent each
     if not, it takes ~25% each (is a quarter circle)
- more than 2 connectors, marker takes ~25% percent each (is a quarter circle)


### Steps for Testing
#### In local machine

1. Clone the repo 
2. Checkout to branch `enhancement/required-interface-connectors`
3. Start the application by executing `yarn install` followed by `yarn start` command
4. Select Component Diagram in Diagram Type menu
5. Insert and connect a Component and Interface to the canvas
6. Change the association to `required interface` and observe that its layout changes based on the number of connectors connected to an interface (as illustrated in screenshot section)

### Screenshots
#### Before
![screen-capture (19)](https://user-images.githubusercontent.com/14681902/187650668-9d923985-7188-4503-9b0e-83563a85ae3e.gif)

#### After
![screen-capture (18)](https://user-images.githubusercontent.com/14681902/187649741-eca6a86b-bd62-43fb-b601-aac25376ab32.gif)



