### PR TITLE
`Development`: Fix issue with appearance of elements without attributes/methods having thicker bottom border

### DIFF
--- a/src/main/packages/common/uml-classifier/uml-classifier-component.tsx
+++ b/src/main/packages/common/uml-classifier/uml-classifier-component.tsx
@@ -48,8 +48,12 @@ export const UMLClassifierComponent: FunctionComponent<Props> = ({ element, scal
       )}
       {children}
       <ThemedRect width="100%" height="100%" strokeColor={element.strokeColor} fillColor="none" pointer-events="none" />
-      <ThemedPath d={`M 0 ${element.headerHeight} H ${element.bounds.width}`} strokeColor={element.strokeColor} />
-      <ThemedPath d={`M 0 ${element.deviderPosition} H ${element.bounds.width}`} strokeColor={element.strokeColor} />
+      {element.hasAttributes && (
+        <ThemedPath d={`M 0 ${element.headerHeight} H ${element.bounds.width}`} strokeColor={element.strokeColor} />
+      )}
+      {element.hasMethods && (
+        <ThemedPath d={`M 0 ${element.deviderPosition} H ${element.bounds.width}`} strokeColor={element.strokeColor} />
+      )}
     </g>
   );
 };

--- a/src/main/packages/common/uml-classifier/uml-classifier.ts
+++ b/src/main/packages/common/uml-classifier/uml-classifier.ts
@@ -16,6 +16,8 @@ export interface IUMLClassifier extends IUMLContainer {
   underline: boolean;
   stereotype: string | null;
   deviderPosition: number;
+  hasAttributes: boolean;
+  hasMethods: boolean;
 }
 
 export abstract class UMLClassifier extends UMLContainer implements IUMLClassifier {
@@ -31,6 +33,8 @@ export abstract class UMLClassifier extends UMLContainer implements IUMLClassifi
   underline: boolean = false;
   stereotype: string | null = null;
   deviderPosition: number = 0;
+  hasAttributes: boolean = false;
+  hasMethods: boolean = false;
 
   get headerHeight() {
     return this.stereotype ? UMLClassifier.stereotypeHeaderHeight : UMLClassifier.nonStereotypeHeaderHeight;
@@ -55,6 +59,9 @@ export abstract class UMLClassifier extends UMLContainer implements IUMLClassifi
   render(layer: ILayer, children: ILayoutable[] = []): ILayoutable[] {
     const attributes = children.filter((x): x is UMLClassifierAttribute => x instanceof UMLClassifierAttribute);
     const methods = children.filter((x): x is UMLClassifierMethod => x instanceof UMLClassifierMethod);
+
+    this.hasAttributes = attributes.length > 0;
+    this.hasMethods = methods.length > 0;
 
     const radix = 10;
     this.bounds.width = [this, ...attributes, ...methods].reduce(


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes


### Motivation and Context
Classifier elements (class, abstract, interface ...) without attributes and methods used to have thicker bottom border. (Illustrated in before subsection of the section screenshot).
This PR fixes the appearance of such elements by removing the thicker bottom border.

### Steps for Testing
1. Clone the repo and checkout to `enhancement/classifier-appearance` branch
2. Run the application by executing `yarn install` followed by `yarn start` command
3. Insert element class or abstract or interface into the canvas
4. Remove all the attributes/methods of the inserted element
5. Observe that the thick border is not present anymore (as illustrated in the screenshot).

### Screenshots
#### Before
<img width="907" alt="image" src="https://user-images.githubusercontent.com/14681902/207465597-7df3533c-a9bd-4f24-9372-a6e2f6d2576a.png">

#### After
![image](https://user-images.githubusercontent.com/14681902/207469249-0587147f-ffb4-456c-9b75-7afe49353b94.png)


