### PR TITLE
`Documentation`: Update documentation of Apollon

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,13 +20,13 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Apollon'
-copyright = '2020, Stephan Krusche'
+copyright = '2022, Stephan Krusche'
 author = 'Stephan Krusche'
 
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '2.0.6'
+release = '2.12.9'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/dev/adding-another-diagram-type.rst
+++ b/docs/source/dev/adding-another-diagram-type.rst
@@ -2,7 +2,7 @@
 Adding another diagram type
 ###########################
 
-Apollon currently has following diagram types.
+Apollon currently has the following diagram types.
 
 Diagram Types
 --------------
@@ -10,7 +10,7 @@ Diagram Types
 .. literalinclude:: api/diagram-type.d.ts
   :language: typescript
 
-To add new diagram type, add the new diagram type inside *src/main/packages/diagram-type.ts*.
+To add a new diagram type, add the new diagram type inside *src/main/packages/diagram-type.ts*.
 
 .. code-block:: typescript
 
@@ -64,8 +64,8 @@ and its update logic in *new-diagram-type-element-1-update.tsx*
 Once the above schema for new diagram is created, we will now import the created diagram elements type from *index.ts* to *uml-element-type.ts* (*src/main/packages/uml-element-type.ts*).
 Newly created elements are then imported to *uml-elements.ts*
 
-And finally, since Apollon supports two languages, English and German, the corresponding translation string of elements are defined in *src/main/i18n* folder.
-The german string is defined in *de.json* and english in *en.json*.
+And finally, since Apollon supports two languages, English and German, the corresponding translation strings of elements are defined in *src/main/i18n* folder.
+The German string is defined in *de.json* and English in *en.json*.
 
 Translation of newly added diagram type
 ----------------------------------------

--- a/docs/source/dev/adding-another-diagram-type.rst
+++ b/docs/source/dev/adding-another-diagram-type.rst
@@ -54,10 +54,10 @@ The tree structure of the project with the new diagram type will have schema as 
 The folder *new-diagram-type* contains all the elements of the new diagram type (*new-diagram-type-element-1*, *new-diagram-type-element-2*) along with *new-diagram-type-preview.tsx* class and *index.ts*.
 In *index.ts* we define an enum for all diagram elements.
 
-*new-diagram-type-preview.tsx* is a class which creates a preview of all available newly created diagram. 
+*new-diagram-type-preview.tsx* is a class which creates a preview of all available newly created diagrams. 
 This preview is used in the side-panel, which the user can use to drag new elements onto the canvas. 
 
-The visual representationof *new-diagram-type-element* is written in *new-diagram-type-element-1-component.tsx* (see :ref:`visual-representation-implementation-of-element`) 
+The visual representation of *new-diagram-type-element* is written in *new-diagram-type-element-1-component.tsx* (see :ref:`visual-representation-implementation-of-element`) 
 and its update logic in *new-diagram-type-element-1-update.tsx*
 *new-diagram-type-element-1.tsx* is a class extending *UMLElement*.
 

--- a/docs/source/dev/adding-another-diagram-type.rst
+++ b/docs/source/dev/adding-another-diagram-type.rst
@@ -1,5 +1,84 @@
-#############
+###########################
 Adding another diagram type
-#############
+###########################
 
