### PR TITLE
Enable Artemis to hook into the React render timeline for more reliable tests

### DIFF
--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -119,11 +119,11 @@ export class ApollonEditor {
   private modelSubscribers: { [key: number]: (model: Apollon.UMLModel) => void } = {};
   private discreteModelSubscribers: { [key: number]: (model: Apollon.UMLModel) => void } = {};
   private errorSubscribers: { [key: number]: (error: Error) => void } = {};
+  private componentMountedPromise: Promise<void>;
 
   constructor(
     private container: HTMLElement,
-    private options: Apollon.ApollonOptions,
-    onMounted?: () => void
+    private options: Apollon.ApollonOptions
   ) {
     let state: PartialModelState | undefined = options.model ? ModelState.fromModel(options.model) : {};
 
@@ -155,12 +155,17 @@ export class ApollonEditor {
       },
     };
 
+    let mountedResolve;
+    this.componentMountedPromise = new Promise((resolve) => {
+      mountedResolve = resolve;
+    });
+
     const element = createElement(Application, {
       ref: this.application,
       state,
       styles: options.theme,
       locale: options.locale,
-      onMounted: onMounted,
+      onMounted: mountedResolve,
     });
     const errorBoundary = createElement(ErrorBoundary, { onError: this.onErrorOccurred.bind(this) }, element);
     this.root = createRoot(container);
@@ -442,5 +447,9 @@ export class ApollonEditor {
       this.application.current.store.current &&
       this.application.current.store.current.state.store
     );
+  }
+
+  get componentMounted(): Promise<void> {
+    return this.componentMountedPromise;
   }
 }

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -161,6 +161,7 @@ export class ApollonEditor {
         if (app == null) return;
         this.application = app;
         await app.initialized;
+        this.store!.subscribe(this.onDispatch);
         nextRenderResolve();
       },
       state,
