### PR TITLE
Add support for BPMN groups and adapt subprocess visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ls1intum/apollon",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ls1intum/apollon",
-      "version": "3.0.0-beta.2",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ls1intum/apollon",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0",
   "description": "A UML diagram editor.",
   "keywords": [],
   "homepage": "https://github.com/ls1intum/apollon#readme",

--- a/src/main/components/uml-element/resizable/resizable.tsx
+++ b/src/main/components/uml-element/resizable/resizable.tsx
@@ -8,7 +8,9 @@ import { ModelState } from '../../store/model-state';
 import { styled } from '../../theme/styles';
 import { UMLElementComponentProps } from '../uml-element-component-props';
 
-type StateProps = {};
+type StateProps = {
+  zoomFactor: number;
+};
 
 type DispatchProps = {
   start: AsyncDispatch<typeof UMLElementRepository.startResizing>;
@@ -25,11 +27,16 @@ const initialState = {
 
 type State = typeof initialState;
 
-const enhance = connect<StateProps, DispatchProps, UMLElementComponentProps, ModelState>(null, {
-  start: UMLElementRepository.startResizing,
-  resize: UMLElementRepository.resize,
-  end: UMLElementRepository.endResizing,
-});
+const enhance = connect<StateProps, DispatchProps, UMLElementComponentProps, ModelState>(
+  (state) => ({
+    zoomFactor: state.editor.zoomFactor,
+  }),
+  {
+    start: UMLElementRepository.startResizing,
+    resize: UMLElementRepository.resize,
+    end: UMLElementRepository.endResizing,
+  },
+);
 
 const Handle = {
   width: 15,
@@ -148,7 +155,7 @@ export const resizable =
             break;
         }
 
-        this.setState({ resizing: true, offset });
+        this.setState({ resizing: true, offset: offset.scale(1 / this.props.zoomFactor) });
         this.props.start();
         const element = event.currentTarget;
         element.setPointerCapture(event.pointerId);
@@ -163,20 +170,20 @@ export const resizable =
         let height = 0;
         switch (resizeFrom) {
           case ResizeFrom.BOTTOMRIGHT:
-            width = event.clientX - this.state.offset.x;
-            height = event.clientY - this.state.offset.y;
+            width = event.clientX / this.props.zoomFactor - this.state.offset.x;
+            height = event.clientY / this.props.zoomFactor - this.state.offset.y;
             break;
           case ResizeFrom.TOPLEFT:
-            width = -event.clientX - this.state.offset.x;
-            height = -event.clientY - this.state.offset.y;
+            width = -event.clientX / this.props.zoomFactor - this.state.offset.x;
+            height = -event.clientY / this.props.zoomFactor - this.state.offset.y;
             break;
           case ResizeFrom.TOPRIGHT:
-            width = event.clientX - this.state.offset.x;
-            height = -event.clientY - this.state.offset.y;
+            width = event.clientX / this.props.zoomFactor - this.state.offset.x;
+            height = -event.clientY / this.props.zoomFactor - this.state.offset.y;
             break;
           case ResizeFrom.BOTTOMLEFT:
-            width = -event.clientX - this.state.offset.x;
-            height = event.clientY - this.state.offset.y;
+            width = -event.clientX / this.props.zoomFactor - this.state.offset.x;
+            height = event.clientY / this.props.zoomFactor - this.state.offset.y;
             break;
         }
         this.resize(width, height, resizeFrom);

--- a/src/main/i18n/de.json
+++ b/src/main/i18n/de.json
@@ -139,7 +139,8 @@
       "BPMNCallConversation": "Aufruf-Konversation",
       "BPMNSequenceFlow": "Sequenz",
       "BPMNMessageFlow": "Nachricht",
-      "BPMNAssociationFlow": "Assoziation"
+      "BPMNAssociationFlow": "Assoziation",
+      "BPMNGroup": "Gruppe"
     }
   }
 }

--- a/src/main/i18n/en.json
+++ b/src/main/i18n/en.json
@@ -139,7 +139,8 @@
       "BPMNCallConversation": "Call Conversation",
       "BPMNSequenceFlow": "Sequence",
       "BPMNMessageFlow": "Message",
-      "BPMNAssociationFlow": "Association"
+      "BPMNAssociationFlow": "Association",
+      "BPMNGroup": "Group"
     }
   }
 }