-TODO
+Apollon currently has following diagram types.
+
+Diagram Types
+--------------
+
+.. literalinclude:: api/diagram-type.d.ts
+  :language: typescript
+
+To add new diagram type, add the new diagram type inside *src/main/packages/diagram-type.ts*.
+
+.. code-block:: typescript
+
+    export type UMLDiagramType = keyof typeof UMLDiagramType;
+    export const UMLDiagramType = {
+        ...
+        Flowchart: 'Flowchart',
+        NewDiagramType: 'NewDiagramType'
+    } as const;
+
+Once we register the new diagram type in *diagram-type.ts*, we will now create a new folder inside *src/main/packages*,  
+where all the elements of the new diagram type is defined.
+
+Structure of new diagram type in the project
+---------------------------------------------
+
+The tree structure of the project with the new diagram type will have schema as follows:
+
+.. code-block:: shell
+
+    |-- .github                                         
+    |-- docs                                            
+    |-- public                                         
+    |-- src                                             
+    |   |-- main                                  
+    |   |   |-- packages    
+    |   |   |   |-- new-diagram-type                                        # newly created diagram   
+    |   |   |   |   |-- index.ts                                            # defines an enum for all diagram element 
+    |   |   |   |   |-- new-diagram-type-preview.tsx                        # xxx-preview.tsx class 
+    |   |   |   |   |-- new-diagram-type-element-1                          # collection of UML Element 1 of Newly created diagram 
+    |   |   |   |   |   |-- new-diagram-type-element-1.tsx                  # element 1 of Newly created diagram 
+    |   |   |   |   |   |-- new-diagram-type-element-1-component.tsx        # visual representation of new-diagram-type-element-1 element  
+    |   |   |   |   |   |-- new-diagram-type-element-1-update.tsx           # update logic for new-diagram-type-element-1 element
+    |   |   |   |   |-- new-diagram-type-element-2                          # collection of UML Element 2 of Newly created diagram 
+    |   |   |   |   |-- ...
+    |   |   |   |-- common        
+    |   |   |   |-- flowchart
+    |   |   |   |-- syntax-tree
+    ...        
+
+The folder *new-diagram-type* contains all the elements of the new diagram type (*new-diagram-type-element-1*, *new-diagram-type-element-2*) along with *new-diagram-type-preview.tsx* class and *index.ts*.
+In *index.ts* we define an enum for all diagram elements.
+
+*new-diagram-type-preview.tsx* is a class which creates a preview of all available newly created diagram. 
+This preview is used in the side-panel, which the user can use to drag new elements onto the canvas. 
+
+The visual representationof *new-diagram-type-element* is written in *new-diagram-type-element-1-component.tsx* (see :ref:`visual-representation-implementation-of-element`) 
+and its update logic in *new-diagram-type-element-1-update.tsx*
+*new-diagram-type-element-1.tsx* is a class extending *UMLElement*.
+
+Once the above schema for new diagram is created, we will now import the created diagram elements type from *index.ts* to *uml-element-type.ts* (*src/main/packages/uml-element-type.ts*).
+Newly created elements are then imported to *uml-elements.ts*
+
+And finally, since Apollon supports two languages, English and German, the corresponding translation string of elements are defined in *src/main/i18n* folder.
+The german string is defined in *de.json* and english in *en.json*.
+
+Translation of newly added diagram type
+----------------------------------------
+Following is the illustration of how translation strings of newly created diagram type and its elements are defined.
+
+.. code-block:: json
+
+    {
+    "packages":{
+        "NewDiagramType":{
+            "NewDiagramTypeElement1":"NewDiagramTypeElement1",
+            "NewDiagramTypeElement2":"NewDiagramTypeElement2",
+            "NewDiagramTypeElementX":"NewDiagramTypeElementX",
+            }
+        }
+    }

--- a/docs/source/dev/api/diagram-type.d.ts
+++ b/docs/source/dev/api/diagram-type.d.ts
@@ -1,0 +1,14 @@
+export type UMLDiagramType = keyof typeof UMLDiagramType;
+export declare const UMLDiagramType: {
+    readonly ClassDiagram: "ClassDiagram";
+    readonly ObjectDiagram: "ObjectDiagram";
+    readonly ActivityDiagram: "ActivityDiagram";
+    readonly UseCaseDiagram: "UseCaseDiagram";
+    readonly CommunicationDiagram: "CommunicationDiagram";
+    readonly ComponentDiagram: "ComponentDiagram";
+    readonly DeploymentDiagram: "DeploymentDiagram";
+    readonly PetriNet: "PetriNet";
+    readonly ReachabilityGraph: "ReachabilityGraph";
+    readonly SyntaxTree: "SyntaxTree";
+    readonly Flowchart: "Flowchart";
+};

--- a/docs/source/dev/examples.rst
+++ b/docs/source/dev/examples.rst
@@ -29,6 +29,7 @@ and resizing can only be done in regard to the components width. For more inform
 what happens on user interaction is added to the element, see :ref:`user-interaction-with-elements`.
 
 
+.. _visual-representation-implementation-of-element:
 
 Example of Visual Representation Implementation of Element
 -------------------------------------------------------------