@@ -316,14 +317,6 @@ export class ApollonEditor {
 
   private componentDidMount = () => {
     this.container.setAttribute('touch-action', 'none');
-
-    setTimeout(() => {
-      if (this.store) {
-        this.store.subscribe(this.onDispatch);
-      } else {
-        setTimeout(this.componentDidMount, 100);
-      }
-    });
   };
 
   /**
@@ -418,6 +411,7 @@ export class ApollonEditor {
         if (app == null) return;
         this.application = app;
         await app.initialized;
+        this.store!.subscribe(this.onDispatch);
         nextRenderResolve();
       },
       state,

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -25,10 +25,10 @@ export class ApollonEditor {
     if (!this.store) {
       // tslint:disable-next-line:no-console
       console.error(
-        'The application state of Apollon could not be retrieved. The editor may already be destroyed or you might need to `await apollonEditor.renderCycle`.',
+        'The application state of Apollon could not be retrieved. The editor may already be destroyed or you might need to `await apollonEditor.nextRender`.',
       );
       throw new Error(
-        'The application state of Apollon could not be retrieved. The editor may already be destroyed or you might need to `await apollonEditor.renderCycle`.',
+        'The application state of Apollon could not be retrieved. The editor may already be destroyed or you might need to `await apollonEditor.nextRender`.',
       );
     }
   }

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -97,7 +97,7 @@ export class ApollonEditor {
     const element = createElement(Svg, { model, options, styles: theme });
     const svg = new Svg({ model, options, styles: theme });
     root.render(element);
-    await delay(0);
+    await delay(50);
 
     return {
       svg: replaceColorVariables(container.querySelector('svg')!.outerHTML),

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -24,8 +24,12 @@ export class ApollonEditor {
   private ensureInitialized() {
     if (!this.store) {
       // tslint:disable-next-line:no-console
-      console.error('The application state of Apollon could not be retrieved. The editor may already be destroyed or you might need to `await apollonEditor.renderCycle`.');
-      throw new Error('The application state of Apollon could not be retrieved. The editor may already be destroyed or you might need to `await apollonEditor.renderCycle`.');
+      console.error(
+        'The application state of Apollon could not be retrieved. The editor may already be destroyed or you might need to `await apollonEditor.renderCycle`.',
+      );
+      throw new Error(
+        'The application state of Apollon could not be retrieved. The editor may already be destroyed or you might need to `await apollonEditor.renderCycle`.',
+      );
     }
   }
 
@@ -113,7 +117,10 @@ export class ApollonEditor {
   private errorSubscribers: { [key: number]: (error: Error) => void } = {};
   private nextRenderPromise: Promise<void>;
 
-  constructor(private container: HTMLElement, private options: Apollon.ApollonOptions) {
+  constructor(
+    private container: HTMLElement,
+    private options: Apollon.ApollonOptions,
+  ) {
     let state: PartialModelState | undefined = options.model ? ModelState.fromModel(options.model) : {};
 
     state = {
@@ -158,7 +165,7 @@ export class ApollonEditor {
       },
       state,
       styles: options.theme,
-      locale: options.locale
+      locale: options.locale,
     });
     const errorBoundary = createElement(ErrorBoundary, { onError: this.onErrorOccurred.bind(this) }, element);
     this.root = createRoot(container);

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -21,16 +21,20 @@ import { ErrorBoundary } from './components/controls/error-boundary/ErrorBoundar
 import { replaceColorVariables } from './utils/replace-color-variables';
 
 export class ApollonEditor {
+  private ensureInitialized() {
+    if (!this.store) {
+      // tslint:disable-next-line:no-console
+      console.error('The application state of Apollon could not be retrieved. The editor may already be destroyed or you might need to `await apollonEditor.renderCycle`.');
+      throw new Error('The application state of Apollon could not be retrieved. The editor may already be destroyed or you might need to `await apollonEditor.renderCycle`.');
+    }
+  }
+
   /**
    * Returns the current model of the Apollon Editor
    */
   get model(): Apollon.UMLModel {
-    if (!this.store) {
-      // tslint:disable-next-line:no-console
-      console.error('The application state of Apollon could not be retrieved. The editor may already be destroyed.');
-      throw new Error('The application state of Apollon could not be retrieved. The editor may already be destroyed.');
-    }
-    return ModelState.toModel(this.store.getState());
+    this.ensureInitialized();
+    return ModelState.toModel(this.store!.getState());
   }
 
   /**
@@ -38,14 +42,10 @@ export class ApollonEditor {
    * @param model valid Apollon Editor Model
    */
   set model(model: Apollon.UMLModel) {
-    if (!this.store) {
-      // tslint:disable-next-line:no-console
-      console.error('The application state of Apollon could not be retrieved. The editor may already be destroyed.');
-      throw new Error('The application state of Apollon could not be retrieved. The editor may already be destroyed.');
-    }
+    this.ensureInitialized();
     const state: PartialModelState = {
       ...ModelState.fromModel(model),
-      editor: { ...this.store.getState().editor },
+      editor: { ...this.store!.getState().editor },
     };
     this.recreateEditor(state);
   }
@@ -55,13 +55,9 @@ export class ApollonEditor {
    * @param diagramType the new diagram type
    */
   set type(diagramType: UMLDiagramType) {
-    if (!this.store) {
-      // tslint:disable-next-line:no-console
-      console.error('The application state of Apollon could not be retrieved. The editor may already be destroyed.');
-      throw new Error('The application state of Apollon could not be retrieved. The editor may already be destroyed.');
-    }
+    this.ensureInitialized();
     const state: PartialModelState = {
-      ...this.store.getState(),
+      ...this.store!.getState(),
       diagram: new UMLDiagram({
         type: diagramType,
       }),
@@ -75,12 +71,8 @@ export class ApollonEditor {
    * @param locale supported locale
    */
   set locale(locale: Locale) {
-    if (!this.store) {
-      // tslint:disable-next-line:no-console
-      console.error('The application state of Apollon could not be retrieved. The editor may already be destroyed.');
-      throw new Error('The application state of Apollon could not be retrieved. The editor may already be destroyed.');
-    }
-    const state = this.store.getState();
+    this.ensureInitialized();
+    const state = this.store!.getState();
     this.options.locale = locale;
     this.recreateEditor(state);
   }

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -159,7 +159,7 @@ export class ApollonEditor {
 
     const element = createElement(Application, {
       ref: (app) => {
-        this.application = app;
+        this.application ??= app;
         initializedResolve();
       },
       state,

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -123,6 +123,7 @@ export class ApollonEditor {
   constructor(
     private container: HTMLElement,
     private options: Apollon.ApollonOptions,
+    onMounted?: () => void
   ) {
     let state: PartialModelState | undefined = options.model ? ModelState.fromModel(options.model) : {};
 
@@ -159,6 +160,7 @@ export class ApollonEditor {
       state,
       styles: options.theme,
       locale: options.locale,
+      onMounted: onMounted,
     });
     const errorBoundary = createElement(ErrorBoundary, { onError: this.onErrorOccurred.bind(this) }, element);
     this.root = createRoot(container);

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -444,7 +444,7 @@ export class ApollonEditor {
   }
 
   private get store(): Store<ModelState, Actions> | undefined {
-    return this.application?.store?.current?.state.store;
+    return this.application?.store?.state.store;
   }
 
   /**

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -1,5 +1,5 @@
 import 'pepjs';
-import { createElement, createRef, RefObject } from 'react';
+import { createElement } from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import { DeepPartial, Store } from 'redux';
 import { ModelState, PartialModelState } from './components/store/model-state';

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -158,8 +158,9 @@ export class ApollonEditor {
     });
 
     const element = createElement(Application, {
-      ref: (app) => {
+      ref: async (app) => {
         this.application ??= app;
+        await app?.initialized;
         initializedResolve();
       },
       state,

--- a/src/main/scenes/application.tsx
+++ b/src/main/scenes/application.tsx
@@ -21,7 +21,6 @@ type Props = {
   state?: PartialModelState;
   styles?: DeepPartial<Styles>;
   locale?: Locale;
-  onMounted?: () => void;
 };
 
 const initialState = Object.freeze({

--- a/src/main/scenes/application.tsx
+++ b/src/main/scenes/application.tsx
@@ -62,7 +62,7 @@ export class Application extends React.Component<Props, State> {
       <CanvasProvider value={canvasContext}>
         <RootProvider value={rootContext}>
           <StoreProvider initialState={this.props.state} ref={(ref) => {
-            this.store = ref as ModelStore;
+            this.store ??= ref as ModelStore;
             this.resolveInitialized();
           }}>
             <I18nProvider locale={this.props.locale}>

--- a/src/main/scenes/application.tsx
+++ b/src/main/scenes/application.tsx
@@ -32,17 +32,9 @@ const initialState = Object.freeze({
 type State = typeof initialState;
 
 export class Application extends React.Component<Props, State> {
-  private onMounted: (() => void) | undefined;
   state = initialState;
 
   store: RefObject<ModelStore> = createRef();
-
-  constructor(props: Props) {
-    super(props);
-    if (props.onMounted) {
-      this.onMounted = props.onMounted;
-    }
-  }
 
   setCanvas = (ref: CanvasComponent) => {
     if (ref && ref.layer.current) {
@@ -88,11 +80,5 @@ export class Application extends React.Component<Props, State> {
         </RootProvider>
       </CanvasProvider>
     );
-  }
-
-  componentDidMount() {
-    if (this.onMounted) {
-      this.onMounted();
-    }
   }
 }

--- a/src/main/scenes/application.tsx
+++ b/src/main/scenes/application.tsx
@@ -41,7 +41,6 @@ export class Application extends React.Component<Props, State> {
     this.resolveInitialized = resolve;
   });
 
-
   setCanvas = (ref: CanvasComponent) => {
     if (ref && ref.layer.current) {
       this.setState({ canvas: { ...ref, layer: ref.layer.current } });
@@ -61,10 +60,13 @@ export class Application extends React.Component<Props, State> {
     return (
       <CanvasProvider value={canvasContext}>
         <RootProvider value={rootContext}>
-          <StoreProvider initialState={this.props.state} ref={(ref) => {
-            this.store ??= ref as ModelStore;
-            this.resolveInitialized();
-          }}>
+          <StoreProvider
+            initialState={this.props.state}
+            ref={(ref) => {
+              this.store ??= ref as ModelStore;
+              this.resolveInitialized();
+            }}
+          >
             <I18nProvider locale={this.props.locale}>
               <Theme styles={this.props.styles} scale={this.props.state?.editor?.scale}>
                 <Layout className="apollon-editor" ref={this.setLayout}>

--- a/src/main/scenes/application.tsx
+++ b/src/main/scenes/application.tsx
@@ -21,6 +21,7 @@ type Props = {
   state?: PartialModelState;
   styles?: DeepPartial<Styles>;
   locale?: Locale;
+  onMounted?: () => void;
 };
 
 const initialState = Object.freeze({
@@ -31,9 +32,17 @@ const initialState = Object.freeze({
 type State = typeof initialState;
 
 export class Application extends React.Component<Props, State> {
+  private onMounted: (() => void) | undefined;
   state = initialState;
 
   store: RefObject<ModelStore> = createRef();
+
+  constructor(props: Props) {
+    super(props);
+    if (props.onMounted) {
+      this.onMounted = props.onMounted;
+    }
+  }
 
   setCanvas = (ref: CanvasComponent) => {
     if (ref && ref.layer.current) {
@@ -79,5 +88,11 @@ export class Application extends React.Component<Props, State> {
         </RootProvider>
       </CanvasProvider>
     );
+  }
+
+  componentDidMount() {
+    if (this.onMounted) {
+      this.onMounted();
+    }
   }
 }

--- a/src/main/scenes/application.tsx
+++ b/src/main/scenes/application.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, RefObject } from 'react';
+import React, { RefObject } from 'react';
 import { DeepPartial } from 'redux';
 import { Canvas, CanvasComponent } from '../components/canvas/canvas';
 import { CanvasContext, CanvasProvider } from '../components/canvas/canvas-context';
@@ -34,7 +34,13 @@ type State = typeof initialState;
 export class Application extends React.Component<Props, State> {
   state = initialState;
 
-  store: RefObject<ModelStore> = createRef();
+  store?: ModelStore;
+
+  private resolveInitialized: () => void = () => {};
+  private initializedPromise: Promise<void> = new Promise((resolve) => {
+    this.resolveInitialized = resolve;
+  });
+
 
   setCanvas = (ref: CanvasComponent) => {
     if (ref && ref.layer.current) {
@@ -55,7 +61,10 @@ export class Application extends React.Component<Props, State> {
     return (
       <CanvasProvider value={canvasContext}>
         <RootProvider value={rootContext}>
-          <StoreProvider ref={this.store} initialState={this.props.state}>
+          <StoreProvider initialState={this.props.state} ref={(ref) => {
+            this.store = ref as ModelStore;
+            this.resolveInitialized();
+          }}>
             <I18nProvider locale={this.props.locale}>
               <Theme styles={this.props.styles} scale={this.props.state?.editor?.scale}>
                 <Layout className="apollon-editor" ref={this.setLayout}>
@@ -80,5 +89,9 @@ export class Application extends React.Component<Props, State> {
         </RootProvider>
       </CanvasProvider>
     );
+  }
+
+  get initialized(): Promise<void> {
+    return this.initializedPromise;
   }
 }

--- a/src/main/scenes/application.tsx
+++ b/src/main/scenes/application.tsx
@@ -35,7 +35,7 @@ export class Application extends React.Component<Props, State> {
 
   store?: ModelStore;
 
-  private resolveInitialized: () => void = () => {};
+  private resolveInitialized: () => void = () => undefined;
   private initializedPromise: Promise<void> = new Promise((resolve) => {
     this.resolveInitialized = resolve;
   });

--- a/src/tests/unit/apollon-editor-test.tsx
+++ b/src/tests/unit/apollon-editor-test.tsx
@@ -49,43 +49,34 @@ const ignoreSVGClassNames = (svgString: string): string => {
 };
 
 describe('test apollon editor ', () => {
-  it('get and set model', () => {
+  // init editor before each test
+  beforeEach(() => {  
     const { container } = testLibraryRender(<div />);
     act(() => {
       editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
     });
     act(() => {
+      // second act is needed because the editor needs to be initialized already to set the model
       editor.model = testClassDiagram as any;
     });
+  });
+
+  it('get and set model', () => {
     expect(testClassDiagram).toEqual(editor.model);
   });
 
   it('exportModelAsSvg', async () => {
-    const { container } = testLibraryRender(<div />);
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
-    act(() => {
-      editor.model = testClassDiagram as any;
-    });
     const svg: ApollonTypes.SVG = await editor.exportAsSVG();
     expect(ignoreSVGClassNames(svg.svg)).toEqual(testClassDiagramAsSVG);
   });
 
   it('subscribeToSelection', async () => {
-    const { container } = testLibraryRender(<div />);
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
-    act(() => {
-      editor.model = testClassDiagram as any;
-    });
     const selection: Selection = {
       elements: testClassDiagram.elements.map((element) => element.id),
       relationships: testClassDiagram.relationships.map((relationship) => relationship.id),
     };
     const selectionCallback = (s: Selection) => {
-      return expect(s).resolves.toEqual(selection);
+      return expect(s).toEqual(selection);
     };
     editor.subscribeToSelectionChange(selectionCallback);
     act(() => {
@@ -93,13 +84,6 @@ describe('test apollon editor ', () => {
     });
   });
   it('unsubscribeFromSelection', async () => {
-    const { container } = testLibraryRender(<div />);
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
-    act(() => {
-      editor.model = testClassDiagram as any;
-    });
     const selection: Selection = {
       elements: testClassDiagram.elements.map((element) => element.id),
       relationships: testClassDiagram.relationships.map((relationship) => relationship.id),
@@ -126,13 +110,6 @@ describe('test apollon editor ', () => {
     // same test as above, but don't unsubscribe
     // this validates that the timing is enough so that selection callback would be called twice
     // it is still possible that callback would be called twice in unsubscribeFromSelection and not in unsubscribeFromSelectionValidation, but less likely
-    const { container } = testLibraryRender(<div />);
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
-    act(() => {
-      editor.model = testClassDiagram as any;
-    });
     const selection: Selection = {
       elements: testClassDiagram.elements.map((element) => element.id),
       relationships: testClassDiagram.relationships.map((relationship) => relationship.id),
@@ -158,10 +135,6 @@ describe('test apollon editor ', () => {
   });
 
   it('subscribeToAssessmentChange', async () => {
-    const { container } = testLibraryRender(<div />);
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
     // create store to inject into apollon editor, so that actions can be dispatched
     const state = ModelState.fromModel(testClassDiagram as any);
     const elements = Object.keys(state.elements!).map((id) => state.elements![id]);
@@ -192,10 +165,6 @@ describe('test apollon editor ', () => {
     store.dispatch(assessAction);
   });
   it('unsubscribeFromAssessment', () => {
-    const { container } = testLibraryRender(<div />);
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
     // create store to inject into apollon editor, so that actions can be dispatched
     const state = ModelState.fromModel(testClassDiagram as any);
     const elements = Object.keys(state.elements!).map((id) => state.elements![id]);
@@ -237,10 +206,6 @@ describe('test apollon editor ', () => {
     }, 500);
   });
   it('unsubscribeFromAssessmentValidation', () => {
-    const { container } = testLibraryRender(<div />);
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
     // create store to inject into apollon editor, so that actions can be dispatched
     const state = ModelState.fromModel(testClassDiagram as any);
     const elements = Object.keys(state.elements!).map((id) => state.elements![id]);
@@ -282,10 +247,6 @@ describe('test apollon editor ', () => {
   });
 
   it('subscribeToModelChange', () => {
-    const { container } = testLibraryRender(<div />);
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
     // create store to inject into apollon editor, so that actions can be dispatched
     const state = ModelState.fromModel(testClassDiagram as any);
     const elements = Object.keys(state.elements!).map((id) => state.elements![id]);
@@ -308,10 +269,6 @@ describe('test apollon editor ', () => {
     store.dispatch(createElementAction);
   });
   it('unsubscribeFromModelChanges', () => {
-    const { container } = testLibraryRender(<div />);
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
     // create store to inject into apollon editor, so that actions can be dispatched
     const state = ModelState.fromModel(testClassDiagram as any);
     const elements = Object.keys(state.elements!).map((id) => state.elements![id]);
@@ -342,10 +299,6 @@ describe('test apollon editor ', () => {
     }, 500);
   });
   it('unsubscribeFromModelChangesValidation', () => {
-    const { container } = testLibraryRender(<div />);
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
     // create store to inject into apollon editor, so that actions can be dispatched
     const state = ModelState.fromModel(testClassDiagram as any);
     const elements = Object.keys(state.elements!).map((id) => state.elements![id]);
@@ -375,10 +328,6 @@ describe('test apollon editor ', () => {
   });
 
   it('subscribeToDiscreteModelChange', () => {
-    const { container } = testLibraryRender(<div />);
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
     // create store to inject into apollon editor, so that actions can be dispatched
     const state = ModelState.fromModel(testClassDiagram as any);
     const elements = Object.keys(state.elements!).map((id) => state.elements![id]);
@@ -404,11 +353,6 @@ describe('test apollon editor ', () => {
   });
 
   it('unsubscribeFromDiscreteModelChanges', () => {
-    const { container } = testLibraryRender(<div />);
-    let editor = {} as Apollon.ApollonEditor;
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
     // create store to inject into apollon editor, so that actions can be dispatched
     const state = ModelState.fromModel(testClassDiagram as any);
     const elements = Object.keys(state.elements!).map((id) => state.elements![id]);
@@ -442,11 +386,6 @@ describe('test apollon editor ', () => {
   });
 
   it('unsubscribeFromDiscreteModelChangesValidation', () => {
-    const { container } = testLibraryRender(<div />);
-    let editor = {} as Apollon.ApollonEditor;
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
     // create store to inject into apollon editor, so that actions can be dispatched
     const state = ModelState.fromModel(testClassDiagram as any);
     const elements = Object.keys(state.elements!).map((id) => state.elements![id]);
@@ -475,126 +414,54 @@ describe('test apollon editor ', () => {
     }, 500);
   });
   it('set type to UseCaseDiagram', () => {
-    const { container } = testLibraryRender(<div />);
-    let editor = {} as Apollon.ApollonEditor;
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
-    act(() => {
-      editor.model = testClassDiagram as any;
-    });
     act(() => {
       editor.type = UMLDiagramType.UseCaseDiagram;
     });
     expect(editor.model.type).toEqual(UMLDiagramType.UseCaseDiagram);
   });
   it('set type to CommunicationDiagram', () => {
-    const { container } = testLibraryRender(<div />);
-    let editor = {} as Apollon.ApollonEditor;
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
-    act(() => {
-      editor.model = testClassDiagram as any;
-    });
     act(() => {
       editor.type = UMLDiagramType.CommunicationDiagram;
     });
     expect(editor.model.type).toEqual(UMLDiagramType.CommunicationDiagram);
   });
   it('set type to ComponentDiagram', () => {
-    const { container } = testLibraryRender(<div />);
-    let editor = {} as Apollon.ApollonEditor;
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
-    act(() => {
-      editor.model = testClassDiagram as any;
-    });
     act(() => {
       editor.type = UMLDiagramType.ComponentDiagram;
     });
     expect(editor.model.type).toEqual(UMLDiagramType.ComponentDiagram);
   });
   it('set type to DeploymentDiagram', () => {
-    const { container } = testLibraryRender(<div />);
-    let editor = {} as Apollon.ApollonEditor;
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
-    act(() => {
-      editor.model = testClassDiagram as any;
-    });
     act(() => {
       editor.type = UMLDiagramType.DeploymentDiagram;
     });
     expect(editor.model.type).toEqual(UMLDiagramType.DeploymentDiagram);
   });
   it('set type to PetriNet', () => {
-    const { container } = testLibraryRender(<div />);
-    let editor = {} as Apollon.ApollonEditor;
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
-    act(() => {
-      editor.model = testClassDiagram as any;
-    });
     act(() => {
       editor.type = UMLDiagramType.PetriNet;
     });
     expect(editor.model.type).toEqual(UMLDiagramType.PetriNet);
   });
   it('set type to ActivityDiagram', () => {
-    const { container } = testLibraryRender(<div />);
-    let editor = {} as Apollon.ApollonEditor;
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
-    act(() => {
-      editor.model = testClassDiagram as any;
-    });
     act(() => {
       editor.type = UMLDiagramType.ActivityDiagram;
     });
     expect(editor.model.type).toEqual(UMLDiagramType.ActivityDiagram);
   });
   it('set type to ObjectDiagram', () => {
-    const { container } = testLibraryRender(<div />);
-    let editor = {} as Apollon.ApollonEditor;
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
-    act(() => {
-      editor.model = testClassDiagram as any;
-    });
     act(() => {
       editor.type = UMLDiagramType.ObjectDiagram;
     });
     expect(editor.model.type).toEqual(UMLDiagramType.ObjectDiagram);
   });
   it('set type to ClassDiagram', () => {
-    const { container } = testLibraryRender(<div />);
-    let editor = {} as Apollon.ApollonEditor;
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
-    act(() => {
-      editor.model = testClassDiagram as any;
-    });
     act(() => {
       editor.type = UMLDiagramType.ClassDiagram;
     });
     expect(editor.model.type).toEqual(UMLDiagramType.ClassDiagram);
   });
   it('set type to SyntaxTree', () => {
-    const { container } = testLibraryRender(<div />);
-    let editor = {} as Apollon.ApollonEditor;
-    act(() => {
-      editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});
-    });
-    act(() => {
-      editor.model = testClassDiagram as any;
-    });
     act(() => {
       editor.type = UMLDiagramType.SyntaxTree;
     });

--- a/src/tests/unit/apollon-editor-test.tsx
+++ b/src/tests/unit/apollon-editor-test.tsx
@@ -50,7 +50,7 @@ const ignoreSVGClassNames = (svgString: string): string => {
 
 describe('test apollon editor ', () => {
   // init editor before each test
-  beforeEach(() => {  
+  beforeEach(() => {
     const { container } = testLibraryRender(<div />);
     act(() => {
       editor = new Apollon.ApollonEditor(container.firstChild as HTMLElement, {});


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [X] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
To fix flaky client tests related to Apollon in #6955, I need to be able to wait for the next render cycle in React. To my knowledge, this is not possible without some "help" from the React code itself (or with a React testing library, which we don't use). Therefore, we need this PR.

### Description
<!-- Describe your changes in detail -->
Added a new promise to the `ApollonEditor` called `nextRender`, which resolves when the next scheduled React render of the editor component happens. It also ensures that `ApollonEditor.store` will be properly initialized before it resolves.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
- Test https://github.com/ls1intum/Artemis/pull/6955 using `@palsch/apollon:2.14.12`, where this PR is available as an NPM package.
- Run `npm start` locally to check that the standalone editor still works.

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see package.json). -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| File | Line |
|------|-------:|
| apollon-editor.ts | 82% |
| application.tsx | 100% |
