### PR TITLE
`Development`: Fix issue with appearance of grid

### DIFF
--- a/public/themings.json
+++ b/public/themings.json
@@ -7,7 +7,8 @@
         "--apollon-background": "#ffffff",
         "--apollon-background-variant": "#e5e5e5",
         "--apollon-gray": "#e9ecef",
-        "--apollon-gray-variant": "#343a40"
+        "--apollon-gray-variant": "#343a40",
+        "--apollon-grid": "rgba(36, 39, 36, 0.1)"
     },
     "dark": {
         "--apollon-primary": "#51a2a2",
@@ -17,6 +18,7 @@
         "--apollon-background": "#1B2121",
         "--apollon-background-variant": "#3e4c4c",
         "--apollon-gray": "#343a40",
-        "--apollon-gray-variant": "#6c757d"
+        "--apollon-gray-variant": "#6c757d",
+        "--apollon-grid": "#3e4c4c"
     }
 }

--- a/src/main/components/canvas/editor.tsx
+++ b/src/main/components/canvas/editor.tsx
@@ -24,8 +24,8 @@ const StyledEditor = styled.div`
   background-position: calc(50% + ${(grid * subdivisions) / 2}px) calc(50% + ${(grid * subdivisions) / 2}px);
   background-size: ${grid * subdivisions}px ${grid * subdivisions}px, ${grid * subdivisions}px ${grid * subdivisions}px,
     ${grid}px ${grid}px, ${grid}px ${grid}px;
-  background-image: linear-gradient(to right, ${(props) => props.theme.color.backgroundVariant} 1px, transparent 1px),
-    linear-gradient(to bottom, ${(props) => props.theme.color.backgroundVariant} 1px, transparent 1px),
+  background-image: linear-gradient(to right, ${(props) => props.theme.color.grid} 1px, transparent 1px),
+    linear-gradient(to bottom, ${(props) => props.theme.color.grid} 1px, transparent 1px),
     linear-gradient(to right, ${(props) => props.theme.color.gray} 1px, transparent 1px),
     linear-gradient(to bottom, ${(props) => props.theme.color.gray} 1px, transparent 1px);
   background-repeat: repeat;

--- a/src/main/components/theme/styles.ts
+++ b/src/main/components/theme/styles.ts
@@ -18,6 +18,7 @@ const apollonTheme = {
     warningYellow: 'var(--apollon-warning-yellow, #ffc800)',
     background: 'var(--apollon-background, #ffffff)',
     backgroundVariant: 'var(--apollon-background-variant, #e5e5e5)',
+    grid: 'var(--apollon-grid, rgba(36, 39, 36, 0.1))',
     primaryContrast: 'var(--apollon-primary-contrast, #212529)',
     gray: 'var(--apollon-gray, #e9ecef)',
     grayAccent: 'var(--apollon-gray-variant, #343a40)',

--- a/src/tests/unit/components/update-pane/__snapshots__/update-pane-test.tsx.snap
+++ b/src/tests/unit/components/update-pane/__snapshots__/update-pane-test.tsx.snap
@@ -33,7 +33,7 @@ exports[`test update pane render with element 1`] = `
   border: 1px solid var(--apollon-gray,#e9ecef);
   background-position: calc(50% + 25px) calc(50% + 25px);
   background-size: 50px 50px,50px 50px, 10px 10px,10px 10px;
-  background-image: linear-gradient(to right,var(--apollon-background-variant,#e5e5e5) 1px,transparent 1px), linear-gradient(to bottom,var(--apollon-background-variant,#e5e5e5) 1px,transparent 1px), linear-gradient(to right,var(--apollon-gray,#e9ecef) 1px,transparent 1px), linear-gradient(to bottom,var(--apollon-gray,#e9ecef) 1px,transparent 1px);
+  background-image: linear-gradient(to right,var(--apollon-grid,rgba(36,39,36,0.1)) 1px,transparent 1px), linear-gradient(to bottom,var(--apollon-grid,rgba(36,39,36,0.1)) 1px,transparent 1px), linear-gradient(to right,var(--apollon-gray,#e9ecef) 1px,transparent 1px), linear-gradient(to bottom,var(--apollon-gray,#e9ecef) 1px,transparent 1px);
   background-repeat: repeat;
   background-attachment: local;
 }
@@ -607,7 +607,7 @@ exports[`test update pane render with relationship 1`] = `
   border: 1px solid var(--apollon-gray,#e9ecef);
   background-position: calc(50% + 25px) calc(50% + 25px);
   background-size: 50px 50px,50px 50px, 10px 10px,10px 10px;
-  background-image: linear-gradient(to right,var(--apollon-background-variant,#e5e5e5) 1px,transparent 1px), linear-gradient(to bottom,var(--apollon-background-variant,#e5e5e5) 1px,transparent 1px), linear-gradient(to right,var(--apollon-gray,#e9ecef) 1px,transparent 1px), linear-gradient(to bottom,var(--apollon-gray,#e9ecef) 1px,transparent 1px);
+  background-image: linear-gradient(to right,var(--apollon-grid,rgba(36,39,36,0.1)) 1px,transparent 1px), linear-gradient(to bottom,var(--apollon-grid,rgba(36,39,36,0.1)) 1px,transparent 1px), linear-gradient(to right,var(--apollon-gray,#e9ecef) 1px,transparent 1px), linear-gradient(to bottom,var(--apollon-gray,#e9ecef) 1px,transparent 1px);
   background-repeat: repeat;
   background-attachment: local;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] Release alpha version to test it in Artemis and Standalone


### Motivation and Context
This PR uses color of grid from `--apollon-grid` variable instead of `--apollon-background-variant` of Apollon.

### Description
As the grid of Apollon was using the same styling as the background of Apollon, changing its color resulted in a change of color of assessment/attributes insertion modal, causing it to be transparent.
This PR fixes this issue by separating color assignment for grid and Apollon background



### Testing
- Deploy [this ](https://bamboo.ase.in.tum.de/browse/ARTEMIS-WEBAPP4460) version to one of the test server of Artemis
- Create new Modeling Exercises by going to administration > Exercises > Create new Modeling Exercise
- Drag an Enumeration element (or any elements with multiple attributes) to the canvas.
- Double click on it and observe that the pop-up modal to edit attributes/methods is not transparent.
- Check it on both dark/light mode


### Description
This PR needs to be tested on Artemis or Standalone


### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/14681902/192091955-b27bb35d-8c07-4caa-82fc-9d77f03fe515.png)

#### After
![image](https://user-images.githubusercontent.com/14681902/192091910-40e52fc2-af3e-41f7-897b-96aeaf6c984e.png)