--- a/docs/source/dev/general-concepts.rst
+++ b/docs/source/dev/general-concepts.rst
@@ -12,7 +12,18 @@ save diagrams. A Diagram consists of Elements, Containers and Relationships.
 
    Apollon Data Model
 
-TODO explain model
+The above diagram illustrates the Data Model of an Apollon.
+It consists of three interfaces: *IUMLElement, IUMLRelationship, and IUMLContainer*.
+
+*IUMLElement* is an interface with attributes of id, name, type owner, and highlight.
+*IUMLRelationship* inherits *IUMLElement* and has additional attributes of a path, source, and target.
+Similarly, *IUMLRelationship* also inherits *IUMLElement* and has the additional attribute of ownedElements and method reorderChildren.
+
+*UMLElement* implements *IUMLElement* and has additional methods of *serialize, deserialize, ports and render*.
+It can be either *UMLRelationship* or *UMLContainer*.
+Additionally, *UMLRelationship* implements *IUMLRelationship*, and *UMLContainer* implements *IUMLContainer*.
+Both of them have an additional method render that is responsible for rendering the elements to the canvas.
+The render method of *UMLRelationship* takes *canvas, source, and target* as its parameter while the one of UMLContainer takes *canvas and children* as its parameter.
 
 **UMLElement**: The Element is part of a UML diagram. It has a unique identifier,
 name, position, size and color.

--- a/docs/source/dev/repository-overview.rst
+++ b/docs/source/dev/repository-overview.rst
@@ -55,107 +55,116 @@ This is an overview of the files and folders in the repository together with a s
 
 .. code-block:: shell
 
-    |-- .github                                         # github templates and workflows for github actions
-    |-- docs                                            # ReadTheDoc files to build the documentation
-    |-- public                                          # test application code
-    |-- src                                             # src of the apollon library
-    |   |-- components                                  # all react components, also contains all components for interaction with the user
-    |   |   |-- assessment                              # assesment-component (content of assesment popup)
-    |   |   |-- canvas                                  # canvas and functionality on canvas, e.g. key-event listener
+    |-- .github                                                     # github templates and workflows for github actions
+    |-- docs                                                        # ReadTheDoc files to build the documentation
+    |-- public                                                      # test application code
+    |-- src                                                         # src of the apollon library
+    |   |-- components                                              # all react components, also contains all components for interaction with the user
+    |   |   |-- assessment                                          # assesment-component (content of assesment popup)
+    |   |   |-- canvas                                              # canvas and functionality on canvas, e.g. key-event listener
     |   |   |-- connectable
