### PR TITLE
Move zoom pane styles to styled component to ensure no issues when in…

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -145,7 +145,7 @@ aside.sidebar section>div {
   justify-content: space-between;
 }
 
-button {
+.switch button {
   background: var(--apollon-background);
   color: var(--apollon-primary-contrast);
   border: 1px solid var(--apollon-gray);
@@ -155,12 +155,12 @@ button {
   outline: none;
 }
 
-button:hover {
+.switch button:hover {
   background-color: var(--apollon-gray);
   border-color: var(--apollon-gray-variant);
 }
 
-button:active {
+.switch button:active {
   background-color: var(--apollon-gray);
   border-color: var(--apollon-gray-variant);
 }

--- a/src/main/components/canvas/zoom-pane.tsx
+++ b/src/main/components/canvas/zoom-pane.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { clamp } from '../../utils/clamp';
+import { styled } from '../theme/styles';
 
 type Props = {
   min?: number;
@@ -9,21 +10,39 @@ type Props = {
   onChange: (value: number) => void;
 };
 
+const ZoomButton = styled.button`
+  background: var(--apollon-background);
+  color: var(--apollon-primary-contrast);
+  border: 1px solid var(--apollon-gray);
+  margin: 0;
+  outline: none;
+  border-radius: 0.25rem;
+  width: 2.25em;
+  height: 2.25em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  :hover {
+    background-color: var(--apollon-gray);
+    border-color: var(--apollon-gray-variant);
+  }
+
+  :active {
+    background-color: var(--apollon-gray);
+    border-color: var(--apollon-gray-variant);
+  }
+`;
+
 export const ZoomPaneComponent: FunctionComponent<Props> = (props) => {
   const { min = 0.5, max = 5, step = 0.5, value, onChange } = props;
 
   return (
     <div style={{ position: 'absolute', left: '0.75em', bottom: '0.75em', display: 'flex' }}>
-      <button
-        style={{ marginRight: '0.5em' }}
-        className="button-rounded"
-        onClick={() => onChange(clamp(value + step, min, max))}
-      >
+      <ZoomButton style={{ marginRight: '0.5em' }} onClick={() => onChange(clamp(value + step, min, max))}>
         +
-      </button>
-      <button className="button-rounded" onClick={() => onChange(clamp(value - step, min, max))}>
-        -
-      </button>
+      </ZoomButton>
+      <ZoomButton onClick={() => onChange(clamp(value - step, min, max))}>-</ZoomButton>
     </div>
   );
 };

--- a/src/tests/unit/components/update-pane/__snapshots__/update-pane-test.tsx.snap
+++ b/src/tests/unit/components/update-pane/__snapshots__/update-pane-test.tsx.snap
@@ -1,6 +1,642 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`test update pane render with element 1`] = `
+.c12 {
+  height: 1em;
+  vertical-align: middle;
+  width: 1em;
+}
+
+.c2 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  min-width: 100%;
+  min-height: 100%;
+  outline: none;
+  overflow: visible;
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+  fill: white;
+}
+
+.c3 {
+  background: var(--apollon-background);
+  color: var(--apollon-primary-contrast);
+  border: 1px solid var(--apollon-gray);
+  margin: 0;
+  outline: none;
+  border-radius: 0.25rem;
+  width: 2.25em;
+  height: 2.25em;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c3:hover {
+  background-color: var(--apollon-gray);
+  border-color: var(--apollon-gray-variant);
+}
+
+.c3:active {
+  background-color: var(--apollon-gray);
+  border-color: var(--apollon-gray-variant);
+}
+
+.c1 {
+  display: block;
+  overflow: auto;
+  position: relative;
+  min-height: inherit;
+  max-height: inherit;
+  width: 100%;
+  height: 100%;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+  border: 1px solid var(--apollon-gray,#e9ecef);
+  background-position: calc(50% + 24.5px) calc(50% + 24.5px);
+  background-size: 50px 50px, 50px 50px, 10px 10px, 10px 10px;
+  background-image: linear-gradient(to right,var(--apollon-grid,rgba(36,39,36,0.1)) 1px,transparent 1px), linear-gradient(to bottom,var(--apollon-grid,rgba(36,39,36,0.1)) 1px,transparent 1px), linear-gradient(to right,var(--apollon-gray,#e9ecef) 1px,transparent 1px), linear-gradient(to bottom,var(--apollon-gray,#e9ecef) 1px,transparent 1px);
+  background-repeat: repeat;
+  background-attachment: local;
+  -webkit-transition: -webkit-transform 500ms, width 500ms, height 500ms;
+  -webkit-transition: transform 500ms, width 500ms, height 500ms;
+  transition: transform 500ms, width 500ms, height 500ms;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.c10 {
+  -webkit-appearance: button;
+  -moz-appearance: button;
+  appearance: button;
+  background-color: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.25em;
+  font-family: inherit;
+  font-size: 1em;
+  font-weight: 400;
+  line-height: 1.5;
+  margin: 0;
+  overflow: visible;
+  padding: 0.375em 0.75em;
+  text-transform: none;
+  -webkit-transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c10 svg {
+  pointer-events: none;
+}
+
+.c10::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c10:focus {
+  outline: 0;
+}
+
+.c10:not(:disabled) {
+  cursor: pointer;
+}
+
+.c11 {
+  border-radius: 0.2em;
+  font-size: 0.875em;
+  padding: 0.25em 0.5em;
+  color: var(--apollon-primary,#2a8fbd);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  fill: var(--apollon-primary-contrast,#212529);
+}
+
+.c15 {
+  border-radius: 0.2em;
+  font-size: 0.875em;
+  padding: 0.25em 0.5em;
+  border-color: var(--apollon-primary,#2a8fbd);
+  color: var(--apollon-primary,#2a8fbd);
+}
+
+.c15:focus {
+  box-shadow: 0 0 0 0.2em var(--apollon-primary,#2a8fbd)80;
+}
+
+.c15:hover {
+  background-color: var(--apollon-primary,#2a8fbd);
+  color: var(--apollon-background,#ffffff);
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 1.9rem;
+}
+
+.c16 {
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c16:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c16:first-child {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c16:last-child {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c16:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c8 {
+  background-clip: padding-box;
+  background-color: var(--apollon-background,#ffffff);
+  border: 1px solid var(--apollon-gray-variant,#343a40);
+  border-radius: 0.25em;
+  color: var(--apollon-gray-variant,#343a40);
+  font-family: Helvetica Neue,Helvetica,Arial,sans-serif,sans-serif;
+  font-size: 1em;
+  font-weight: 400;
+  line-height: 1.5;
+  margin: 0;
+  overflow: visible;
+  padding: 0.375em 0.75em;
+  -webkit-transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.c8:focus {
+  border-color: #404040;
+  outline: 0;
+  box-shadow: 0 0 0 0.2em var(--apollon-primary,#2a8fbd)40;
+}
+
+.c8::-webkit-input-placeholder {
+  color: var(--apollon-gray-variant,#343a40);
+  opacity: 1;
+}
+
+.c8::-moz-placeholder {
+  color: var(--apollon-gray-variant,#343a40);
+  opacity: 1;
+}
+
+.c8:-ms-input-placeholder {
+  color: var(--apollon-gray-variant,#343a40);
+  opacity: 1;
+}
+
+.c8::placeholder {
+  color: var(--apollon-gray-variant,#343a40);
+  opacity: 1;
+}
+
+.c9 {
+  display: block;
+  width: 100%;
+  border-radius: 0.2em;
+  font-size: 0.875em;
+  padding: 0.25em 0.5em;
+}
+
+.c19 {
+  margin-bottom: 0.5em;
+  display: block;
+  width: 100%;
+  border-radius: 0.2em;
+  font-size: 0.875em;
+  padding: 0.25em 0.5em;
+}
+
+.c20 {
+  display: block;
+  width: 100%;
+  border-radius: 0.2em;
+  font-size: 0.875em;
+  padding: 0.25em 0.5em;
+}
+
+.c20:not(:focus) {
+  border-style: dashed;
+}
+
+.c20:not(:focus):not(:hover) {
+  background: var(--apollon-background,#ffffff);
+  opacity: 0.5;
+}
+
+.c17 {
+  margin-top: 0;
+  font-size: 1.25em;
+  font-weight: 500;
+  line-height: 1.2;
+  margin-bottom: 0.5em;
+}
+
+.c13 {
+  border: 0;
+  border-top: 1px solid var(--apollon-primary-contrast,#212529);
+  box-sizing: content-box;
+  height: 0;
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+  overflow: visible;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c4 {
+  background-clip: padding-box;
+  background-color: var(--apollon-background-variant,#e5e5e5);
+  border: 1px solid var(--apollon-primary-contrast,#212529)33;
+  border-radius: 0.3em;
+  box-sizing: border-box;
+  display: block;
+  -webkit-filter: drop-shadow(0 2px 2px rgba(0,0,0,0.2));
+  filter: drop-shadow(0 2px 2px rgba(0,0,0,0.2));
+  font-family: Helvetica Neue,Helvetica,Arial,sans-serif,sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  left: 0;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  line-break: auto;
+  line-height: 1.5;
+  max-width: 276px;
+  position: absolute;
+  text-align: left;
+  text-align: start;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: none;
+  text-shadow: none;
+  top: 0;
+  will-change: transform;
+  white-space: normal;
+  word-break: normal;
+  word-spacing: normal;
+  word-wrap: break-word;
+  -webkit-transform: translate(calc(0px - 100% - 0.5em),calc(100px - 100%));
+  -ms-transform: translate(calc(0px - 100% - 0.5em),calc(100px - 100%));
+  transform: translate(calc(0px - 100% - 0.5em),calc(100px - 100%));
+}
+
+.c4 *,
+.c4 *:before,
+.c4 *:after {
+  box-sizing: inherit;
+}
+
+.c6 {
+  color: var(--apollon-primary-contrast,#212529);
+  padding: 0.5em 0.75em;
+  max-height: 500px;
+  overflow: auto;
+}
+
+.c5 {
+  display: block;
+  height: 0.5em;
+  position: absolute;
+  width: 1em;
+  height: 1em;
+  right: calc((0.5em + 1px) * -1);
+  width: 0.5em;
+  bottom: 0.3em;
+}
+
+.c5::before,
+.c5::after {
+  content: '';
+  border-color: transparent;
+  border-style: solid;
+  display: block;
+  position: absolute;
+}
+
+.c5::before {
+  border-left-color: var(--apollon-primary-contrast,#212529)33;
+  border-width: 0.5em 0 0.5em 0.5em;
+  right: 0;
+}
+
+.c5::after {
+  border-left-color: var(--apollon-gray,#e9ecef);
+  border-width: 0.5em 0 0.5em 0.5em;
+  right: 1px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-width: inherit;
+  min-height: inherit;
+  max-width: inherit;
+  max-height: inherit;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: relative;
+  touch-action: none;
+  font-family: Helvetica Neue,Helvetica,Arial,sans-serif,sans-serif;
+  font-size: 16px;
+  color: var(--apollon-primary-contrast,#212529);
+  font-weight: 400;
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.c0 *,
+.c0 *:before,
+.c0 *:after {
+  box-sizing: inherit;
+}
+
+.c0 svg text {
+  fill: var(--apollon-primary-contrast,#212529);
+  font-family: Helvetica Neue,Helvetica,Arial,sans-serif;
+  font-size: 16px;
+}
+
+.c0 svg marker,
+.c0 svg text {
+  fill-opacity: 1;
+}
+
+.c0 svg * {
+  overflow: visible;
+}
+
+<body>
+  <div>
+    <div
+      class="c0 apollon-editor"
+    >
+      <div
+        style="height: 100%; width: 100%; overflow: hidden;"
+      >
+        <div
+          class="c1"
+          scale="1"
+        >
+          <svg
+            class="c2"
+            data-cy="modeling-editor-canvas"
+            height="640"
+            id="modeling-editor-canvas"
+            tabindex="-1"
+            width="840"
+          >
+            <g
+              style="transform-origin: top left; transform: translate(0px,0px);"
+            />
+          </svg>
+        </div>
+        <div
+          style="position: absolute; left: 0.75em; bottom: 0.75em; display: flex;"
+        >
+          <button
+            class="c3"
+            style="margin-right: 0.5em;"
+          >
+            +
+          </button>
+          <button
+            class="c3"
+          >
+            -
+          </button>
+        </div>
+      </div>
+      <div
+        class="c4"
+      >
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+        >
+          <div>
+            <section>
+              <div
+                class="c7"
+              >
+                <input
+                  class="c8 c9"
+                  maxlength="100"
+                  value=""
+                />
+                <button
+                  class="c10 c11"
+                  color="link"
+                  tabindex="-1"
+                >
+                  <svg
+                    class="c12"
+                    height="16px"
+                    viewBox="0 0 448 512"
+                    width="16px"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M440 64H336l-33.6-44.8A48 48 0 0 0 264 0h-80a48 48 0 0 0-38.4 19.2L112 64H8a8 8 0 0 0-8 8v16a8 8 0 0 0 8 8h18.9l33.2 372.3a48 48 0 0 0 47.8 43.7h232.2a48 48 0 0 0 47.8-43.7L421.1 96H440a8 8 0 0 0 8-8V72a8 8 0 0 0-8-8zM171.2 38.4A16.1 16.1 0 0 1 184 32h80a16.1 16.1 0 0 1 12.8 6.4L296 64H152zm184.8 427a15.91 15.91 0 0 1-15.9 14.6H107.9A15.91 15.91 0 0 1 92 465.4L59 96h330z"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <hr
+                class="c13"
+              />
+            </section>
+            <section>
+              <div
+                class="c14"
+              >
+                <button
+                  class="c10 c15 c16"
+                  color="primary"
+                >
+                  Abstract
+                </button>
+                <button
+                  class="c10 c15 c16"
+                  color="primary"
+                >
+                  Interface
+                </button>
+                <button
+                  class="c10 c15 c16"
+                  color="primary"
+                >
+                  Enumeration
+                </button>
+              </div>
+              <hr
+                class="c13"
+              />
+            </section>
+            <section>
+              <h1
+                class="c17"
+              >
+                Attributes
+              </h1>
+              <div
+                class="c18"
+              >
+                <input
+                  class="c8 c19"
+                  maxlength="100"
+                  value=""
+                />
+                <button
+                  class="c10 c11"
+                  color="link"
+                  tabindex="-1"
+                >
+                  <svg
+                    class="c12"
+                    height="16px"
+                    viewBox="0 0 448 512"
+                    width="16px"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M440 64H336l-33.6-44.8A48 48 0 0 0 264 0h-80a48 48 0 0 0-38.4 19.2L112 64H8a8 8 0 0 0-8 8v16a8 8 0 0 0 8 8h18.9l33.2 372.3a48 48 0 0 0 47.8 43.7h232.2a48 48 0 0 0 47.8-43.7L421.1 96H440a8 8 0 0 0 8-8V72a8 8 0 0 0-8-8zM171.2 38.4A16.1 16.1 0 0 1 184 32h80a16.1 16.1 0 0 1 12.8 6.4L296 64H152zm184.8 427a15.91 15.91 0 0 1-15.9 14.6H107.9A15.91 15.91 0 0 1 92 465.4L59 96h330z"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <input
+                class="c8 c20"
+                maxlength="100"
+                value=""
+              />
+            </section>
+            <section>
+              <hr
+                class="c13"
+              />
+              <h1
+                class="c17"
+              >
+                Methods
+              </h1>
+              <div
+                class="c18"
+              >
+                <input
+                  class="c8 c19"
+                  maxlength="100"
+                  value=""
+                />
+                <button
+                  class="c10 c11"
+                  color="link"
+                  tabindex="-1"
+                >
+                  <svg
+                    class="c12"
+                    height="16px"
+                    viewBox="0 0 448 512"
+                    width="16px"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M440 64H336l-33.6-44.8A48 48 0 0 0 264 0h-80a48 48 0 0 0-38.4 19.2L112 64H8a8 8 0 0 0-8 8v16a8 8 0 0 0 8 8h18.9l33.2 372.3a48 48 0 0 0 47.8 43.7h232.2a48 48 0 0 0 47.8-43.7L421.1 96H440a8 8 0 0 0 8-8V72a8 8 0 0 0-8-8zM171.2 38.4A16.1 16.1 0 0 1 184 32h80a16.1 16.1 0 0 1 12.8 6.4L296 64H152zm184.8 427a15.91 15.91 0 0 1-15.9 14.6H107.9A15.91 15.91 0 0 1 92 465.4L59 96h330z"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <input
+                class="c8 c20"
+                maxlength="100"
+                value=""
+              />
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`test update pane render with relationship 1`] = `
 .c11 {
   height: 1em;
   vertical-align: middle;
@@ -19,6 +655,39 @@ exports[`test update pane render with element 1`] = `
   -ms-transform-origin: center center;
   transform-origin: center center;
   fill: white;
+}
+
+.c3 {
+  background: var(--apollon-background);
+  color: var(--apollon-primary-contrast);
+  border: 1px solid var(--apollon-gray);
+  margin: 0;
+  outline: none;
+  border-radius: 0.25rem;
+  width: 2.25em;
+  height: 2.25em;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c3:hover {
+  background-color: var(--apollon-gray);
+  border-color: var(--apollon-gray-variant);
+}
+
+.c3:active {
+  background-color: var(--apollon-gray);
+  border-color: var(--apollon-gray-variant);
 }
 
 .c1 {
@@ -97,7 +766,9 @@ exports[`test update pane render with element 1`] = `
   fill: var(--apollon-primary-contrast,#212529);
 }
 
-.c14 {
+.c13 {
+  display: block;
+  width: 100%;
   border-radius: 0.2em;
   font-size: 0.875em;
   padding: 0.25em 0.5em;
@@ -105,51 +776,16 @@ exports[`test update pane render with element 1`] = `
   color: var(--apollon-primary,#2a8fbd);
 }
 
-.c14:focus {
+.c13:focus {
   box-shadow: 0 0 0 0.2em var(--apollon-primary,#2a8fbd)80;
 }
 
-.c14:hover {
+.c13:hover {
   background-color: var(--apollon-primary,#2a8fbd);
   color: var(--apollon-background,#ffffff);
 }
 
-.c13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-height: 1.9rem;
-}
-
-.c15 {
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.c15:not(:first-child) {
-  margin-left: -1px;
-}
-
-.c15:first-child {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
-.c15:last-child {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-
-.c15:not(:first-child):not(:last-child) {
-  border-radius: 0;
-}
-
-.c7 {
+.c17 {
   background-clip: padding-box;
   background-color: var(--apollon-background,#ffffff);
   border: 1px solid var(--apollon-gray-variant,#343a40);
@@ -166,38 +802,30 @@ exports[`test update pane render with element 1`] = `
   transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
-.c7:focus {
+.c17:focus {
   border-color: #404040;
   outline: 0;
   box-shadow: 0 0 0 0.2em var(--apollon-primary,#2a8fbd)40;
 }
 
-.c7::-webkit-input-placeholder {
+.c17::-webkit-input-placeholder {
   color: var(--apollon-gray-variant,#343a40);
   opacity: 1;
 }
 
-.c7::-moz-placeholder {
+.c17::-moz-placeholder {
   color: var(--apollon-gray-variant,#343a40);
   opacity: 1;
 }
 
-.c7:-ms-input-placeholder {
+.c17:-ms-input-placeholder {
   color: var(--apollon-gray-variant,#343a40);
   opacity: 1;
 }
 
-.c7::placeholder {
+.c17::placeholder {
   color: var(--apollon-gray-variant,#343a40);
   opacity: 1;
-}
-
-.c8 {
-  display: block;
-  width: 100%;
-  border-radius: 0.2em;
-  font-size: 0.875em;
-  padding: 0.25em 0.5em;
 }
 
 .c18 {
@@ -217,569 +845,7 @@ exports[`test update pane render with element 1`] = `
   padding: 0.25em 0.5em;
 }
 
-.c19:not(:focus) {
-  border-style: dashed;
-}
-
-.c19:not(:focus):not(:hover) {
-  background: var(--apollon-background,#ffffff);
-  opacity: 0.5;
-}
-
-.c16 {
-  margin-top: 0;
-  font-size: 1.25em;
-  font-weight: 500;
-  line-height: 1.2;
-  margin-bottom: 0.5em;
-}
-
-.c12 {
-  border: 0;
-  border-top: 1px solid var(--apollon-primary-contrast,#212529);
-  box-sizing: content-box;
-  height: 0;
-  margin-top: 0.75em;
-  margin-bottom: 0.75em;
-  overflow: visible;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c3 {
-  background-clip: padding-box;
-  background-color: var(--apollon-background-variant,#e5e5e5);
-  border: 1px solid var(--apollon-primary-contrast,#212529)33;
-  border-radius: 0.3em;
-  box-sizing: border-box;
-  display: block;
-  -webkit-filter: drop-shadow(0 2px 2px rgba(0,0,0,0.2));
-  filter: drop-shadow(0 2px 2px rgba(0,0,0,0.2));
-  font-family: Helvetica Neue,Helvetica,Arial,sans-serif,sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  left: 0;
-  -webkit-letter-spacing: normal;
-  -moz-letter-spacing: normal;
-  -ms-letter-spacing: normal;
-  letter-spacing: normal;
-  line-break: auto;
-  line-height: 1.5;
-  max-width: 276px;
-  position: absolute;
-  text-align: left;
-  text-align: start;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: none;
-  text-shadow: none;
-  top: 0;
-  will-change: transform;
-  white-space: normal;
-  word-break: normal;
-  word-spacing: normal;
-  word-wrap: break-word;
-  -webkit-transform: translate(calc(0px - 100% - 0.5em),calc(100px - 100%));
-  -ms-transform: translate(calc(0px - 100% - 0.5em),calc(100px - 100%));
-  transform: translate(calc(0px - 100% - 0.5em),calc(100px - 100%));
-}
-
-.c3 *,
-.c3 *:before,
-.c3 *:after {
-  box-sizing: inherit;
-}
-
-.c5 {
-  color: var(--apollon-primary-contrast,#212529);
-  padding: 0.5em 0.75em;
-  max-height: 500px;
-  overflow: auto;
-}
-
-.c4 {
-  display: block;
-  height: 0.5em;
-  position: absolute;
-  width: 1em;
-  height: 1em;
-  right: calc((0.5em + 1px) * -1);
-  width: 0.5em;
-  bottom: 0.3em;
-}
-
-.c4::before,
-.c4::after {
-  content: '';
-  border-color: transparent;
-  border-style: solid;
-  display: block;
-  position: absolute;
-}
-
-.c4::before {
-  border-left-color: var(--apollon-primary-contrast,#212529)33;
-  border-width: 0.5em 0 0.5em 0.5em;
-  right: 0;
-}
-
-.c4::after {
-  border-left-color: var(--apollon-gray,#e9ecef);
-  border-width: 0.5em 0 0.5em 0.5em;
-  right: 1px;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-  height: 100%;
-  min-width: inherit;
-  min-height: inherit;
-  max-width: inherit;
-  max-height: inherit;
-  box-sizing: border-box;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  position: relative;
-  touch-action: none;
-  font-family: Helvetica Neue,Helvetica,Arial,sans-serif,sans-serif;
-  font-size: 16px;
-  color: var(--apollon-primary-contrast,#212529);
-  font-weight: 400;
-  line-height: 1.5;
-  -webkit-text-size-adjust: 100%;
-  text-size-adjust: 100%;
-  -webkit-tap-highlight-color: transparent;
-}
-
-.c0 *,
-.c0 *:before,
-.c0 *:after {
-  box-sizing: inherit;
-}
-
-.c0 svg text {
-  fill: var(--apollon-primary-contrast,#212529);
-  font-family: Helvetica Neue,Helvetica,Arial,sans-serif;
-  font-size: 16px;
-}
-
-.c0 svg marker,
-.c0 svg text {
-  fill-opacity: 1;
-}
-
-.c0 svg * {
-  overflow: visible;
-}
-
-<body>
-  <div>
-    <div
-      class="c0 apollon-editor"
-    >
-      <div
-        style="height: 100%; width: 100%; overflow: hidden;"
-      >
-        <div
-          class="c1"
-          scale="1"
-        >
-          <svg
-            class="c2"
-            data-cy="modeling-editor-canvas"
-            height="640"
-            id="modeling-editor-canvas"
-            tabindex="-1"
-            width="840"
-          >
-            <g
-              style="transform-origin: top left; transform: translate(0px,0px);"
-            />
-          </svg>
-        </div>
-        <div
-          style="position: absolute; left: 0.75em; bottom: 0.75em; display: flex;"
-        >
-          <button
-            class="button-rounded"
-            style="margin-right: 0.5em;"
-          >
-            +
-          </button>
-          <button
-            class="button-rounded"
-          >
-            -
-          </button>
-        </div>
-      </div>
-      <div
-        class="c3"
-      >
-        <div
-          class="c4"
-        />
-        <div
-          class="c5"
-        >
-          <div>
-            <section>
-              <div
-                class="c6"
-              >
-                <input
-                  class="c7 c8"
-                  maxlength="100"
-                  value=""
-                />
-                <button
-                  class="c9 c10"
-                  color="link"
-                  tabindex="-1"
-                >
-                  <svg
-                    class="c11"
-                    height="16px"
-                    viewBox="0 0 448 512"
-                    width="16px"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M440 64H336l-33.6-44.8A48 48 0 0 0 264 0h-80a48 48 0 0 0-38.4 19.2L112 64H8a8 8 0 0 0-8 8v16a8 8 0 0 0 8 8h18.9l33.2 372.3a48 48 0 0 0 47.8 43.7h232.2a48 48 0 0 0 47.8-43.7L421.1 96H440a8 8 0 0 0 8-8V72a8 8 0 0 0-8-8zM171.2 38.4A16.1 16.1 0 0 1 184 32h80a16.1 16.1 0 0 1 12.8 6.4L296 64H152zm184.8 427a15.91 15.91 0 0 1-15.9 14.6H107.9A15.91 15.91 0 0 1 92 465.4L59 96h330z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <hr
-                class="c12"
-              />
-            </section>
-            <section>
-              <div
-                class="c13"
-              >
-                <button
-                  class="c9 c14 c15"
-                  color="primary"
-                >
-                  Abstract
-                </button>
-                <button
-                  class="c9 c14 c15"
-                  color="primary"
-                >
-                  Interface
-                </button>
-                <button
-                  class="c9 c14 c15"
-                  color="primary"
-                >
-                  Enumeration
-                </button>
-              </div>
-              <hr
-                class="c12"
-              />
-            </section>
-            <section>
-              <h1
-                class="c16"
-              >
-                Attributes
-              </h1>
-              <div
-                class="c17"
-              >
-                <input
-                  class="c7 c18"
-                  maxlength="100"
-                  value=""
-                />
-                <button
-                  class="c9 c10"
-                  color="link"
-                  tabindex="-1"
-                >
-                  <svg
-                    class="c11"
-                    height="16px"
-                    viewBox="0 0 448 512"
-                    width="16px"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M440 64H336l-33.6-44.8A48 48 0 0 0 264 0h-80a48 48 0 0 0-38.4 19.2L112 64H8a8 8 0 0 0-8 8v16a8 8 0 0 0 8 8h18.9l33.2 372.3a48 48 0 0 0 47.8 43.7h232.2a48 48 0 0 0 47.8-43.7L421.1 96H440a8 8 0 0 0 8-8V72a8 8 0 0 0-8-8zM171.2 38.4A16.1 16.1 0 0 1 184 32h80a16.1 16.1 0 0 1 12.8 6.4L296 64H152zm184.8 427a15.91 15.91 0 0 1-15.9 14.6H107.9A15.91 15.91 0 0 1 92 465.4L59 96h330z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <input
-                class="c7 c19"
-                maxlength="100"
-                value=""
-              />
-            </section>
-            <section>
-              <hr
-                class="c12"
-              />
-              <h1
-                class="c16"
-              >
-                Methods
-              </h1>
-              <div
-                class="c17"
-              >
-                <input
-                  class="c7 c18"
-                  maxlength="100"
-                  value=""
-                />
-                <button
-                  class="c9 c10"
-                  color="link"
-                  tabindex="-1"
-                >
-                  <svg
-                    class="c11"
-                    height="16px"
-                    viewBox="0 0 448 512"
-                    width="16px"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M440 64H336l-33.6-44.8A48 48 0 0 0 264 0h-80a48 48 0 0 0-38.4 19.2L112 64H8a8 8 0 0 0-8 8v16a8 8 0 0 0 8 8h18.9l33.2 372.3a48 48 0 0 0 47.8 43.7h232.2a48 48 0 0 0 47.8-43.7L421.1 96H440a8 8 0 0 0 8-8V72a8 8 0 0 0-8-8zM171.2 38.4A16.1 16.1 0 0 1 184 32h80a16.1 16.1 0 0 1 12.8 6.4L296 64H152zm184.8 427a15.91 15.91 0 0 1-15.9 14.6H107.9A15.91 15.91 0 0 1 92 465.4L59 96h330z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <input
-                class="c7 c19"
-                maxlength="100"
-                value=""
-              />
-            </section>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`test update pane render with relationship 1`] = `
-.c10 {
-  height: 1em;
-  vertical-align: middle;
-  width: 1em;
-}
-
-.c2 {
-  position: absolute;
-  top: 0;
-  left: 0;
-  min-width: 100%;
-  min-height: 100%;
-  outline: none;
-  overflow: visible;
-  -webkit-transform-origin: center center;
-  -ms-transform-origin: center center;
-  transform-origin: center center;
-  fill: white;
-}
-
-.c1 {
-  display: block;
-  overflow: auto;
-  position: relative;
-  min-height: inherit;
-  max-height: inherit;
-  width: 100%;
-  height: 100%;
-  -ms-overflow-style: -ms-autohiding-scrollbar;
-  border: 1px solid var(--apollon-gray,#e9ecef);
-  background-position: calc(50% + 24.5px) calc(50% + 24.5px);
-  background-size: 50px 50px, 50px 50px, 10px 10px, 10px 10px;
-  background-image: linear-gradient(to right,var(--apollon-grid,rgba(36,39,36,0.1)) 1px,transparent 1px), linear-gradient(to bottom,var(--apollon-grid,rgba(36,39,36,0.1)) 1px,transparent 1px), linear-gradient(to right,var(--apollon-gray,#e9ecef) 1px,transparent 1px), linear-gradient(to bottom,var(--apollon-gray,#e9ecef) 1px,transparent 1px);
-  background-repeat: repeat;
-  background-attachment: local;
-  -webkit-transition: -webkit-transform 500ms, width 500ms, height 500ms;
-  -webkit-transition: transform 500ms, width 500ms, height 500ms;
-  transition: transform 500ms, width 500ms, height 500ms;
-  -webkit-transform-origin: top left;
-  -ms-transform-origin: top left;
-  transform-origin: top left;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
 .c8 {
-  -webkit-appearance: button;
-  -moz-appearance: button;
-  appearance: button;
-  background-color: transparent;
-  border: 1px solid transparent;
-  border-radius: 0.25em;
-  font-family: inherit;
-  font-size: 1em;
-  font-weight: 400;
-  line-height: 1.5;
-  margin: 0;
-  overflow: visible;
-  padding: 0.375em 0.75em;
-  text-transform: none;
-  -webkit-transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.c8 svg {
-  pointer-events: none;
-}
-
-.c8::-moz-focus-inner {
-  border-style: none;
-  padding: 0;
-}
-
-.c8:focus {
-  outline: 0;
-}
-
-.c8:not(:disabled) {
-  cursor: pointer;
-}
-
-.c9 {
-  border-radius: 0.2em;
-  font-size: 0.875em;
-  padding: 0.25em 0.5em;
-  color: var(--apollon-primary,#2a8fbd);
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  fill: var(--apollon-primary-contrast,#212529);
-}
-
-.c12 {
-  display: block;
-  width: 100%;
-  border-radius: 0.2em;
-  font-size: 0.875em;
-  padding: 0.25em 0.5em;
-  border-color: var(--apollon-primary,#2a8fbd);
-  color: var(--apollon-primary,#2a8fbd);
-}
-
-.c12:focus {
-  box-shadow: 0 0 0 0.2em var(--apollon-primary,#2a8fbd)80;
-}
-
-.c12:hover {
-  background-color: var(--apollon-primary,#2a8fbd);
-  color: var(--apollon-background,#ffffff);
-}
-
-.c16 {
-  background-clip: padding-box;
-  background-color: var(--apollon-background,#ffffff);
-  border: 1px solid var(--apollon-gray-variant,#343a40);
-  border-radius: 0.25em;
-  color: var(--apollon-gray-variant,#343a40);
-  font-family: Helvetica Neue,Helvetica,Arial,sans-serif,sans-serif;
-  font-size: 1em;
-  font-weight: 400;
-  line-height: 1.5;
-  margin: 0;
-  overflow: visible;
-  padding: 0.375em 0.75em;
-  -webkit-transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-}
-
-.c16:focus {
-  border-color: #404040;
-  outline: 0;
-  box-shadow: 0 0 0 0.2em var(--apollon-primary,#2a8fbd)40;
-}
-
-.c16::-webkit-input-placeholder {
-  color: var(--apollon-gray-variant,#343a40);
-  opacity: 1;
-}
-
-.c16::-moz-placeholder {
-  color: var(--apollon-gray-variant,#343a40);
-  opacity: 1;
-}
-
-.c16:-ms-input-placeholder {
-  color: var(--apollon-gray-variant,#343a40);
-  opacity: 1;
-}
-
-.c16::placeholder {
-  color: var(--apollon-gray-variant,#343a40);
-  opacity: 1;
-}
-
-.c17 {
-  margin-bottom: 0.5em;
-  display: block;
-  width: 100%;
-  border-radius: 0.2em;
-  font-size: 0.875em;
-  padding: 0.25em 0.5em;
-}
-
-.c18 {
-  display: block;
-  width: 100%;
-  border-radius: 0.2em;
-  font-size: 0.875em;
-  padding: 0.25em 0.5em;
-}
-
-.c7 {
   margin-top: 0;
   font-size: 1.25em;
   font-weight: 500;
@@ -788,7 +854,7 @@ exports[`test update pane render with relationship 1`] = `
   margin-bottom: 0;
 }
 
-.c14 {
+.c15 {
   margin-top: 0;
   font-size: 1.25em;
   font-weight: 500;
@@ -796,13 +862,13 @@ exports[`test update pane render with relationship 1`] = `
   margin-bottom: 0.5em;
 }
 
-.c15 {
+.c16 {
   margin-top: 0;
   margin-bottom: 1em;
   margin-bottom: 0;
 }
 
-.c11 {
+.c12 {
   border: 0;
   border-top: 1px solid var(--apollon-primary-contrast,#212529);
   box-sizing: content-box;
@@ -812,7 +878,7 @@ exports[`test update pane render with relationship 1`] = `
   overflow: visible;
 }
 
-.c13::after {
+.c14::after {
   border-top: 0.3em solid;
   border-right: 0.3em solid transparent;
   border-bottom: 0;
@@ -825,7 +891,7 @@ exports[`test update pane render with relationship 1`] = `
   width: 0;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -840,7 +906,7 @@ exports[`test update pane render with relationship 1`] = `
   justify-content: space-between;
 }
 
-.c3 {
+.c4 {
   background-clip: padding-box;
   background-color: var(--apollon-background-variant,#e5e5e5);
   border: 1px solid var(--apollon-primary-contrast,#212529)33;
@@ -879,20 +945,20 @@ exports[`test update pane render with relationship 1`] = `
   transform: translate(calc(100px - 100% - 0.5em),calc(65px - 100%));
 }
 
-.c3 *,
-.c3 *:before,
-.c3 *:after {
+.c4 *,
+.c4 *:before,
+.c4 *:after {
   box-sizing: inherit;
 }
 
-.c5 {
+.c6 {
   color: var(--apollon-primary-contrast,#212529);
   padding: 0.5em 0.75em;
   max-height: 500px;
   overflow: auto;
 }
 
-.c4 {
+.c5 {
   display: block;
   height: 0.5em;
   position: absolute;
@@ -903,8 +969,8 @@ exports[`test update pane render with relationship 1`] = `
   bottom: 0.3em;
 }
 
-.c4::before,
-.c4::after {
+.c5::before,
+.c5::after {
   content: '';
   border-color: transparent;
   border-style: solid;
@@ -912,13 +978,13 @@ exports[`test update pane render with relationship 1`] = `
   position: absolute;
 }
 
-.c4::before {
+.c5::before {
   border-left-color: var(--apollon-primary-contrast,#212529)33;
   border-width: 0.5em 0 0.5em 0.5em;
   right: 0;
 }
 
-.c4::after {
+.c5::after {
   border-left-color: var(--apollon-gray,#e9ecef);
   border-width: 0.5em 0 0.5em 0.5em;
   right: 1px;
@@ -1002,44 +1068,44 @@ exports[`test update pane render with relationship 1`] = `
           style="position: absolute; left: 0.75em; bottom: 0.75em; display: flex;"
         >
           <button
-            class="button-rounded"
+            class="c3"
             style="margin-right: 0.5em;"
           >
             +
           </button>
           <button
-            class="button-rounded"
+            class="c3"
           >
             -
           </button>
         </div>
       </div>
       <div
-        class="c3"
+        class="c4"
       >
         <div
-          class="c4"
+          class="c5"
         />
         <div
-          class="c5"
+          class="c6"
         >
           <div>
             <section>
               <div
-                class="c6"
+                class="c7"
               >
                 <h1
-                  class="c7"
+                  class="c8"
                   style="flex-grow: 1;"
                 >
                   Association
                 </h1>
                 <button
-                  class="c8 c9"
+                  class="c9 c10"
                   color="link"
                 >
                   <svg
-                    class="c10"
+                    class="c11"
                     height="16px"
                     viewBox="0 0 512 512"
                     width="16px"
@@ -1051,11 +1117,11 @@ exports[`test update pane render with relationship 1`] = `
                   </svg>
                 </button>
                 <button
-                  class="c8 c9"
+                  class="c9 c10"
                   color="link"
                 >
                   <svg
-                    class="c10"
+                    class="c11"
                     height="16px"
                     viewBox="0 0 448 512"
                     width="16px"
@@ -1068,7 +1134,7 @@ exports[`test update pane render with relationship 1`] = `
                 </button>
               </div>
               <hr
-                class="c11"
+                class="c12"
               />
             </section>
             <section>
@@ -1076,86 +1142,86 @@ exports[`test update pane render with relationship 1`] = `
                 class=""
               >
                 <button
-                  class="c8 c12 c13"
+                  class="c9 c13 c14"
                   color="primary"
                 >
                   Association (bidirectional)
                 </button>
               </div>
               <hr
-                class="c11"
+                class="c12"
               />
             </section>
             <section>
               <h1
-                class="c14"
+                class="c15"
               />
               <div
-                class="c6"
+                class="c7"
               >
                 <span
-                  class="c15"
+                  class="c16"
                   style="margin-right: 0.5em;"
                 >
                   Multiplicity
                 </span>
                 <input
-                  class="c16 c17"
+                  class="c17 c18"
                   maxlength="100"
                   style="min-width: 0;"
                   value=""
                 />
               </div>
               <div
-                class="c6"
+                class="c7"
               >
                 <span
-                  class="c15"
+                  class="c16"
                   style="margin-right: 0.5em;"
                 >
                   Role
                 </span>
                 <input
-                  class="c16 c18"
+                  class="c17 c19"
                   maxlength="100"
                   value=""
                 />
               </div>
               <hr
-                class="c11"
+                class="c12"
               />
             </section>
             <section>
               <h1
-                class="c14"
+                class="c15"
               />
               <div
-                class="c6"
+                class="c7"
               >
                 <span
-                  class="c15"
+                  class="c16"
                   style="margin-right: 0.5em;"
                 >
                   Multiplicity
                 </span>
                 <input
-                  class="c16 c17"
+                  class="c17 c18"
                   maxlength="100"
                   style="min-width: 0;"
                   value=""
                 />
               </div>
               <div
-                class="c6"
+                class="c7"
               >
                 <span
-                  class="c15"
+                  class="c16"
                   style="margin-right: 0.5em;"
                 >
                   Role
                 </span>
                 <input
-                  class="c16 c18"
+                  class="c17 c19"
                   maxlength="100"
                   value=""
                 />

--- a/src/tests/unit/packages/common/default-element-popup/__snapshots__/default-element-popup-test.tsx.snap
+++ b/src/tests/unit/packages/common/default-element-popup/__snapshots__/default-element-popup-test.tsx.snap
@@ -7,14 +7,14 @@ exports[`test default element popup render 1`] = `
       <div>
         <section>
           <div
-            class="sc-jxOSlx WMFeS"
+            class="sc-lcIPJg hPdAaT"
           >
             <input
-              class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+              class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
               maxLength="100"
             />
             <button
-              class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+              class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
               color="link"
               tabindex="-1"
             >

--- a/src/tests/unit/packages/common/default-relationship-popup/__snapshots__/default-relationship-popup-test.tsx.snap
+++ b/src/tests/unit/packages/common/default-relationship-popup/__snapshots__/default-relationship-popup-test.tsx.snap
@@ -7,15 +7,15 @@ exports[`test default relationship popup render 1`] = `
       <div>
         <section>
           <div
-            class="sc-kdBSHD gzfaPq"
+            class="sc-tagGq kaljVw"
           >
             <h1
-              class="sc-lcIPJg chQxvR"
+              class="sc-kdBSHD bunwHc"
             >
               Relationship
             </h1>
             <button
-              class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+              class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
               color="link"
               tabindex="-1"
             >

--- a/src/tests/unit/packages/common/uml-classifier-update/__snapshots__/uml-classifier-update-test.tsx.snap
+++ b/src/tests/unit/packages/common/uml-classifier-update/__snapshots__/uml-classifier-update-test.tsx.snap
@@ -6,15 +6,15 @@ exports[`test class association popup render 1`] = `
     <div>
       <section>
         <div
-          class="sc-fXSgeo hRUsyw"
+          class="sc-JrDLc cQSxzb"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             value=""
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -32,52 +32,52 @@ exports[`test class association popup render 1`] = `
           </button>
         </div>
         <hr
-          class="sc-tagGq XeZYh"
+          class="sc-esYiGF iLojZW"
         />
       </section>
       <section>
         <div
-          class="sc-hmdomO gQZejn"
+          class="sc-bXCLTC leCMrB"
         >
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr koHCVn sc-bXCLTC PDrUU"
+            class="sc-fHjqPf sc-hmdomO egzafX dFvOaw sc-jsJBEP gDTmhe"
             color="primary"
           >
             Abstract
           </button>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr koHCVn sc-bXCLTC PDrUU"
+            class="sc-fHjqPf sc-hmdomO egzafX dFvOaw sc-jsJBEP gDTmhe"
             color="primary"
           >
             Interface
           </button>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr koHCVn sc-bXCLTC PDrUU"
+            class="sc-fHjqPf sc-hmdomO egzafX dFvOaw sc-jsJBEP gDTmhe"
             color="primary"
           >
             Enumeration
           </button>
         </div>
         <hr
-          class="sc-tagGq XeZYh"
+          class="sc-esYiGF iLojZW"
         />
       </section>
       <section>
         <h1
-          class="sc-lcIPJg chQxvR"
+          class="sc-kdBSHD bunwHc"
         >
           Attributes
         </h1>
         <div
-          class="sc-esYiGF jnEhCX"
+          class="sc-fXSgeo hRUsyw"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL etmSlo"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO cpgdNd"
             maxlength="100"
             value="attribute"
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -95,30 +95,30 @@ exports[`test class association popup render 1`] = `
           </button>
         </div>
         <input
-          class="sc-bmzYkS sc-iHGNWf fEVqYL lmyIYN"
+          class="sc-iHGNWf sc-dtBdUo jSLZkO jRogEI"
           maxlength="100"
           value=""
         />
       </section>
       <section>
         <hr
-          class="sc-tagGq XeZYh"
+          class="sc-esYiGF iLojZW"
         />
         <h1
-          class="sc-lcIPJg chQxvR"
+          class="sc-kdBSHD bunwHc"
         >
           Methods
         </h1>
         <div
-          class="sc-esYiGF jnEhCX"
+          class="sc-fXSgeo hRUsyw"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL etmSlo"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO cpgdNd"
             maxlength="100"
             value="classMethod"
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -136,7 +136,7 @@ exports[`test class association popup render 1`] = `
           </button>
         </div>
         <input
-          class="sc-bmzYkS sc-iHGNWf fEVqYL lmyIYN"
+          class="sc-iHGNWf sc-dtBdUo jSLZkO jRogEI"
           maxlength="100"
           value=""
         />

--- a/src/tests/unit/packages/flowchart/flowchart-decision/__snapshots__/flowchart-decision-update-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-decision/__snapshots__/flowchart-decision-update-test.tsx.snap
@@ -6,16 +6,16 @@ exports[`test flowchart decision update render 1`] = `
     <div>
       <section>
         <div
-          class="sc-jnOGJG djsxMp"
+          class="sc-dZoequ jKvDgE"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             placeholder="Decision"
             value=""
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >

--- a/src/tests/unit/packages/flowchart/flowchart-flowline/__snapshots__/flowchart-flowline-update-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-flowline/__snapshots__/flowchart-flowline-update-test.tsx.snap
@@ -6,16 +6,16 @@ exports[`test flowchart flowline update render 1`] = `
     <div>
       <section>
         <div
-          class="sc-dZoequ jKvDgE"
+          class="sc-eZkCL cXjuPz"
         >
           <h1
-            class="sc-lcIPJg cQIeHE"
+            class="sc-kdBSHD hzLlal"
             style="flex-grow: 1;"
           >
             Flowline
           </h1>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
           >
             <svg
@@ -31,7 +31,7 @@ exports[`test flowchart flowline update render 1`] = `
             </svg>
           </button>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
           >
             <svg
@@ -48,12 +48,12 @@ exports[`test flowchart flowline update render 1`] = `
           </button>
         </div>
         <hr
-          class="sc-tagGq XeZYh"
+          class="sc-esYiGF iLojZW"
         />
       </section>
       <section>
         <input
-          class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+          class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
           maxlength="100"
           value="FlowchartFlowline"
         />

--- a/src/tests/unit/packages/flowchart/flowchart-function-call/__snapshots__/flowchart-function-call-update-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-function-call/__snapshots__/flowchart-function-call-update-test.tsx.snap
@@ -6,16 +6,16 @@ exports[`test flowchart function call update render 1`] = `
     <div>
       <section>
         <div
-          class="sc-jnOGJG djsxMp"
+          class="sc-dZoequ jKvDgE"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             placeholder="Decision"
             value=""
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >

--- a/src/tests/unit/packages/flowchart/flowchart-input-output/__snapshots__/flowchart-input-output-update-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-input-output/__snapshots__/flowchart-input-output-update-test.tsx.snap
@@ -6,16 +6,16 @@ exports[`test flowchart input output update render 1`] = `
     <div>
       <section>
         <div
-          class="sc-jnOGJG djsxMp"
+          class="sc-dZoequ jKvDgE"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             placeholder="Decision"
             value=""
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >

--- a/src/tests/unit/packages/flowchart/flowchart-process/__snapshots__/flowchart-process-update-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-process/__snapshots__/flowchart-process-update-test.tsx.snap
@@ -6,16 +6,16 @@ exports[`test flowchart input output update render 1`] = `
     <div>
       <section>
         <div
-          class="sc-jnOGJG djsxMp"
+          class="sc-dZoequ jKvDgE"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             placeholder="Decision"
             value=""
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >

--- a/src/tests/unit/packages/flowchart/flowchart-terminal/__snapshots__/flowchart-terminal-update-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-terminal/__snapshots__/flowchart-terminal-update-test.tsx.snap
@@ -6,16 +6,16 @@ exports[`test flowchart input output update render 1`] = `
     <div>
       <section>
         <div
-          class="sc-jnOGJG djsxMp"
+          class="sc-dZoequ jKvDgE"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             placeholder="Decision"
             value=""
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >

--- a/src/tests/unit/packages/uml-class-diagram/class-association-popup/__snapshots__/class-association-popup-test.tsx.snap
+++ b/src/tests/unit/packages/uml-class-diagram/class-association-popup/__snapshots__/class-association-popup-test.tsx.snap
@@ -6,16 +6,16 @@ exports[`test class association popup render 1`] = `
     <div>
       <section>
         <div
-          class="sc-hCPjZK kDgYLY"
+          class="sc-Nxspf ahgD"
         >
           <h1
-            class="sc-lcIPJg cQIeHE"
+            class="sc-kdBSHD hzLlal"
             style="flex-grow: 1;"
           >
             Association
           </h1>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
           >
             <svg
@@ -31,7 +31,7 @@ exports[`test class association popup render 1`] = `
             </svg>
           </button>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
           >
             <svg
@@ -48,94 +48,94 @@ exports[`test class association popup render 1`] = `
           </button>
         </div>
         <hr
-          class="sc-tagGq XeZYh"
+          class="sc-esYiGF iLojZW"
         />
       </section>
       <section>
         <div
-          class="sc-hknOHE"
+          class="sc-uVWWZ"
         >
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr iSkCc sc-bbSZdi bnYqnK"
+            class="sc-fHjqPf sc-hmdomO egzafX bMsvDP sc-fBWQRz lllBmM"
             color="primary"
           >
             Association (bidirectional)
           </button>
         </div>
         <hr
-          class="sc-tagGq XeZYh"
+          class="sc-esYiGF iLojZW"
         />
       </section>
       <section>
         <h1
-          class="sc-lcIPJg chQxvR"
+          class="sc-kdBSHD bunwHc"
         />
         <div
-          class="sc-hCPjZK kDgYLY"
+          class="sc-Nxspf ahgD"
         >
           <span
-            class="sc-lcIPJg gscKFM"
+            class="sc-kdBSHD RWzdp"
             style="margin-right: 0.5em;"
           >
             Multiplicity
           </span>
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL etmSlo"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO cpgdNd"
             maxlength="100"
             style="min-width: 0;"
             value=""
           />
         </div>
         <div
-          class="sc-hCPjZK kDgYLY"
+          class="sc-Nxspf ahgD"
         >
           <span
-            class="sc-lcIPJg gscKFM"
+            class="sc-kdBSHD RWzdp"
             style="margin-right: 0.5em;"
           >
             Role
           </span>
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             value=""
           />
         </div>
         <hr
-          class="sc-tagGq XeZYh"
+          class="sc-esYiGF iLojZW"
         />
       </section>
       <section>
         <h1
-          class="sc-lcIPJg chQxvR"
+          class="sc-kdBSHD bunwHc"
         />
         <div
-          class="sc-hCPjZK kDgYLY"
+          class="sc-Nxspf ahgD"
         >
           <span
-            class="sc-lcIPJg gscKFM"
+            class="sc-kdBSHD RWzdp"
             style="margin-right: 0.5em;"
           >
             Multiplicity
           </span>
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL etmSlo"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO cpgdNd"
             maxlength="100"
             style="min-width: 0;"
             value=""
           />
         </div>
         <div
-          class="sc-hCPjZK kDgYLY"
+          class="sc-Nxspf ahgD"
         >
           <span
-            class="sc-lcIPJg gscKFM"
+            class="sc-kdBSHD RWzdp"
             style="margin-right: 0.5em;"
           >
             Role
           </span>
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             value=""
           />

--- a/src/tests/unit/packages/uml-communication-diagram/uml-communication-link/__snapshots__/uml-communication-link-popup-test.tsx.snap
+++ b/src/tests/unit/packages/uml-communication-diagram/uml-communication-link/__snapshots__/uml-communication-link-popup-test.tsx.snap
@@ -6,15 +6,15 @@ exports[`test communication link popup render 1`] = `
     <div>
       <section>
         <div
-          class="sc-Nxspf ahgD"
+          class="sc-cfxfcM iJlpTp"
         >
           <h1
-            class="sc-lcIPJg cQIeHE"
+            class="sc-kdBSHD hzLlal"
           >
             Communication Link
           </h1>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
           >
             <svg
@@ -31,12 +31,12 @@ exports[`test communication link popup render 1`] = `
           </button>
         </div>
         <hr
-          class="sc-tagGq XeZYh"
+          class="sc-esYiGF iLojZW"
         />
       </section>
       <section>
         <h1
-          class="sc-lcIPJg chQxvR"
+          class="sc-kdBSHD bunwHc"
         >
           Messages
            (
@@ -46,15 +46,15 @@ exports[`test communication link popup render 1`] = `
           )
         </h1>
         <div
-          class="sc-Nxspf ahgD"
+          class="sc-cfxfcM iJlpTp"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL etmSlo"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO cpgdNd"
             maxlength="100"
             value="CommunicationSourceLinkMessage0"
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -71,7 +71,7 @@ exports[`test communication link popup render 1`] = `
             </svg>
           </button>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -89,15 +89,15 @@ exports[`test communication link popup render 1`] = `
           </button>
         </div>
         <div
-          class="sc-Nxspf ahgD"
+          class="sc-cfxfcM iJlpTp"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL etmSlo"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO cpgdNd"
             maxlength="100"
             value="CommunicationSourceLinkMessage1"
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -114,7 +114,7 @@ exports[`test communication link popup render 1`] = `
             </svg>
           </button>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -132,15 +132,15 @@ exports[`test communication link popup render 1`] = `
           </button>
         </div>
         <div
-          class="sc-Nxspf ahgD"
+          class="sc-cfxfcM iJlpTp"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL etmSlo"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO cpgdNd"
             maxlength="100"
             value="CommunicationSourceLinkMessage2"
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -157,7 +157,7 @@ exports[`test communication link popup render 1`] = `
             </svg>
           </button>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -175,15 +175,15 @@ exports[`test communication link popup render 1`] = `
           </button>
         </div>
         <div
-          class="sc-Nxspf ahgD"
+          class="sc-cfxfcM iJlpTp"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL etmSlo"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO cpgdNd"
             maxlength="100"
             value="CommunicationTargetLinkMessage0"
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -200,7 +200,7 @@ exports[`test communication link popup render 1`] = `
             </svg>
           </button>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -218,15 +218,15 @@ exports[`test communication link popup render 1`] = `
           </button>
         </div>
         <div
-          class="sc-Nxspf ahgD"
+          class="sc-cfxfcM iJlpTp"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL etmSlo"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO cpgdNd"
             maxlength="100"
             value="CommunicationTargetLinkMessage1"
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -243,7 +243,7 @@ exports[`test communication link popup render 1`] = `
             </svg>
           </button>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -261,15 +261,15 @@ exports[`test communication link popup render 1`] = `
           </button>
         </div>
         <div
-          class="sc-Nxspf ahgD"
+          class="sc-cfxfcM iJlpTp"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL etmSlo"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO cpgdNd"
             maxlength="100"
             value="CommunicationTargetLinkMessage2"
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -286,7 +286,7 @@ exports[`test communication link popup render 1`] = `
             </svg>
           </button>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -304,7 +304,7 @@ exports[`test communication link popup render 1`] = `
           </button>
         </div>
         <input
-          class="sc-bmzYkS sc-iHGNWf fEVqYL lmyIYN"
+          class="sc-iHGNWf sc-dtBdUo jSLZkO jRogEI"
           maxlength="100"
           value=""
         />

--- a/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-node/uml-deployment-node-popup/__snapshots__/deployment-node-popup-test.tsx.snap
+++ b/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-node/uml-deployment-node-popup/__snapshots__/deployment-node-popup-test.tsx.snap
@@ -6,15 +6,15 @@ exports[`test deployment node popup render 1`] = `
     <div>
       <section>
         <div
-          class="sc-gmPhUn kYucFZ"
+          class="sc-hRJfrW gziudj"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             value=""
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -34,13 +34,13 @@ exports[`test deployment node popup render 1`] = `
       </section>
       <section>
         <hr
-          class="sc-tagGq XeZYh"
+          class="sc-esYiGF iLojZW"
         />
         <div
-          class="sc-gmPhUn kYucFZ"
+          class="sc-hRJfrW gziudj"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             value="node"
           />

--- a/src/tests/unit/packages/uml-petri-diagram/uml-petri-net-arc/__snapshots__/uml-petri-net-arc-update-test.tsx.snap
+++ b/src/tests/unit/packages/uml-petri-diagram/uml-petri-net-arc/__snapshots__/uml-petri-net-arc-update-test.tsx.snap
@@ -6,15 +6,15 @@ exports[`test petri net arc update render 1`] = `
     <div>
       <section>
         <div
-          class="sc-bypJrT hnnasP"
+          class="sc-ddjGPC hMjkq"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             value="UMLClassBidirectional"
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
           >
             <svg
@@ -30,7 +30,7 @@ exports[`test petri net arc update render 1`] = `
             </svg>
           </button>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >

--- a/src/tests/unit/packages/uml-petri-diagram/uml-petri-net-place/__snapshots__/uml-petri-net-place-update-test.tsx.snap
+++ b/src/tests/unit/packages/uml-petri-diagram/uml-petri-net-place/__snapshots__/uml-petri-net-place-update-test.tsx.snap
@@ -6,15 +6,15 @@ exports[`test petri net arc update render 1`] = `
     <div>
       <section>
         <div
-          class="sc-klVQfs bbVOet"
+          class="sc-bypJrT hnnasP"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             value=""
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -32,21 +32,21 @@ exports[`test petri net arc update render 1`] = `
           </button>
         </div>
         <hr
-          class="sc-tagGq XeZYh"
+          class="sc-esYiGF iLojZW"
         />
       </section>
       <section>
         <div
-          class="sc-klVQfs bbVOet"
+          class="sc-bypJrT hnnasP"
         >
           <span
-            class="sc-lcIPJg gscKFM"
+            class="sc-kdBSHD RWzdp"
             style="margin-right: 0.5em; min-width: 70px;"
           >
             Tokens
           </span>
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             style="min-width: 0;"
             type="number"
@@ -56,11 +56,11 @@ exports[`test petri net arc update render 1`] = `
       </section>
       <section>
         <div
-          class="sc-klVQfs bbVOet"
+          class="sc-bypJrT hnnasP"
           style="margin-top: 0.5em; align-items: center;"
         >
           <span
-            class="sc-lcIPJg gscKFM"
+            class="sc-kdBSHD RWzdp"
             style="margin-right: 0.5em; min-width: 70px;"
           >
             Capacity
@@ -69,7 +69,7 @@ exports[`test petri net arc update render 1`] = `
             style="position: relative;"
           >
             <input
-              class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+              class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
               maxlength="100"
               type="number"
               value="Infinity"
@@ -93,7 +93,7 @@ exports[`test petri net arc update render 1`] = `
             </svg>
           </div>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
             type="reset"

--- a/src/tests/unit/packages/uml-reachability-graph/uml-reachability-graph-arc/__snapshots__/uml-reachability-graph-arc-update-test.tsx.snap
+++ b/src/tests/unit/packages/uml-reachability-graph/uml-reachability-graph-arc/__snapshots__/uml-reachability-graph-arc-update-test.tsx.snap
@@ -6,15 +6,15 @@ exports[`test reachability graph arc update render 1`] = `
     <div>
       <section>
         <div
-          class="sc-ddjGPC hMjkq"
+          class="sc-dSCufp fAuGzn"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             value="UMLClassBidirectional"
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
           >
             <svg
@@ -30,7 +30,7 @@ exports[`test reachability graph arc update render 1`] = `
             </svg>
           </button>
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >

--- a/src/tests/unit/packages/uml-reachability-graph/uml-reachability-graph-marking/__snapshots__/uml-reachability-graph-marking-update-test.tsx.snap
+++ b/src/tests/unit/packages/uml-reachability-graph/uml-reachability-graph-marking/__snapshots__/uml-reachability-graph-marking-update-test.tsx.snap
@@ -6,15 +6,15 @@ exports[`test reachability graph arc update render 1`] = `
     <div>
       <section>
         <div
-          class="sc-dSCufp fAuGzn"
+          class="sc-fxwrCY jnjvWh"
         >
           <input
-            class="sc-bmzYkS sc-iHGNWf fEVqYL gacFBO"
+            class="sc-iHGNWf sc-dtBdUo jSLZkO kIvhJv"
             maxlength="100"
             value=""
           />
           <button
-            class="sc-hzhJZQ sc-fHjqPf jXCbhr lgmFnr"
+            class="sc-fHjqPf sc-hmdomO egzafX OnZRE"
             color="link"
             tabindex="-1"
           >
@@ -32,7 +32,7 @@ exports[`test reachability graph arc update render 1`] = `
           </button>
         </div>
         <hr
-          class="sc-tagGq XeZYh"
+          class="sc-esYiGF iLojZW"
         />
       </section>
       <section>


### PR DESCRIPTION
This PR moves styles from the CSS file to a styled component as otherwise the version of Apollon integrated with Apollon Standalone will not apply styles to the zoom buttons as expected.

### Checklist
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes
- [ ] I translated all the newly inserted strings into German and English

### Motivation and Context
The zoom buttons on the Apollon Canvas were not rendered properly in Apollon Standalone.

### Description
The styles used for the zoom buttons of the canvas are inlined using 'styled' components. The snapshot test regarding the canvas component are updated accordingly.

### Steps for Testing
As this change only changes how styles are applied, the easiest approach to test this PR would be by running Apollon and ensuring that the zoom buttons including their hover states look as expected.

### Screenshots
<img width="1157" alt="Screenshot 2023-10-12 at 14 05 08" src="https://github.com/ls1intum/Apollon/assets/143808484/9e3f8085-ba42-4ace-a383-61b931988285">

