### PR TITLE
`Development`: Fix issue with overflow of Text in the Color Description while exporting to PDF

### DIFF
--- a/src/main/utils/svg/multiline.tsx
+++ b/src/main/utils/svg/multiline.tsx
@@ -1,5 +1,4 @@
 import React, { Component, CSSProperties, SVGProps } from 'react';
-import { findDOMNode } from 'react-dom';
 
 const defaultProps = Object.freeze({
   x: 0 as number,
@@ -76,7 +75,7 @@ export class Multiline extends Component<Props, State> {
       divElem.innerHTML = str;
       Object.assign(divElem.style, style);
       const width = this.calculateStringWidth(divElem, (el: any) => {
-        return el.clientWidth;
+        return el.clientWidth + 2;
       });
 
       return width;

--- a/src/main/utils/svg/multiline.tsx
+++ b/src/main/utils/svg/multiline.tsx
@@ -32,6 +32,10 @@ export class Multiline extends Component<Props, State> {
   spaceWidth = 0;
   wordsWithComputedWidth = [] as { word: string; width: number }[];
 
+  componentWillMount() {
+    this.updateWordsByLines(this.props, true);
+  }
+
   componentDidMount() {
     this.updateWordsByLines(this.props, true);
   }
@@ -68,11 +72,6 @@ export class Multiline extends Component<Props, State> {
   getStringWidth(str: string, style?: CSSProperties): number {
     try {
       // Calculate length of each word to be used to determine number of words per line
-      const container = findDOMNode(this);
-      if (!container) {
-        return 0;
-      }
-
       const divElem = document.createElement('div');
       divElem.innerHTML = str;
       Object.assign(divElem.style, style);

--- a/src/main/utils/svg/multiline.tsx
+++ b/src/main/utils/svg/multiline.tsx
@@ -63,18 +63,7 @@ export class Multiline extends Component<Props, State> {
       if (!container) {
         return 0;
       }
-
-      const text = document.createElementNS('http://www.w3.org/2000/svg', 'tspan');
-      container.appendChild(text);
-
-      Object.assign(text.style, style);
-      text.textContent = str;
-      let width = text.getComputedTextLength();
-
-      container.removeChild(text);
-      if(width === 0) width = this.getTextSize(str);
-
-      return width;
+      return this.getTextSize(str);
     } catch (e) {
       return 0;
     }

--- a/src/main/utils/svg/multiline.tsx
+++ b/src/main/utils/svg/multiline.tsx
@@ -71,11 +71,11 @@ export class Multiline extends Component<Props, State> {
 
   getTextSize = (txt: string) => {
     const element = document.createElement('canvas');
-    const context = element.getContext("2d")!;
-    context.font = "17px Arial";
+    const context = element.getContext('2d')!;
+    context.font = '17px Arial';
     const width = context.measureText(txt).width;
     return width;
-  }
+  };
 
   updateWordsByLines(props: Readonly<Props>, needCalculate: boolean) {
     // Only perform calculations if using features that require them (multiline, scaleToFit)

--- a/src/main/utils/svg/multiline.tsx
+++ b/src/main/utils/svg/multiline.tsx
@@ -69,14 +69,23 @@ export class Multiline extends Component<Props, State> {
 
       Object.assign(text.style, style);
       text.textContent = str;
-      const width = text.getComputedTextLength();
+      let width = text.getComputedTextLength();
 
       container.removeChild(text);
+      if(width === 0) width = this.getTextSize(str);
 
       return width;
     } catch (e) {
       return 0;
     }
+  }
+
+  getTextSize = (txt: string) => {
+    const element = document.createElement('canvas');
+    const context = element.getContext("2d")!;
+    context.font = "17px Arial";
+    const width = context.measureText(txt).width;
+    return width;
   }
 
   updateWordsByLines(props: Readonly<Props>, needCalculate: boolean) {

--- a/src/tests/unit/packages/uml-reachability-graph/uml-reachability-graph-marking/__snapshots__/uml-reachability-graph-marking-component-test.tsx.snap
+++ b/src/tests/unit/packages/uml-reachability-graph/uml-reachability-graph-marking/__snapshots__/uml-reachability-graph-marking-component-test.tsx.snap
@@ -22,11 +22,7 @@ exports[`uml-reachability-graph-marking-component render the uml-reachability-gr
           width="200"
           x="100"
           y="50"
-        >
-          <tspan>
-             
-          </tspan>
-        </text>
+        />
       </g>
     </svg>
   </div>


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes


### Motivation and Context
This PR fixes the issue with overflow of text in color description while exporting the diagrams.
Issue Number: https://github.com/ls1intum/Apollon/issues/267

### Steps for Testing

1. Goto [test server](https://test1.apollon.ase.in.tum.de/)
2. Insert Color description to the canvas with long text.
3. Export the diagram to PDF (or any other format).
4. Observe that the text of the Color Description does not overflow. (As illustrated in screenshot section)


### Screenshots
#### Before 
![screen-capture](https://user-images.githubusercontent.com/14681902/199502075-53e51889-7e12-4e19-9c08-e41dc6a2b23c.gif)
#### After
![screen-capture (1)](https://user-images.githubusercontent.com/14681902/199503182-b64e5f40-403e-4b52-9ef3-36e1d5e61af4.gif)

PS: Changes released in beta version: [2.12.5-beta.4](https://www.npmjs.com/package/@ls1intum/apollon/v/2.12.5-beta.4)