-    |   |   |   |-- connection-preview                  # generic connection-preview, handles user interaction with connection-preview elements
-    |   |   |   |-- uml-relationship-preview            # look of connection preview
-    |   |   |-- controls                                # generic controls components which are used throughout the application
-    |   |   |-- create-pane                             # create-pane on the side bar which can be used to create UML elements per drag and drop
-    |   |   |-- draggable                               # contains code for generic drag and drop concept + draggable layer, which is used to create
-    |   |   |   |-- draggable                           # defines user interaction with draggable components (only adds interaction listeners to component)
-    |   |   |   |-- draggable-context                   # defines how the react context for drag and drop elements look like
-    |   |   |   |-- draggable-layer                     # defines conceptually a layer on which elements are dragged and then dropped. Updates the position of the ghost and creates the drop event
-    |   |   |   |-- drop-event                          # defines how the drop event looks like
-    |   |   |   |-- droppable                           # defines user interaction with droppable components (only adds interaction listeners to component)
-    |   |   |   |-- ghost                               # container which contains the dragged HTML-Element
-    |   |   |   |-- with-draggable                      # gives access to draggable-context properties
-    |   |   |-- i18n                                    # takes care that components are localized
-    |   |   |-- sidebar                                 # sidebar, containing create-pane and modeling/interactive tab
-    |   |   |-- store                                   # manages application state
-    |   |   |-- theme                                   # provides theme
-    |   |   |-- uml-element                             # HOCs which implement user interaction which then results in a service call to implement the effect
-    |   |   |   |-- assessable                          # HOC for styling components with assessments depending on their score
-    |   |   |   |-- connectable                         # HOC for connecting and reconnecting components, also adds the ports to a component which can be used as connection source and target
-    |   |   |   |-- droppable                           # HOC for making a component a drop container
-    |   |   |   |-- hoverable                           # HOC for making a component hoverable
-    |   |   |   |-- interactable                        # HOC for making a component interactable
-    |   |   |   |-- movable                             # HOC for making a component movable
-    |   |   |   |-- reconnectable                       # HOC for making a component reconnectable
-    |   |   |   |-- resizable                           # HOC for making a component resizable
-    |   |   |   |-- selectable                          # HOC for making a component selectable
-    |   |   |   |-- updatable                           # HOC for making a component updatable, that means they can open a popup, which displays mode specific content
-    |   |   |   |-- canvas-element.tsx                  # generic canvas element (also implements the looks of hovering/select effect of elements)
-    |   |   |   |-- canvas-relationship.tsx             # generic canvas relationship (also implements the looks of hovering/select effect of relationships)
-    |   |   |   |-- uml-element-component.tsx           # decorates elements with features (implemented in HOC) depending on Apollon-Mode and element functionality, wrapper of every UML-Element
-    |   |   |   |-- uml-element-component-props.tsx     # UML-Element specific props
-    |   |   |--update-pane                              # popover which is opened when dbl clicking on an element
-    |   |-- i18n                                        # translations
-    |   |-- packages                                    # describes appearance of available uml-diagram-type specific elements and which diagram types are available
-    |   |   |--common                                   # common
-    |   |   |--uml-activity-diagram                     # activity diagram elements
-    |   |   |--uml-class-diagram                        # class diagram elements
-    |   |   |--uml-communication-diagram                # communication diagram elements
-    |   |   |--uml-component-diagram                    # component diagram elements
-    |   |   |--uml-deployment-diagram                   # deployment diagram elements
-    |   |   |--uml-object-diagram                       # object diagram elements
-    |   |   |--uml-use-case-diagram                     # use-case diagram elements
-    |   |   |--component.ts                             # mapping of UML element/relationship type to UML element component
-    |   |   |--compose-preview.ts                       # type of preview compose-functions
-    |   |   |--diagram-type.ts                          # exports enum of all availabel diagram types
-    |   |   |--popups.ts                                # mapping of uml element types to popup content
-    |   |   |--uml-element-type.ts                      # collection of all supported UML element types
-    |   |   |--uml-elements.ts                          # collection of all supported UML elements
-    |   |   |--uml-relationship-type.ts                 # collection of all supporte UML relationship types
-    |   |   |--uml-relationships.ts                     # collection of all supported UML relationships
+    |   |   |   |-- connection-preview                              # generic connection-preview, handles user interaction with connection-preview elements
+    |   |   |   |-- uml-relationship-preview                        # look of connection preview
+    |   |   |-- controls                                            # generic controls components which are used throughout the application
+    |   |   |-- create-pane                                         # create-pane on the side bar which can be used to create UML elements per drag and drop
+    |   |   |-- draggable                                           # contains code for generic drag and drop concept + draggable layer, which is used to create
+    |   |   |   |-- draggable                                       # defines user interaction with draggable components (only adds interaction listeners to component)
+    |   |   |   |-- draggable-context                               # defines how the react context for drag and drop elements look like
+    |   |   |   |-- draggable-layer                                 # defines conceptually a layer on which elements are dragged and then dropped. Updates the position of the ghost and creates the drop event
+    |   |   |   |-- drop-event                                      # defines how the drop event looks like
+    |   |   |   |-- droppable                                       # defines user interaction with droppable components (only adds interaction listeners to component)
+    |   |   |   |-- ghost                                           # container which contains the dragged HTML-Element
+    |   |   |   |-- with-draggable                                  # gives access to draggable-context properties
+    |   |   |-- i18n                                                # takes care that components are localized
+    |   |   |-- sidebar                                             # sidebar, containing create-pane and modeling/interactive tab
+    |   |   |-- store                                               # manages application state
+    |   |   |-- style-pane                                          # contains color selector implementation 
+    |   |   |-- theme                                               # provides theme
+    |   |   |-- uml-element                                         # HOCs which implement user interaction which then results in a service call to implement the effect
+    |   |   |   |-- assessable                                      # HOC for styling components with assessments depending on their score
+    |   |   |   |-- connectable                                     # HOC for connecting and reconnecting components, also adds the ports to a component which can be used as connection source and target
+    |   |   |   |-- droppable                                       # HOC for making a component a drop container
+    |   |   |   |-- hoverable                                       # HOC for making a component hoverable
+    |   |   |   |-- interactable                                    # HOC for making a component interactable
+    |   |   |   |-- movable                                         # HOC for making a component movable
+    |   |   |   |-- reconnectable                                   # HOC for making a component reconnectable
+    |   |   |   |-- resizable                                       # HOC for making a component resizable
+    |   |   |   |-- selectable                                      # HOC for making a component selectable
+    |   |   |   |-- updatable                                       # HOC for making a component updatable, that means they can open a popup, which displays mode specific content
+    |   |   |   |-- canvas-element.tsx                              # generic canvas element (also implements the looks of hovering/select effect of elements)
+    |   |   |   |-- canvas-relationship.tsx                         # generic canvas relationship (also implements the looks of hovering/select effect of relationships)
+    |   |   |   |-- uml-element-component.tsx                       # decorates elements with features (implemented in HOC) depending on Apollon-Mode and element functionality, wrapper of every UML-Element
+    |   |   |   |-- uml-element-component-props.tsx                 # UML-Element specific props
+    |   |   |--update-pane                                          # popover which is opened when dbl clicking on an element
+    |   |-- i18n                                                    # translations
+    |   |-- packages                                                # describes appearance of available uml-diagram-type specific elements and which diagram types are available
+    |   |   |--common                                               # common
+    |   |   |--flowchart                                            # flowchart elements
+    |   |   |--syntax-tree                                          # syntaxtree elements
+    |   |   |--uml-activity-diagram                                 # activity diagram elements
+    |   |   |--uml-class-diagram                                    # class diagram elements
+    |   |   |--uml-communication-diagram                            # communication diagram elements
+    |   |   |--uml-component-diagram                                # component diagram elements
+    |   |   |--uml-deployment-diagram                               # deployment diagram elements
+    |   |   |--uml-object-diagram                                   # object diagram elements
+    |   |   |--uml-petri-net                                        # petri net elements
+    |   |   |--uml-reachability-graph                               # reachability graph elements
+    |   |   |--uml-use-case-diagram                                 # use-case diagram elements
+    |   |   |--component.ts                                         # mapping of UML element/relationship type to UML element component
+    |   |   |--compose-preview.ts                                   # type of preview compose-functions
+    |   |   |--diagram-type.ts                                      # exports enum of all availabel diagram types
+    |   |   |--popups.ts                                            # mapping of uml element types to popup content
+    |   |   |--uml-element-selector-type.ts                         # UML element selector types
+    |   |   |--uml-element-type.ts                                  # collection of all supported UML element types
+    |   |   |--uml-elements.ts                                      # collection of all supported UML elements
+    |   |   |--uml-relationship-type.ts                             # collection of all supporte UML relationship types
+    |   |   |--uml-relationships.ts                                 # collection of all supported UML relationships
     |   |-- scenes
