### PR TITLE
Fix issues with end and start node alignment

### DIFF
--- a/src/main/packages/uml-activity-diagram/activity-preview.ts
+++ b/src/main/packages/uml-activity-diagram/activity-preview.ts
@@ -31,14 +31,14 @@ export const composeActivityPreview: ComposePreview = (
 
   // Activity Initial Node
   const activityInitialNode = new UMLActivityInitialNode({
-    bounds: { x: 0, y: 0, width: 45 * scale, height: 45 * scale },
+    bounds: { x: 0, y: 0, width: 50 * scale, height: 50 * scale },
   });
 
   elements.push(activityInitialNode);
 
   // Activity Final Node
   const activityFinalNode = new UMLActivityFinalNode({
-    bounds: { x: 0, y: 0, width: 45 * scale, height: 45 * scale },
+    bounds: { x: 0, y: 0, width: 50 * scale, height: 50 * scale },
   });
   elements.push(activityFinalNode);
 

--- a/src/main/packages/uml-activity-diagram/uml-activity-final-node/uml-activity-final-node.ts
+++ b/src/main/packages/uml-activity-diagram/uml-activity-final-node/uml-activity-final-node.ts
@@ -13,7 +13,7 @@ export class UMLActivityFinalNode extends UMLElement {
   static features: UMLElementFeatures = { ...UMLElement.features, resizable: false, updatable: false };
 
   type: UMLElementType = ActivityElementType.ActivityFinalNode;
-  bounds: IBoundary = { ...this.bounds, width: 45, height: 45 };
+  bounds: IBoundary = { ...this.bounds, width: 50, height: 50 };
 
   constructor(values?: DeepPartial<IUMLElement>) {
     super(values);

--- a/src/main/packages/uml-activity-diagram/uml-activity-initial-node/uml-activity-initial-node.ts
+++ b/src/main/packages/uml-activity-diagram/uml-activity-initial-node/uml-activity-initial-node.ts
@@ -14,7 +14,7 @@ export class UMLActivityInitialNode extends UMLElement {
   static features: UMLElementFeatures = { ...UMLElement.features, resizable: false, updatable: false };
 
   type: UMLElementType = ActivityElementType.ActivityInitialNode;
-  bounds: IBoundary = { ...this.bounds, width: 45, height: 45 };
+  bounds: IBoundary = { ...this.bounds, width: 50, height: 50 };
 
   constructor(values?: DeepPartial<IUMLElement>) {
     super(values);

--- a/src/tests/unit/packages/uml-activity-diagram/uml-activity-final-node/__snapshots__/uml-activity-final-node-component-test.tsx.snap
+++ b/src/tests/unit/packages/uml-activity-diagram/uml-activity-final-node/__snapshots__/uml-activity-final-node-component-test.tsx.snap
@@ -10,7 +10,7 @@ exports[`render the uml-activity-final-node-component 1`] = `
           cx="50%"
           cy="50%"
           fill="white"
-          r="20"
+          r="22.5"
           stroke="black"
           stroke-width="5"
         />
@@ -20,7 +20,7 @@ exports[`render the uml-activity-final-node-component 1`] = `
           cy="50%"
           fill="black"
           fill-opacity="1"
-          r="15"
+          r="17.5"
           stroke="none"
         />
       </g>

--- a/src/tests/unit/packages/uml-activity-diagram/uml-activity-initial-node/__snapshots__/uml-activity-initial-node-component-test.tsx.snap
+++ b/src/tests/unit/packages/uml-activity-diagram/uml-activity-initial-node/__snapshots__/uml-activity-initial-node-component-test.tsx.snap
@@ -11,7 +11,7 @@ exports[`render the uml-activity-intial-node-component 1`] = `
           cy="50%"
           fill="black"
           fill-opacity="1"
-          r="22.5"
+          r="25"
           stroke="none"
         />
       </g>


### PR DESCRIPTION
This PR fixes issues with the alignment of start and end node on the activity diagram.

<img width="245" alt="Screenshot 2023-09-26 at 09 38 48" src="https://github.com/ls1intum/Apollon/assets/143808484/47b70d77-9afb-4994-b569-613a71d3dd33">

### Checklist
- [ ] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes
- [ ] I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. ...

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see package.json). -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| File | Branch | Line |
|------|-------:|-----:|
<!--
| uml-activity-fork-node-component.ts | 85% | 77% |
| uml-activity-action-node-component.ts | 13% | 95% |
-->
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