--- a/src/main/packages/bpmn/bpmn-annotation/bpmn-annotation.ts
+++ b/src/main/packages/bpmn/bpmn-annotation/bpmn-annotation.ts
@@ -1,13 +1,13 @@
 import { BPMNElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
-import { UMLElement } from '../../../services/uml-element/uml-element';
 import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
 import { UMLElementFeatures } from '../../../services/uml-element/uml-element-features';
+import { UMLContainer } from '../../../services/uml-container/uml-container';
 
-export class BPMNAnnotation extends UMLElement {
-  static features: UMLElementFeatures = { ...UMLElement.features };
+export class BPMNAnnotation extends UMLContainer {
+  static features: UMLElementFeatures = { ...UMLContainer.features };
 
   type: UMLElementType = BPMNElementType.BPMNAnnotation;
 

--- a/src/main/packages/bpmn/bpmn-call-activity/bpmn-call-activity.ts
+++ b/src/main/packages/bpmn/bpmn-call-activity/bpmn-call-activity.ts
@@ -1,11 +1,11 @@
 import { BPMNElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
-import { UMLElement } from '../../../services/uml-element/uml-element';
 import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
+import { UMLContainer } from '../../../services/uml-container/uml-container';
 
-export class BPMNCallActivity extends UMLElement {
+export class BPMNCallActivity extends UMLContainer {
   type: UMLElementType = BPMNElementType.BPMNCallActivity;
 
   render(canvas: ILayer): ILayoutable[] {

--- a/src/main/packages/bpmn/bpmn-conversation/bpmn-conversation.ts
+++ b/src/main/packages/bpmn/bpmn-conversation/bpmn-conversation.ts
@@ -8,10 +8,11 @@ import { IBoundary } from '../../../utils/geometry/boundary';
 import { DeepPartial } from 'redux';
 import { assign } from '../../../utils/fx/assign';
 import * as Apollon from '../../../typings';
+import { UMLContainer } from '../../../services/uml-container/uml-container';
 
 export type BPMNConversationType = 'default' | 'call';
 
-export class BPMNConversation extends UMLElement {
+export class BPMNConversation extends UMLContainer {
   static features: UMLElementFeatures = { ...UMLElement.features, resizable: false };
   static defaultConversationType: BPMNConversationType = 'default';
 

--- a/src/main/packages/bpmn/bpmn-diagram-preview.ts
+++ b/src/main/packages/bpmn/bpmn-diagram-preview.ts
@@ -11,6 +11,7 @@ import { BPMNTransaction } from './bpmn-transaction/bpmn-transaction';
 import { BPMNCallActivity } from './bpmn-call-activity/bpmn-call-activity';
 import { BPMNAnnotation } from './bpmn-annotation/bpmn-annotation';
 import { BPMNConversation } from './bpmn-conversation/bpmn-conversation';
+import { BPMNGroup } from './bpmn-group/bpmn-group';
 
 export const composeBPMNPreview: ComposePreview = (
   layer: ILayer,
@@ -43,6 +44,12 @@ export const composeBPMNPreview: ComposePreview = (
   elements.push(
     new BPMNCallActivity({
       name: translate('packages.BPMN.BPMNCallActivity'),
+      bounds: defaultBounds,
+    }),
+  );
+
+  elements.push(
+    new BPMNGroup({
       bounds: defaultBounds,
     }),
   );

--- a/src/main/packages/bpmn/bpmn-end-event/bpmn-end-event.ts
+++ b/src/main/packages/bpmn/bpmn-end-event/bpmn-end-event.ts
@@ -2,23 +2,23 @@ import { DeepPartial } from 'redux';
 import { BPMNElementType, BPMNRelationshipType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
-import { IUMLElement, UMLElement } from '../../../services/uml-element/uml-element';
 import { UMLElementFeatures } from '../../../services/uml-element/uml-element-features';
 import { assign } from '../../../utils/fx/assign';
 import { IBoundary } from '../../../utils/geometry/boundary';
 import { UMLElementType } from '../../uml-element-type';
+import { UMLContainer } from '../../../services/uml-container/uml-container';
 
-export class BPMNEndEvent extends UMLElement {
+export class BPMNEndEvent extends UMLContainer {
   static supportedRelationships = [BPMNRelationshipType.BPMNFlow];
-  static features: UMLElementFeatures = { ...UMLElement.features, resizable: false };
+  static features: UMLElementFeatures = { ...UMLContainer.features, resizable: false };
 
   type: UMLElementType = BPMNElementType.BPMNEndEvent;
   bounds: IBoundary = { ...this.bounds, width: 40, height: 40 };
   name = 'End Event';
 
-  constructor(values?: DeepPartial<IUMLElement>) {
+  constructor(values?: DeepPartial<UMLContainer>) {
     super(values);
-    assign<IUMLElement>(this, values);
+    assign<UMLContainer>(this, values);
   }
 
   render(canvas: ILayer): ILayoutable[] {

--- a/src/main/packages/bpmn/bpmn-flow/bpmn-flow-update.tsx
+++ b/src/main/packages/bpmn/bpmn-flow/bpmn-flow-update.tsx
@@ -11,7 +11,7 @@ import { styled } from '../../../components/theme/styles';
 import { UMLElementRepository } from '../../../services/uml-element/uml-element-repository';
 import { ExchangeIcon } from '../../../components/controls/icon/exchange';
 import { UMLRelationshipRepository } from '../../../services/uml-relationship/uml-relationship-repository';
-import { BPMNFlowType, BPMNFlow } from './bpmn-flow';
+import { BPMNFlow, BPMNFlowType } from './bpmn-flow';
 import { ColorButton } from '../../../components/controls/color-button/color-button';
 import { StylePane } from '../../../components/style-pane/style-pane';
 import { Dropdown } from '../../../components/controls/dropdown/dropdown';

--- a/src/main/packages/bpmn/bpmn-gateway/bpmn-gateway.ts
+++ b/src/main/packages/bpmn/bpmn-gateway/bpmn-gateway.ts
@@ -1,13 +1,13 @@
 import { BPMNElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
-import { IUMLElement, UMLElement } from '../../../services/uml-element/uml-element';
 import { UMLElementType } from '../../uml-element-type';
 import { UMLElementFeatures } from '../../../services/uml-element/uml-element-features';
 import { IBoundary } from '../../../utils/geometry/boundary';
 import { DeepPartial } from 'redux';
 import { assign } from '../../../utils/fx/assign';
 import * as Apollon from '../../../typings';
+import { UMLContainer } from '../../../services/uml-container/uml-container';
 
 export type BPMNGatewayType =
   | 'complex'
@@ -18,8 +18,8 @@ export type BPMNGatewayType =
   | 'parallel'
   | 'parallel-event-based';
 
-export class BPMNGateway extends UMLElement {
-  static features: UMLElementFeatures = { ...UMLElement.features, resizable: false };
+export class BPMNGateway extends UMLContainer {
+  static features: UMLElementFeatures = { ...UMLContainer.features, resizable: false };
   static defaultGatewayType: BPMNGatewayType = 'exclusive';
 
   type: UMLElementType = BPMNElementType.BPMNGateway;
@@ -28,11 +28,11 @@ export class BPMNGateway extends UMLElement {
 
   constructor(values?: DeepPartial<BPMNGateway>) {
     super(values);
-    assign<IUMLElement>(this, values);
+    assign<BPMNGateway>(this, values);
     this.gatewayType = values?.gatewayType || BPMNGateway.defaultGatewayType;
   }
 
-  serialize(children?: UMLElement[]): Apollon.BPMNGateway {
+  serialize(children?: UMLContainer[]): Apollon.BPMNGateway {
     return {
       ...super.serialize(),
       type: this.type as keyof typeof BPMNElementType,

--- a/src/main/packages/bpmn/bpmn-group/bpmn-group-component.tsx
+++ b/src/main/packages/bpmn/bpmn-group/bpmn-group-component.tsx
@@ -1,0 +1,36 @@
+import React, { FunctionComponent } from 'react';
+import { BPMNGroup } from './bpmn-group';
+import { ThemedRect } from '../../../components/theme/themedComponents';
+import { Multiline } from '../../../utils/svg/multiline';
+
+export const BPMNGroupComponent: FunctionComponent<Props> = ({ element, children }) => (
+  <g>
+    <ThemedRect
+      rx={10}
+      ry={10}
+      width="100%"
+      height="100%"
+      strokeColor={element.strokeColor}
+      fillColor="transparent"
+      strokeDasharray="4"
+    />
+    <Multiline
+      x={element.bounds.width / 2}
+      y={element.bounds.height / 2}
+      width={element.bounds.width}
+      height={element.bounds.height}
+      fontWeight="bold"
+      fill={element.textColor}
+      lineHeight={16}
+      capHeight={11}
+    >
+      {element.name}
+    </Multiline>
+    {children}
+  </g>
+);
+
+interface Props {
+  element: BPMNGroup;
+  children?: React.ReactNode;
+}

--- a/src/main/packages/bpmn/bpmn-group/bpmn-group.ts
+++ b/src/main/packages/bpmn/bpmn-group/bpmn-group.ts
@@ -14,8 +14,8 @@ export class BPMNGroup extends UMLPackage {
 
   type: UMLElementType = BPMNElementType.BPMNGroup;
 
-  render(canvas: ILayer): ILayoutable[] {
+  render(canvas: ILayer, children: ILayoutable[] = []): ILayoutable[] {
     this.bounds = calculateNameBounds(this, canvas);
-    return [this];
+    return [this, ...children];
   }
 }

--- a/src/main/packages/bpmn/bpmn-group/bpmn-group.ts
+++ b/src/main/packages/bpmn/bpmn-group/bpmn-group.ts
@@ -1,0 +1,21 @@
+import { BPMNElementType } from '..';
+import { ILayer } from '../../../services/layouter/layer';
+import { ILayoutable } from '../../../services/layouter/layoutable';
+import { UMLPackage } from '../../common/uml-package/uml-package';
+import { calculateNameBounds } from '../../../utils/name-bounds';
+import { UMLElementType } from '../../uml-element-type';
+import { UMLElementFeatures } from '../../../services/uml-element/uml-element-features';
+
+export class BPMNGroup extends UMLPackage {
+  static features: UMLElementFeatures = {
+    ...UMLPackage.features,
+    connectable: false,
+  };
+
+  type: UMLElementType = BPMNElementType.BPMNGroup;
+
+  render(canvas: ILayer): ILayoutable[] {
+    this.bounds = calculateNameBounds(this, canvas);
+    return [this];
+  }
+}

--- a/src/main/packages/bpmn/bpmn-intermediate-event/bpmn-intermediate-event.ts
+++ b/src/main/packages/bpmn/bpmn-intermediate-event/bpmn-intermediate-event.ts
@@ -2,22 +2,22 @@ import { DeepPartial } from 'redux';
 import { BPMNElementType, BPMNRelationshipType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
-import { IUMLElement, UMLElement } from '../../../services/uml-element/uml-element';
 import { UMLElementFeatures } from '../../../services/uml-element/uml-element-features';
 import { assign } from '../../../utils/fx/assign';
 import { IBoundary } from '../../../utils/geometry/boundary';
 import { UMLElementType } from '../../uml-element-type';
+import { UMLContainer } from '../../../services/uml-container/uml-container';
 
-export class BPMNIntermediateEvent extends UMLElement {
+export class BPMNIntermediateEvent extends UMLContainer {
   static supportedRelationships = [BPMNRelationshipType.BPMNFlow];
-  static features: UMLElementFeatures = { ...UMLElement.features, resizable: false };
+  static features: UMLElementFeatures = { ...UMLContainer.features, resizable: false };
 
   type: UMLElementType = BPMNElementType.BPMNIntermediateEvent;
   bounds: IBoundary = { ...this.bounds, width: 40, height: 40 };
 
-  constructor(values?: DeepPartial<IUMLElement>) {
+  constructor(values?: DeepPartial<UMLContainer>) {
     super(values);
-    assign<IUMLElement>(this, values);
+    assign<UMLContainer>(this, values);
   }
 
   render(canvas: ILayer): ILayoutable[] {

--- a/src/main/packages/bpmn/bpmn-start-event/bpmn-start-event.ts
+++ b/src/main/packages/bpmn/bpmn-start-event/bpmn-start-event.ts
@@ -2,23 +2,23 @@ import { DeepPartial } from 'redux';
 import { BPMNElementType, BPMNRelationshipType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
-import { IUMLElement, UMLElement } from '../../../services/uml-element/uml-element';
 import { UMLElementFeatures } from '../../../services/uml-element/uml-element-features';
 import { assign } from '../../../utils/fx/assign';
 import { IBoundary } from '../../../utils/geometry/boundary';
 import { UMLElementType } from '../../uml-element-type';
+import { UMLContainer } from '../../../services/uml-container/uml-container';
 
-export class BPMNStartEvent extends UMLElement {
+export class BPMNStartEvent extends UMLContainer {
   static supportedRelationships = [BPMNRelationshipType.BPMNFlow];
-  static features: UMLElementFeatures = { ...UMLElement.features, resizable: false };
+  static features: UMLElementFeatures = { ...UMLContainer.features, resizable: false };
 
   type: UMLElementType = BPMNElementType.BPMNStartEvent;
   bounds: IBoundary = { ...this.bounds, width: 40, height: 40 };
   name = 'Start Event';
 
-  constructor(values?: DeepPartial<IUMLElement>) {
+  constructor(values?: DeepPartial<UMLContainer>) {
     super(values);
-    assign<IUMLElement>(this, values);
+    assign<UMLContainer>(this, values);
   }
 
   render(canvas: ILayer): ILayoutable[] {

--- a/src/main/packages/bpmn/bpmn-subprocess/bpmn-subprocess-component.tsx
+++ b/src/main/packages/bpmn/bpmn-subprocess/bpmn-subprocess-component.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { BPMNSubprocess } from './bpmn-subprocess';
-import { ThemedRect } from '../../../components/theme/themedComponents';
+import { ThemedPolyline, ThemedRect } from '../../../components/theme/themedComponents';
 import { Multiline } from '../../../utils/svg/multiline';
 
 export const BPMNSubprocessComponent: FunctionComponent<Props> = ({ element, fillColor }) => (
@@ -12,7 +12,23 @@ export const BPMNSubprocessComponent: FunctionComponent<Props> = ({ element, fil
       height="100%"
       strokeColor={element.strokeColor}
       fillColor={fillColor || element.fillColor}
-      strokeDasharray="4"
+    />
+    <ThemedRect
+      x={element.bounds.width / 2 - 7}
+      y={element.bounds.height - 14}
+      width={14}
+      height={14}
+      strokeColor={element.strokeColor}
+    />
+    <ThemedPolyline
+      points={`${element.bounds.width / 2 - 4} ${element.bounds.height - 7}, ${element.bounds.width / 2 + 4} ${
+        element.bounds.height - 7
+      }`}
+    />
+    <ThemedPolyline
+      points={`${element.bounds.width / 2} ${element.bounds.height - 11}, ${element.bounds.width / 2} ${
+        element.bounds.height - 3
+      }`}
     />
     <Multiline
       x={element.bounds.width / 2}

--- a/src/main/packages/bpmn/bpmn-subprocess/bpmn-subprocess.ts
+++ b/src/main/packages/bpmn/bpmn-subprocess/bpmn-subprocess.ts
@@ -1,11 +1,11 @@
 import { BPMNElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
-import { UMLElement } from '../../../services/uml-element/uml-element';
 import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
+import { UMLContainer } from '../../../services/uml-container/uml-container';
 
-export class BPMNSubprocess extends UMLElement {
+export class BPMNSubprocess extends UMLContainer {
   type: UMLElementType = BPMNElementType.BPMNSubprocess;
 
   render(canvas: ILayer): ILayoutable[] {

--- a/src/main/packages/bpmn/bpmn-task/bpmn-task.ts
+++ b/src/main/packages/bpmn/bpmn-task/bpmn-task.ts
@@ -1,11 +1,11 @@
 import { BPMNElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
-import { UMLElement } from '../../../services/uml-element/uml-element';
 import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
+import { UMLContainer } from '../../../services/uml-container/uml-container';
 
-export class BPMNTask extends UMLElement {
+export class BPMNTask extends UMLContainer {
   type: UMLElementType = BPMNElementType.BPMNTask;
 
   render(canvas: ILayer): ILayoutable[] {

--- a/src/main/packages/bpmn/bpmn-transaction/bpmn-transaction.ts
+++ b/src/main/packages/bpmn/bpmn-transaction/bpmn-transaction.ts
@@ -1,11 +1,11 @@
 import { BPMNElementType } from '..';
 import { ILayer } from '../../../services/layouter/layer';
 import { ILayoutable } from '../../../services/layouter/layoutable';
-import { UMLElement } from '../../../services/uml-element/uml-element';
 import { calculateNameBounds } from '../../../utils/name-bounds';
 import { UMLElementType } from '../../uml-element-type';
+import { UMLContainer } from '../../../services/uml-container/uml-container';
 
-export class BPMNTransaction extends UMLElement {
+export class BPMNTransaction extends UMLContainer {
   type: UMLElementType = BPMNElementType.BPMNTransaction;
 
   render(canvas: ILayer): ILayoutable[] {

--- a/src/main/packages/bpmn/index.ts
+++ b/src/main/packages/bpmn/index.ts
@@ -11,6 +11,7 @@ export const BPMNElementType = {
   BPMNEndEvent: 'BPMNEndEvent',
   BPMNGateway: 'BPMNGateway',
   BPMNConversation: 'BPMNConversation',
+  BPMNGroup: 'BPMNGroup',
 } as const;
 
 export const BPMNRelationshipType = {

--- a/src/main/packages/components.ts
+++ b/src/main/packages/components.ts
@@ -58,6 +58,7 @@ import { BPMNTransactionComponent } from './bpmn/bpmn-transaction/bpmn-transacti
 import { BPMNCallActivityComponent } from './bpmn/bpmn-call-activity/bpmn-call-activity-component';
 import { BPMNAnnotationComponent } from './bpmn/bpmn-annotation/bpmn-annotation-component';
 import { BPMNConversationComponent } from './bpmn/bpmn-conversation/bpmn-conversation-component';
+import { BPMNGroupComponent } from './bpmn/bpmn-group/bpmn-group-component';
 
 export const Components: {
   [key in UMLElementType | UMLRelationshipType]:
@@ -113,6 +114,7 @@ export const Components: {
   [UMLElementType.BPMNEndEvent]: BPMNEndEventComponent,
   [UMLElementType.BPMNGateway]: BPMNGatewayComponent,
   [UMLElementType.BPMNConversation]: BPMNConversationComponent,
+  [UMLElementType.BPMNGroup]: BPMNGroupComponent,
   [UMLRelationshipType.ClassAggregation]: UMLAssociationComponent,
   [UMLRelationshipType.ClassBidirectional]: UMLAssociationComponent,
   [UMLRelationshipType.ClassComposition]: UMLAssociationComponent,

--- a/src/main/packages/popups.ts
+++ b/src/main/packages/popups.ts
@@ -82,6 +82,7 @@ export const Popups: { [key in UMLElementType | UMLRelationshipType]: ComponentT
   [UMLElementType.BPMNEndEvent]: DefaultPopup,
   [UMLElementType.BPMNGateway]: BPMNGatewayUpdate,
   [UMLElementType.BPMNConversation]: BPMNConversationUpdate,
+  [UMLElementType.BPMNGroup]: DefaultPopup,
   // Relationships
   [UMLRelationshipType.ClassAggregation]: UMLClassAssociationUpdate,
   [UMLRelationshipType.ClassBidirectional]: UMLClassAssociationUpdate,

--- a/src/main/packages/uml-elements.ts
+++ b/src/main/packages/uml-elements.ts
@@ -48,6 +48,7 @@ import { BPMNTransaction } from './bpmn/bpmn-transaction/bpmn-transaction';
 import { BPMNCallActivity } from './bpmn/bpmn-call-activity/bpmn-call-activity';
 import { BPMNAnnotation } from './bpmn/bpmn-annotation/bpmn-annotation';
 import { BPMNConversation } from './bpmn/bpmn-conversation/bpmn-conversation';
+import { BPMNGroup } from './bpmn/bpmn-group/bpmn-group';
 
 export const UMLElements = {
   [UMLElementType.Package]: UMLClassPackage,
@@ -99,4 +100,5 @@ export const UMLElements = {
   [UMLElementType.BPMNEndEvent]: BPMNEndEvent,
   [UMLElementType.BPMNGateway]: BPMNGateway,
   [UMLElementType.BPMNConversation]: BPMNConversation,
+  [UMLElementType.BPMNGroup]: BPMNGroup,
 };

--- a/src/tests/unit/packages/bpmn/bpmn-annotation/bpmn-annotation-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-annotation/bpmn-annotation-component-test.tsx
@@ -1,14 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { CSSProperties } from 'react';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNAnnotation } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation';
 import { BPMNAnnotationComponent } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation-component';
-
-// override getStringWidth, because it uses by jsdom unsupported SVGElement methods
-Multiline.prototype.getStringWidth = (str: string, style?: CSSProperties) => {
-  return 0;
-};
 
 it('render the bpmn-annotation-component', () => {
   const annotation: BPMNAnnotation = new BPMNAnnotation({ name: 'Annotation' });

--- a/src/tests/unit/packages/bpmn/bpmn-annotation/bpmn-annotation-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-annotation/bpmn-annotation-component-test.tsx
@@ -1,9 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { SyntaxTreeTerminal } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal';
-import { SyntaxTreeTerminalComponent } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal-component';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { CSSProperties } from 'react';
+import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNAnnotation } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation';
 import { BPMNAnnotationComponent } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation-component';
 

--- a/src/tests/unit/packages/bpmn/bpmn-call-activity/bpmn-call-activity-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-call-activity/bpmn-call-activity-component-test.tsx
@@ -1,11 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { SyntaxTreeTerminal } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal';
-import { SyntaxTreeTerminalComponent } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal-component';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { CSSProperties } from 'react';
-import { BPMNAnnotation } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation';
-import { BPMNAnnotationComponent } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation-component';
+import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNCallActivity } from '../../../../../main/packages/bpmn/bpmn-call-activity/bpmn-call-activity';
 import { BPMNCallActivityComponent } from '../../../../../main/packages/bpmn/bpmn-call-activity/bpmn-call-activity-component';
 

--- a/src/tests/unit/packages/bpmn/bpmn-call-activity/bpmn-call-activity-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-call-activity/bpmn-call-activity-component-test.tsx
@@ -1,14 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { CSSProperties } from 'react';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNCallActivity } from '../../../../../main/packages/bpmn/bpmn-call-activity/bpmn-call-activity';
 import { BPMNCallActivityComponent } from '../../../../../main/packages/bpmn/bpmn-call-activity/bpmn-call-activity-component';
-
-// override getStringWidth, because it uses by jsdom unsupported SVGElement methods
-Multiline.prototype.getStringWidth = (str: string, style?: CSSProperties) => {
-  return 0;
-};
 
 it('render the bpmn-call-activity-component', () => {
   const callActivity: BPMNCallActivity = new BPMNCallActivity({ name: 'Call Activity' });

--- a/src/tests/unit/packages/bpmn/bpmn-conversation/bpmn-conversation-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-conversation/bpmn-conversation-component-test.tsx
@@ -1,11 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { SyntaxTreeTerminal } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal';
-import { SyntaxTreeTerminalComponent } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal-component';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { CSSProperties } from 'react';
-import { BPMNAnnotation } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation';
-import { BPMNAnnotationComponent } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation-component';
+import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNConversationComponent } from '../../../../../main/packages/bpmn/bpmn-conversation/bpmn-conversation-component';
 import { BPMNConversation } from '../../../../../main/packages/bpmn/bpmn-conversation/bpmn-conversation';
 

--- a/src/tests/unit/packages/bpmn/bpmn-conversation/bpmn-conversation-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-conversation/bpmn-conversation-component-test.tsx
@@ -1,14 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { CSSProperties } from 'react';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNConversationComponent } from '../../../../../main/packages/bpmn/bpmn-conversation/bpmn-conversation-component';
 import { BPMNConversation } from '../../../../../main/packages/bpmn/bpmn-conversation/bpmn-conversation';
-
-// override getStringWidth, because it uses by jsdom unsupported SVGElement methods
-Multiline.prototype.getStringWidth = (str: string, style?: CSSProperties) => {
-  return 0;
-};
 
 it('render the bpmn-conversation-component', () => {
   const conversation: BPMNConversation = new BPMNConversation({ name: 'Conversation' });

--- a/src/tests/unit/packages/bpmn/bpmn-end-event/bpmn-end-event-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-end-event/bpmn-end-event-component-test.tsx
@@ -1,14 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { CSSProperties } from 'react';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNEndEventComponent } from '../../../../../main/packages/bpmn/bpmn-end-event/bpmn-end-event-component';
 import { BPMNEndEvent } from '../../../../../main/packages/bpmn/bpmn-end-event/bpmn-end-event';
-
-// override getStringWidth, because it uses by jsdom unsupported SVGElement methods
-Multiline.prototype.getStringWidth = (str: string, style?: CSSProperties) => {
-  return 0;
-};
 
 it('render the bpmn-end-event-component', () => {
   const endEvent: BPMNEndEvent = new BPMNEndEvent({ name: 'End' });

--- a/src/tests/unit/packages/bpmn/bpmn-flow/bpmn-flow-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-flow/bpmn-flow-component-test.tsx
@@ -1,14 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { CSSProperties } from 'react';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNFlow } from '../../../../../main/packages/bpmn/bpmn-flow/bpmn-flow';
 import { BPMNFlowComponent } from '../../../../../main/packages/bpmn/bpmn-flow/bpmn-flow-component';
-
-// override getStringWidth, because it uses by jsdom unsupported SVGElement methods
-Multiline.prototype.getStringWidth = (str: string, style?: CSSProperties) => {
-  return 0;
-};
 
 it('render the bpmn-flow-component', () => {
   const flow: BPMNFlow = new BPMNFlow({ id: '1', name: 'Sequence' });

--- a/src/tests/unit/packages/bpmn/bpmn-flow/bpmn-flow-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-flow/bpmn-flow-component-test.tsx
@@ -1,11 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { SyntaxTreeTerminal } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal';
-import { SyntaxTreeTerminalComponent } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal-component';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { CSSProperties } from 'react';
-import { BPMNAnnotation } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation';
-import { BPMNAnnotationComponent } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation-component';
+import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNFlow } from '../../../../../main/packages/bpmn/bpmn-flow/bpmn-flow';
 import { BPMNFlowComponent } from '../../../../../main/packages/bpmn/bpmn-flow/bpmn-flow-component';
 

--- a/src/tests/unit/packages/bpmn/bpmn-gateway/bpmn-gateway-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-gateway/bpmn-gateway-component-test.tsx
@@ -1,14 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { CSSProperties } from 'react';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNGateway } from '../../../../../main/packages/bpmn/bpmn-gateway/bpmn-gateway';
 import { BPMNGatewayComponent } from '../../../../../main/packages/bpmn/bpmn-gateway/bpmn-gateway-component';
-
-// override getStringWidth, because it uses by jsdom unsupported SVGElement methods
-Multiline.prototype.getStringWidth = (str: string, style?: CSSProperties) => {
-  return 0;
-};
 
 it('render the bpmn-gateway-component', () => {
   const gateway: BPMNGateway = new BPMNGateway({ name: 'Gateway' });

--- a/src/tests/unit/packages/bpmn/bpmn-gateway/bpmn-gateway-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-gateway/bpmn-gateway-component-test.tsx
@@ -1,11 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { SyntaxTreeTerminal } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal';
-import { SyntaxTreeTerminalComponent } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal-component';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { CSSProperties } from 'react';
-import { BPMNAnnotation } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation';
-import { BPMNAnnotationComponent } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation-component';
+import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNGateway } from '../../../../../main/packages/bpmn/bpmn-gateway/bpmn-gateway';
 import { BPMNGatewayComponent } from '../../../../../main/packages/bpmn/bpmn-gateway/bpmn-gateway-component';
 

--- a/src/tests/unit/packages/bpmn/bpmn-group/__snapshots__/bpmn-group-component-test.tsx.snap
+++ b/src/tests/unit/packages/bpmn/bpmn-group/__snapshots__/bpmn-group-component-test.tsx.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render the bpmn-group-component 1`] = `
+<body>
+  <div>
+    <svg>
+      <g>
+        <rect
+          class="sc-fqkvVR zazVk"
+          fill="transparent"
+          height="100%"
+          rx="10"
+          ry="10"
+          stroke="black"
+          stroke-dasharray="4"
+          width="100%"
+        />
+        <text
+          font-weight="bold"
+          height="100"
+          pointer-events="none"
+          text-anchor="middle"
+          width="200"
+          x="100"
+          y="50"
+        >
+          <tspan
+            dy="5.5"
+            x="100"
+          >
+            Group
+          </tspan>
+        </text>
+      </g>
+    </svg>
+  </div>
+</body>
+`;

--- a/src/tests/unit/packages/bpmn/bpmn-group/bpmn-group-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-group/bpmn-group-component-test.tsx
@@ -1,14 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { CSSProperties } from 'react';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNGroup } from '../../../../../main/packages/bpmn/bpmn-group/bpmn-group';
 import { BPMNGroupComponent } from '../../../../../main/packages/bpmn/bpmn-group/bpmn-group-component';
-
-// override getStringWidth, because it uses by jsdom unsupported SVGElement methods
-Multiline.prototype.getStringWidth = (str: string, style?: CSSProperties) => {
-  return 0;
-};
 
 it('render the bpmn-group-component', () => {
   const group: BPMNGroup = new BPMNGroup({ name: 'Group' });

--- a/src/tests/unit/packages/bpmn/bpmn-group/bpmn-group-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-group/bpmn-group-component-test.tsx
@@ -2,21 +2,21 @@ import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
 import { CSSProperties } from 'react';
 import { Multiline } from '../../../../../main/utils/svg/multiline';
-import { BPMNEndEventComponent } from '../../../../../main/packages/bpmn/bpmn-end-event/bpmn-end-event-component';
-import { BPMNEndEvent } from '../../../../../main/packages/bpmn/bpmn-end-event/bpmn-end-event';
+import { BPMNGroup } from '../../../../../main/packages/bpmn/bpmn-group/bpmn-group';
+import { BPMNGroupComponent } from '../../../../../main/packages/bpmn/bpmn-group/bpmn-group-component';
 
 // override getStringWidth, because it uses by jsdom unsupported SVGElement methods
 Multiline.prototype.getStringWidth = (str: string, style?: CSSProperties) => {
   return 0;
 };
 
-it('render the bpmn-end-event-component', () => {
-  const endEvent: BPMNEndEvent = new BPMNEndEvent({ name: 'End' });
+it('render the bpmn-group-component', () => {
+  const group: BPMNGroup = new BPMNGroup({ name: 'Group' });
   const { getByText, baseElement } = wrappedRender(
     <svg>
-      <BPMNEndEventComponent element={endEvent} />
+      <BPMNGroupComponent element={group} />
     </svg>,
   );
-  expect(getByText(endEvent.name)).toBeInTheDocument();
+  expect(getByText(group.name)).toBeInTheDocument();
   expect(baseElement).toMatchSnapshot();
 });

--- a/src/tests/unit/packages/bpmn/bpmn-intermediate-event/bpmn-intermediate-event-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-intermediate-event/bpmn-intermediate-event-component-test.tsx
@@ -1,11 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { SyntaxTreeTerminal } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal';
-import { SyntaxTreeTerminalComponent } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal-component';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { CSSProperties } from 'react';
-import { BPMNAnnotation } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation';
-import { BPMNAnnotationComponent } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation-component';
+import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNIntermediateEvent } from '../../../../../main/packages/bpmn/bpmn-intermediate-event/bpmn-intermediate-event';
 import { BPMNIntermediateEventComponent } from '../../../../../main/packages/bpmn/bpmn-intermediate-event/bpmn-intermediate-event-component';
 

--- a/src/tests/unit/packages/bpmn/bpmn-intermediate-event/bpmn-intermediate-event-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-intermediate-event/bpmn-intermediate-event-component-test.tsx
@@ -1,14 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { CSSProperties } from 'react';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNIntermediateEvent } from '../../../../../main/packages/bpmn/bpmn-intermediate-event/bpmn-intermediate-event';
 import { BPMNIntermediateEventComponent } from '../../../../../main/packages/bpmn/bpmn-intermediate-event/bpmn-intermediate-event-component';
-
-// override getStringWidth, because it uses by jsdom unsupported SVGElement methods
-Multiline.prototype.getStringWidth = (str: string, style?: CSSProperties) => {
-  return 0;
-};
 
 it('render the bpmn-intermediate-event-component', () => {
   const intermediateEvent: BPMNIntermediateEvent = new BPMNIntermediateEvent({ name: 'Event' });

--- a/src/tests/unit/packages/bpmn/bpmn-start-event/bpmn-start-event-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-start-event/bpmn-start-event-component-test.tsx
@@ -1,14 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { CSSProperties } from 'react';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNStartEvent } from '../../../../../main/packages/bpmn/bpmn-start-event/bpmn-start-event';
 import { BPMNStartEventComponent } from '../../../../../main/packages/bpmn/bpmn-start-event/bpmn-start-event-component';
-
-// override getStringWidth, because it uses by jsdom unsupported SVGElement methods
-Multiline.prototype.getStringWidth = (str: string, style?: CSSProperties) => {
-  return 0;
-};
 
 it('render the bpmn-start-event-component', () => {
   const startEvent: BPMNStartEvent = new BPMNStartEvent({ name: 'Start' });

--- a/src/tests/unit/packages/bpmn/bpmn-start-event/bpmn-start-event-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-start-event/bpmn-start-event-component-test.tsx
@@ -1,11 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { SyntaxTreeTerminal } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal';
-import { SyntaxTreeTerminalComponent } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal-component';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { CSSProperties } from 'react';
-import { BPMNAnnotation } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation';
-import { BPMNAnnotationComponent } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation-component';
+import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNStartEvent } from '../../../../../main/packages/bpmn/bpmn-start-event/bpmn-start-event';
 import { BPMNStartEventComponent } from '../../../../../main/packages/bpmn/bpmn-start-event/bpmn-start-event-component';
 

--- a/src/tests/unit/packages/bpmn/bpmn-subprocess/__snapshots__/bpmn-subprocess-component-test.tsx.snap
+++ b/src/tests/unit/packages/bpmn/bpmn-subprocess/__snapshots__/bpmn-subprocess-component-test.tsx.snap
@@ -12,8 +12,28 @@ exports[`render the bpmn-subprocess-component 1`] = `
           rx="10"
           ry="10"
           stroke="black"
-          stroke-dasharray="4"
           width="100%"
+        />
+        <rect
+          class="sc-fqkvVR kprGcp"
+          fill="white"
+          height="14"
+          stroke="black"
+          width="14"
+          x="93"
+          y="86"
+        />
+        <polyline
+          class="sc-aXZVg bUvEJV"
+          fill="white"
+          points="96 93, 104 93"
+          stroke="black"
+        />
+        <polyline
+          class="sc-aXZVg bUvEJV"
+          fill="white"
+          points="100 89, 100 97"
+          stroke="black"
         />
         <text
           font-weight="bold"

--- a/src/tests/unit/packages/bpmn/bpmn-subprocess/bpmn-subprocess-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-subprocess/bpmn-subprocess-component-test.tsx
@@ -1,14 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { CSSProperties } from 'react';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNSubprocess } from '../../../../../main/packages/bpmn/bpmn-subprocess/bpmn-subprocess';
 import { BPMNSubprocessComponent } from '../../../../../main/packages/bpmn/bpmn-subprocess/bpmn-subprocess-component';
-
-// override getStringWidth, because it uses by jsdom unsupported SVGElement methods
-Multiline.prototype.getStringWidth = (str: string, style?: CSSProperties) => {
-  return 0;
-};
 
 it('render the bpmn-subprocess-component', () => {
   const subprocess: BPMNSubprocess = new BPMNSubprocess({ name: 'SyntaxTreeTerminal' });

--- a/src/tests/unit/packages/bpmn/bpmn-subprocess/bpmn-subprocess-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-subprocess/bpmn-subprocess-component-test.tsx
@@ -1,11 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { SyntaxTreeTerminal } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal';
-import { SyntaxTreeTerminalComponent } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal-component';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { CSSProperties } from 'react';
-import { BPMNAnnotation } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation';
-import { BPMNAnnotationComponent } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation-component';
+import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNSubprocess } from '../../../../../main/packages/bpmn/bpmn-subprocess/bpmn-subprocess';
 import { BPMNSubprocessComponent } from '../../../../../main/packages/bpmn/bpmn-subprocess/bpmn-subprocess-component';
 

--- a/src/tests/unit/packages/bpmn/bpmn-task/bpmn-task-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-task/bpmn-task-component-test.tsx
@@ -1,14 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { CSSProperties } from 'react';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNTask } from '../../../../../main/packages/bpmn/bpmn-task/bpmn-task';
 import { BPMNTaskComponent } from '../../../../../main/packages/bpmn/bpmn-task/bpmn-task-component';
-
-// override getStringWidth, because it uses by jsdom unsupported SVGElement methods
-Multiline.prototype.getStringWidth = (str: string, style?: CSSProperties) => {
-  return 0;
-};
 
 it('render the bpmn-task-component', () => {
   const task: BPMNTask = new BPMNTask({ name: 'Task' });

--- a/src/tests/unit/packages/bpmn/bpmn-task/bpmn-task-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-task/bpmn-task-component-test.tsx
@@ -1,11 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { SyntaxTreeTerminal } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal';
-import { SyntaxTreeTerminalComponent } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal-component';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { CSSProperties } from 'react';
-import { BPMNAnnotation } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation';
-import { BPMNAnnotationComponent } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation-component';
+import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNTask } from '../../../../../main/packages/bpmn/bpmn-task/bpmn-task';
 import { BPMNTaskComponent } from '../../../../../main/packages/bpmn/bpmn-task/bpmn-task-component';
 

--- a/src/tests/unit/packages/bpmn/bpmn-transaction/bpmn-transaction-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-transaction/bpmn-transaction-component-test.tsx
@@ -1,11 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { SyntaxTreeTerminal } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal';
-import { SyntaxTreeTerminalComponent } from '../../../../../main/packages/syntax-tree/syntax-tree-terminal/syntax-tree-terminal-component';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { CSSProperties } from 'react';
-import { BPMNAnnotation } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation';
-import { BPMNAnnotationComponent } from '../../../../../main/packages/bpmn/bpmn-annotation/bpmn-annotation-component';
+import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNTransaction } from '../../../../../main/packages/bpmn/bpmn-transaction/bpmn-transaction';
 import { BPMNTransactionComponent } from '../../../../../main/packages/bpmn/bpmn-transaction/bpmn-transaction-component';
 

--- a/src/tests/unit/packages/bpmn/bpmn-transaction/bpmn-transaction-component-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-transaction/bpmn-transaction-component-test.tsx
@@ -1,14 +1,7 @@
 import { wrappedRender } from '../../../test-utils/render';
 import * as React from 'react';
-import { CSSProperties } from 'react';
-import { Multiline } from '../../../../../main/utils/svg/multiline';
 import { BPMNTransaction } from '../../../../../main/packages/bpmn/bpmn-transaction/bpmn-transaction';
 import { BPMNTransactionComponent } from '../../../../../main/packages/bpmn/bpmn-transaction/bpmn-transaction-component';
-
-// override getStringWidth, because it uses by jsdom unsupported SVGElement methods
-Multiline.prototype.getStringWidth = (str: string, style?: CSSProperties) => {
-  return 0;
-};
 
 it('render the bpmn-transaction-component', () => {
   const transaction: BPMNTransaction = new BPMNTransaction({ name: 'Transaction' });


### PR DESCRIPTION
This PR intends to add support for groups within BPMN diagrams and adapts how subprocesses are rendered to comply with the BPMN 2.0 standard.

### Checklist
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes
- [x] I translated all the newly inserted strings into German and English

### Motivation and Context
Groups allow for easier entity management in larger BPMN diagrams - therefore this change adds support for them.
Additionally, to comply with the specification of the BPMN 2.0 standard, the way how subprocesses are rendered is updated.

### Steps for Testing
1. Add a group (box with dashed outline) to the canvas
2. Drop other elements inside the group
3. Trying dragging the group around to assure everything inside the group is moved as well
4. Delete group to ensure contained elements are deleted as well
5. Drag subprocess onto the canvas and make sure it is displayed as expected

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see package.json). -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| File | % Stmts | % Branch | % Funcs | % Lines |
|------|-------:|-----:|-----:|-----:|
 main/packages/bpmn/bpmn-group                                          |   94.73 |      100 |   66.66 |   94.73 |                                                
  bpmn-group-component.tsx                                              |     100 |      100 |     100 |     100 |                                                    
  bpmn-group.ts                                                         |   85.71 |      100 |      50 |   85.71 |
 main/packages/bpmn/bpmn-subprocess                                     |   95.45 |      100 |   66.66 |   95.45 |                          
  bpmn-subprocess-component.tsx                                         |     100 |      100 |     100 |     100 |                              
  bpmn-subprocess.ts                                                    |      80 |      100 |      50 |      80 |

### Screenshots
<img width="1516" alt="Screenshot 2023-10-26 at 11 53 31" src="https://github.com/ls1intum/Apollon/assets/143808484/2efa623f-0511-4fe1-b60e-90a480f7a72d">