-    |   |   |-- application.tsx                         # provides application wide providers and apollon-editor component tree
-    |   |   |-- application-styles.tsx                  # styles of the apollon editor layout
-    |   |   |-- svg.tsx                                 # builds the svg, which can be exported
-    |   |   |-- svg-styles.tsx                          # styles of the svg
-    |   |-- services                                    # provides services which interact with global application state, which is managed by redux
-    |   |   |-- assessment                              # functionality: adds/overwrites assessment + get assessment by id
-    |   |   |-- copypaste                               # functionality: copy and paste uml element
-    |   |   |-- editor                                  # functionality: change view
-    |   |   |-- layouter                                # functionality: layouts elements
-    |   |   |-- uml-container                           # functionality: get container, append element to container, remove element from container
-    |   |   |-- uml-diagram                             # functionality: get uml diagram, append element to uml diagram
-    |   |   |-- uml-element                             # functionality: see subfolders
-    |   |   |   |-- connectable                         # functionality: start, end + delete connection
-    |   |   |   |-- hoverable                           # functionality: adds / removes elements from global hovered elements
-    |   |   |   |-- interactable                        # functionality: adds / removes elements from global interaction elements
-    |   |   |   |-- movable                             # functionality: updates UML element position
-    |   |   |   |-- resizable                           # functionality: updates UML element bounds
-    |   |   |   |-- selectable                          # functionality: adds / removes elements from global selected elements
-    |   |   |   |-- updatable                           # functionality: adds / removes elements from global updating elements
-    |   |   |   |-- uml-element.ts                      # defines the uml-element model
-    |   |   |   |-- uml-element-common-repository.ts    # provides creators for common actions of uml-elements
-    |   |   |   |-- uml-element-features.ts             # provides type for UMLElementFeatures
-    |   |   |   |-- uml-element-ports.ts                # provides IUMLElementPort, which is used as connection src and target
-    |   |   |   |-- uml-element-reducer.ts              # implements state update for uml-element functionality: create, update, remove elements
-    |   |   |   |-- uml-element-repository.ts           # unifies repositories of uml elements
-    |   |   |   |-- uml-element-saga.ts                 # implementation of side effects of uml-element actions
-    |   |   |   |-- uml-element-types.ts                # types definition of uml-element-common functionality
+    |   |   |-- application.tsx                                     # provides application wide providers and apollon-editor component tree
+    |   |   |-- application-styles.tsx                              # styles of the apollon editor layout
+    |   |   |-- svg.tsx                                             # builds the svg, which can be exported
+    |   |   |-- svg-styles.tsx                                      # styles of the svg
+    |   |-- services                                                # provides services which interact with global application state, which is managed by redux
+    |   |   |-- assessment                                          # functionality: adds/overwrites assessment + get assessment by id
+    |   |   |-- copypaste                                           # functionality: copy and paste uml element
+    |   |   |-- editor                                              # functionality: change view
+    |   |   |-- last-action                                         # functionality: updates last action state
+    |   |   |-- layouter                                            # functionality: layouts elements
+    |   |   |-- uml-container                                       # functionality: get container, append element to container, remove element from container
+    |   |   |-- uml-diagram                                         # functionality: get uml diagram, append element to uml diagram
+    |   |   |-- uml-element                                         # functionality: see subfolders
+    |   |   |   |-- connectable                                     # functionality: start, end + delete connection
+    |   |   |   |-- hoverable                                       # functionality: adds / removes elements from global hovered elements
+    |   |   |   |-- interactable                                    # functionality: adds / removes elements from global interaction elements
+    |   |   |   |-- movable                                         # functionality: updates UML element position
+    |   |   |   |-- resizable                                       # functionality: updates UML element bounds
+    |   |   |   |-- selectable                                      # functionality: adds / removes elements from global selected elements
+    |   |   |   |-- updatable                                       # functionality: adds / removes elements from global updating elements
+    |   |   |   |-- uml-element.ts                                  # defines the uml-element model
+    |   |   |   |-- uml-element-common-repository.ts                # provides creators for common actions of uml-elements
+    |   |   |   |-- uml-element-features.ts                         # provides type for UMLElementFeatures
+    |   |   |   |-- uml-element-ports.ts                            # provides IUMLElementPort, which is used as connection src and target
+    |   |   |   |-- uml-element-reducer.ts                          # implements state update for uml-element functionality: create, update, remove elements
+    |   |   |   |-- uml-element-repository.ts                       # unifies repositories of uml elements
+    |   |   |   |-- uml-element-saga.ts                             # implementation of side effects of uml-element actions
+    |   |   |   |-- uml-element-types.ts                            # types definition of uml-element-common functionality
     |   |   |-- uml-relationship
