### PR TITLE
Fix assessment subscription in `apollon-editor.ts`

### DIFF
--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -310,6 +310,8 @@ export class ApollonEditor {
     setTimeout(() => {
       if (this.store) {
         this.store.subscribe(this.onDispatch);
+      } else {
+        setTimeout(this.componentDidMount, 100);
       }
     });
   };

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -114,11 +114,11 @@ export class ApollonEditor {
   private currentModelState?: ModelState;
   private assessments: Apollon.Assessment[] = [];
   private application: RefObject<Application> = createRef();
-  private selectionSubscribers: {[key: number]: (selection: Apollon.Selection) => void} = {};
-  private assessmentSubscribers: {[key: number]: ((assessments: Apollon.Assessment[]) => void)} = {};
-  private modelSubscribers: {[key: number]: (model: Apollon.UMLModel) => void} = {};
-  private discreteModelSubscribers: {[key: number]: (model: Apollon.UMLModel) => void} = {};
-  private errorSubscribers: {[key: number]: (error: Error) => void} = {};
+  private selectionSubscribers: { [key: number]: (selection: Apollon.Selection) => void } = {};
+  private assessmentSubscribers: { [key: number]: (assessments: Apollon.Assessment[]) => void } = {};
+  private modelSubscribers: { [key: number]: (model: Apollon.UMLModel) => void } = {};
+  private discreteModelSubscribers: { [key: number]: (model: Apollon.UMLModel) => void } = {};
+  private errorSubscribers: { [key: number]: (error: Error) => void } = {};
 
   constructor(private container: HTMLElement, private options: Apollon.ApollonOptions) {
     let state: PartialModelState | undefined = options.model ? ModelState.fromModel(options.model) : {};
@@ -186,7 +186,7 @@ export class ApollonEditor {
     dispatch(UMLElementRepository.select([...selection.elements, ...selection.relationships]));
   }
 
-  _getNewSubscriptionId(subscribers: {[key: number]: any}): number {
+  _getNewSubscriptionId(subscribers: { [key: number]: any }): number {
     // largest key + 1
     return Math.max(...Object.keys(subscribers).map((key) => parseInt(key))) + 1;
   }

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -187,7 +187,8 @@ export class ApollonEditor {
   }
 
   _getNewSubscriptionId(subscribers: {[key: number]: any}): number {
-    return Object.keys(subscribers).length;
+    // largest key + 1
+    return Math.max(...Object.keys(subscribers).map((key) => parseInt(key))) + 1;
   }
 
   /**

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -114,11 +114,11 @@ export class ApollonEditor {
   private currentModelState?: ModelState;
   private assessments: Apollon.Assessment[] = [];
   private application: RefObject<Application> = createRef();
-  private selectionSubscribers: ((selection: Apollon.Selection) => void)[] = [];
-  private assessmentSubscribers: ((assessments: Apollon.Assessment[]) => void)[] = [];
-  private modelSubscribers: ((model: Apollon.UMLModel) => void)[] = [];
-  private discreteModelSubscribers: ((model: Apollon.UMLModel) => void)[] = [];
-  private errorSubscribers: ((error: Error) => void)[] = [];
+  private selectionSubscribers: {[key: number]: (selection: Apollon.Selection) => void} = {};
+  private assessmentSubscribers: {[key: number]: ((assessments: Apollon.Assessment[]) => void)} = {};
+  private modelSubscribers: {[key: number]: (model: Apollon.UMLModel) => void} = {};
+  private discreteModelSubscribers: {[key: number]: (model: Apollon.UMLModel) => void} = {};
+  private errorSubscribers: {[key: number]: (error: Error) => void} = {};
 
   constructor(private container: HTMLElement, private options: Apollon.ApollonOptions) {
     let state: PartialModelState | undefined = options.model ? ModelState.fromModel(options.model) : {};
@@ -186,13 +186,19 @@ export class ApollonEditor {
     dispatch(UMLElementRepository.select([...selection.elements, ...selection.relationships]));
   }
 
+  _getNewSubscriptionId(subscribers: {[key: number]: any}): number {
+    return Object.keys(subscribers).length;
+  }
+
   /**
    * Register callback which is executed when the selection of elements and relationships changes
    * @param callback function which is called when selection changes
    * @return returns the subscription identifier which can be used to unsubscribe
    */
   subscribeToSelectionChange(callback: (selection: Apollon.Selection) => void): number {
-    return this.selectionSubscribers.push(callback) - 1;
+    const id = this._getNewSubscriptionId(this.selectionSubscribers);
+    this.selectionSubscribers[id] = callback;
+    return id;
   }
 
   /**
@@ -200,7 +206,7 @@ export class ApollonEditor {
    * @param subscriptionId subscription identifier
    */
   unsubscribeFromSelectionChange(subscriptionId: number) {
-    this.selectionSubscribers.splice(subscriptionId, 1);
+    delete this.selectionSubscribers[subscriptionId];
   }
 
   /**
@@ -209,7 +215,9 @@ export class ApollonEditor {
    * @return returns the subscription identifier which can be used to unsubscribe
    */
   subscribeToAssessmentChange(callback: (assessments: Apollon.Assessment[]) => void): number {
-    return this.assessmentSubscribers.push(callback) - 1;
+    const id = this._getNewSubscriptionId(this.assessmentSubscribers);
+    this.assessmentSubscribers[id] = callback;
+    return id;
   }
 
   /**
@@ -217,7 +225,7 @@ export class ApollonEditor {
    * @param subscriptionId subscription identifier
    */
   unsubscribeFromAssessmentChange(subscriptionId: number) {
-    this.assessmentSubscribers.splice(subscriptionId, 1);
+    delete this.assessmentSubscribers[subscriptionId];
   }
 
   /**
@@ -226,7 +234,9 @@ export class ApollonEditor {
    * @return returns the subscription identifier which can be used to unsubscribe
    */
   subscribeToModelChange(callback: (model: UMLModel) => void): number {
-    return this.modelSubscribers.push(callback) - 1;
+    const id = this._getNewSubscriptionId(this.modelSubscribers);
+    this.modelSubscribers[id] = callback;
+    return id;
   }
 
   /**
@@ -234,7 +244,7 @@ export class ApollonEditor {
    * @param subscriptionId subscription identifier
    */
   unsubscribeFromModelChange(subscriptionId: number) {
-    this.modelSubscribers.splice(subscriptionId, 1);
+    delete this.modelSubscribers[subscriptionId];
   }
 
   /**
@@ -244,7 +254,9 @@ export class ApollonEditor {
    * @return returns the subscription identifier which can be used to unsubscribe
    */
   subscribeToModelDiscreteChange(callback: (model: UMLModel) => void): number {
-    return this.discreteModelSubscribers.push(callback) - 1;
+    const id = this._getNewSubscriptionId(this.discreteModelSubscribers);
+    this.discreteModelSubscribers[id] = callback;
+    return id;
   }
 
   /**
@@ -252,7 +264,7 @@ export class ApollonEditor {
    * @param subscriptionId subscription identifier
    */
   unsubscribeFromDiscreteModelChange(subscriptionId: number) {
-    this.discreteModelSubscribers.splice(subscriptionId, 1);
+    delete this.discreteModelSubscribers[subscriptionId];
   }
 
   /**
@@ -262,7 +274,9 @@ export class ApollonEditor {
    * @return returns the subscription identifier which can be used to unsubscribe
    */
   subscribeToApollonErrors(callback: (error: Error) => void): number {
-    return this.errorSubscribers.push(callback) - 1;
+    const id = this._getNewSubscriptionId(this.errorSubscribers);
+    this.errorSubscribers[id] = callback;
+    return id;
   }
 
   /**
@@ -270,7 +284,7 @@ export class ApollonEditor {
    * @param subscriptionId subscription identifier
    */
   unsubscribeToApollonErrors(subscriptionId: number) {
-    this.errorSubscribers.splice(subscriptionId, 1);
+    delete this.errorSubscribers[subscriptionId];
   }
 
   /**
@@ -312,7 +326,7 @@ export class ApollonEditor {
 
     // check if previous selection differs from current selection, if yes -> notify subscribers
     if (JSON.stringify(this.selection) !== JSON.stringify(selection)) {
-      this.selectionSubscribers.forEach((subscriber) => subscriber(selection));
+      Object.values(this.selectionSubscribers).forEach((subscriber) => subscriber(selection));
       this.selection = selection;
     }
 
@@ -326,7 +340,7 @@ export class ApollonEditor {
 
     // check if previous assessment differs from current selection, if yes -> notify subscribers
     if (JSON.stringify(this.assessments) !== JSON.stringify(umlAssessments)) {
-      this.assessmentSubscribers.forEach((subscriber) => subscriber(umlAssessments));
+      Object.values(this.assessmentSubscribers).forEach((subscriber) => subscriber(umlAssessments));
       this.assessments = umlAssessments;
     }
 
@@ -351,7 +365,7 @@ export class ApollonEditor {
         this.store.getState().lastAction.endsWith('DELETE')
       ) {
         const lastModel = ModelState.toModel(this.store.getState());
-        this.discreteModelSubscribers.forEach((subscriber) => subscriber(lastModel));
+        Object.values(this.discreteModelSubscribers).forEach((subscriber) => subscriber(lastModel));
       }
     } catch (error) {
       // if error occured while getting current state for subscribers -> do not emit changes
@@ -366,7 +380,7 @@ export class ApollonEditor {
       const model = this.model;
       const lastModel = this.currentModelState ? ModelState.toModel(this.currentModelState) : null;
       if ((!lastModel && model) || (lastModel && JSON.stringify(model) !== JSON.stringify(lastModel))) {
-        this.modelSubscribers.forEach((subscriber) => subscriber(model));
+        Object.values(this.modelSubscribers).forEach((subscriber) => subscriber(model));
         this.currentModelState = this.store.getState();
       } else {
         this.currentModelState = this.store.getState();
@@ -393,7 +407,7 @@ export class ApollonEditor {
   }
 
   private onErrorOccurred(error: Error) {
-    this.errorSubscribers.forEach((subscriber) => subscriber(error));
+    Object.values(this.errorSubscribers).forEach((subscriber) => subscriber(error));
     this.restoreEditor();
   }
 

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -200,7 +200,7 @@ export class ApollonEditor {
    * @param subscriptionId subscription identifier
    */
   unsubscribeFromSelectionChange(subscriptionId: number) {
-    this.selectionSubscribers.splice(subscriptionId);
+    this.selectionSubscribers.splice(subscriptionId, 1);
   }
 
   /**
@@ -217,7 +217,7 @@ export class ApollonEditor {
    * @param subscriptionId subscription identifier
    */
   unsubscribeFromAssessmentChange(subscriptionId: number) {
-    this.assessmentSubscribers.splice(subscriptionId);
+    this.assessmentSubscribers.splice(subscriptionId, 1);
   }
 
   /**
@@ -234,7 +234,7 @@ export class ApollonEditor {
    * @param subscriptionId subscription identifier
    */
   unsubscribeFromModelChange(subscriptionId: number) {
-    this.modelSubscribers.splice(subscriptionId);
+    this.modelSubscribers.splice(subscriptionId, 1);
   }
 
   /**
@@ -252,7 +252,7 @@ export class ApollonEditor {
    * @param subscriptionId subscription identifier
    */
   unsubscribeFromDiscreteModelChange(subscriptionId: number) {
-    this.discreteModelSubscribers.splice(subscriptionId);
+    this.discreteModelSubscribers.splice(subscriptionId, 1);
   }
 
   /**
@@ -270,7 +270,7 @@ export class ApollonEditor {
    * @param subscriptionId subscription identifier
    */
   unsubscribeToApollonErrors(subscriptionId: number) {
-    this.errorSubscribers.splice(subscriptionId);
+    this.errorSubscribers.splice(subscriptionId, 1);
   }
 
   /**

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -188,6 +188,7 @@ export class ApollonEditor {
 
   _getNewSubscriptionId(subscribers: { [key: number]: any }): number {
     // largest key + 1
+    if (Object.keys(subscribers).length === 0) return 0;
     return Math.max(...Object.keys(subscribers).map((key) => parseInt(key))) + 1;
   }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] ~I added multiple screenshots/screencasts of my UI changes~
- [ ] ~I translated all the newly inserted strings into German and English~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We have a bug in Artemis where all tutor assessments get lost on save. Artemis sometimes does not get events for new assessments. Therefore, assessments can often get lost, especially in Safari.

### Description
<!-- Describe your changes in detail -->
Change `.splice(i)` (which removes all elements in the array starting from `i`) with an object-key-based approach. This additionally prevents problems from occurring when indexes shift because of `splice`.

Also, a subscription to `this.store` in `apollon-editor.ts` did sometimes not work because `this.store` was still undefined when it was called. I added code to automatically retry the subscription when if fails because of that.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Deploy https://github.com/ls1intum/Artemis/pull/6901 (has version of the npm package with this fix in it)
2. Assess modeling exercise participation
3. Assess components
4. Press "Save" or "Override Assessment"
5. Assessments are no longer lost. They were gone previously.

For better reproducibility, test in Safari. In Safari, the bug occurs more often (closer to 100% of the time). In Chrome, the issue sometimes does not appear at all.

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see package.json). -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| File | Line |
|------|-------:|
| apollon-editor.ts | 79.59 % |
<!--
| uml-activity-fork-node-component.ts | 85% | 77% |
| uml-activity-action-node-component.ts | 13% | 95% |
-->
