### PR TITLE
Fix issues with the zoomfactor being passed to svg components

### DIFF
--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -387,7 +387,6 @@ export class ApollonEditor {
         this.store.getState().lastAction.endsWith('DELETE')
       ) {
         const lastModel = ModelState.toModel(this.store.getState());
-        console.log(lastModel);
         Object.values(this.discreteModelSubscribers).forEach((subscriber) => subscriber(lastModel));
       }
     } catch (error) {

--- a/src/main/apollon-editor.ts
+++ b/src/main/apollon-editor.ts
@@ -1,5 +1,3 @@
-// tslint:disable: no-console
-
 import 'pepjs';
 import { createElement } from 'react';
 import { createRoot, Root } from 'react-dom/client';

--- a/src/main/components/uml-element/movable/movable.tsx
+++ b/src/main/components/uml-element/movable/movable.tsx
@@ -94,7 +94,7 @@ export const movable = (
     }
 
     render() {
-      const { movable: _, start, move, end, ...props } = this.props;
+      const { movable: _movable, zoomFactor: _zoomFactor, start, move, end, ...props } = this.props;
       return <WrappedComponent {...props} />;
     }
 


### PR DESCRIPTION
This tiny fix corrects and issue with the custom 'zoomFactor' property being passed to an svg element, causing console errors and two unittests to fail for Artemis.