-    |   |   |   |-- reconnectable                       # functionality: adds / removes elements from global reconnected elements
-    |   |   |   |-- connections.ts                      # algorithm for path drawing
-    |   |   |   |-- uml-relationship.ts                 # defines the uml-relationship model
-    |   |   |   |-- uml-relationship-feature.ts         # defines the features of uml-relationships
-    |   |   |   |-- uml-relationship-reducer.ts         # implements state update for uml-relationship functions
-    |   |   |   |-- uml-relationship-repository.ts      # unifies all repositories of uml-relationships
-    |   |   |   |-- uml-relationship-saga.ts            # implements side effects of uml-relationships
-    |   |   |   |-- uml-relationship-types.ts           # defines uml-relationship action types
-    |   |   |-- undo                                    # functionality: undo / redo action
-    |   |   |-- actions.ts                              # export type for all actions
-    |   |   |-- reducer.ts                              # maps global state to reducers
-    |   |   |-- saga.ts                                 # unifies all sagas
-    |   |-- utils                                       # provides utility code
-    |   |-- apollon-editor.ts                           # exports apollon-editor functionality to library using application
-    |   |-- index.ts                                    # js module export
-    |   |-- typings.ts                                  # exports typings to library using application
-    |-- webpack                                         # packaging config for apollon standalone
+    |   |   |   |-- reconnectable                                   # functionality: adds / removes elements from global reconnected elements
+    |   |   |   |-- connections.ts                                  # algorithm for path drawing
+    |   |   |   |-- uml-relationship-centered-description.ts        # implements centered description in relationship functionality
+    |   |   |   |-- uml-relationship-common-repository.ts           # defines common repository of uml-relationships
+    |   |   |   |-- uml-relationship.ts                             # defines the uml-relationship model
+    |   |   |   |-- uml-relationship-feature.ts                     # defines the features of uml-relationships
+    |   |   |   |-- uml-relationship-reducer.ts                     # implements state update for uml-relationship functions
+    |   |   |   |-- uml-relationship-repository.ts                  # unifies all repositories of uml-relationships
+    |   |   |   |-- uml-relationship-saga.ts                        # implements side effects of uml-relationships
+    |   |   |   |-- uml-relationship-types.ts                       # defines uml-relationship action types
+    |   |   |-- undo                                                # functionality: undo / redo action
+    |   |   |-- actions.ts                                          # export type for all actions
+    |   |   |-- reducer.ts                                          # maps global state to reducers
+    |   |   |-- saga.ts                                             # unifies all sagas
+    |   |-- utils                                                   # provides utility code
+    |   |-- apollon-editor.ts                                       # exports apollon-editor functionality to library using application
+    |   |-- index.ts                                                # js module export
+    |   |-- typings.ts                                              # exports typings to library using application
+    |-- webpack                                                     # packaging config for apollon standalone

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "postpublish": "pinst --enable",
     "start": "webpack serve --config ./webpack/webpack.dev.js",
     "build": "rm -rf dist && webpack --config ./webpack/webpack.prod.js",
-    "copyAPIToDoc": "cp lib/es6/apollon-editor.d.ts lib/es6/typings.d.ts docs/source/user/api",
+    "copyAPIToDoc": "cp lib/es6/apollon-editor.d.ts lib/es6/typings.d.ts docs/source/user/api && cp lib/es6/packages/diagram-type.d.ts docs/source/dev/api",
     "lint": "yarn lint:ts && yarn lint:css",
     "lint:ts": "tslint --force -p tsconfig.json -c tslint.json -t stylish",
     "lint:css": "stylelint 'src/**/*.ts'",


### PR DESCRIPTION
### Motivation and Context
The current documentation of Apollon, found [here](https://apollon-library.readthedocs.io/en/latest/), is outdated and hence needs an update.

### Description
This PR simply updates the documentation of Apollon.

### Steps for Testing
#### In local machine
1. Clone the repo and checkout to the `documentation/update-documentation` branch.
2. Goto `docs/` folder and install all the python dependencies by executing `pip install -r requirements.txt`
3. Finally execute `make singlehtml` command
4. Goto `docs/build/singlehtml` folder and open `index.html` in your browser.
5. Observe the updated documentation.

#### From Artifact
You can also test the documentation from the latest build [here](https://confluence.ase.in.tum.de/download/attachments/148573014/singlehtml.rar?version=1&modificationDate=1672334584439&api=v2).

PS: For more information regarding building the documentation, please refer to [Artemis Documentation](https://github.com/ls1intum/Artemis/tree/develop/docs).

