### PR TITLE
fix an issue with transforming corrupted models from v2

### DIFF
--- a/src/main/compat/v2/transform.ts
+++ b/src/main/compat/v2/transform.ts
@@ -10,11 +10,16 @@ import { UMLModelV2, isCommunicationLink } from './typings';
  *
  */
 export function v2ModeltoV3Model(model: UMLModelV2): UMLModel {
+  const elements = Array.isArray(model.elements) ? model.elements : [];
+  const relationships = Array.isArray(model.relationships) ? model.relationships : [];
+  const assessments = Array.isArray(model.assessments) ? model.assessments : [];
+  const interactive = model.interactive || { elements: [], relationships: [] };
+
   return {
     ...model,
     version: '3.0.0',
-    elements: model.elements.reduce((acc, val) => ({ ...acc, [val.id]: val }), {}),
-    relationships: model.relationships
+    elements: elements.reduce((acc, val) => ({ ...acc, [val.id]: val }), {}),
+    relationships: relationships
       .map((relationship) => {
         if (isCommunicationLink(relationship)) {
           return {
@@ -26,10 +31,10 @@ export function v2ModeltoV3Model(model: UMLModelV2): UMLModel {
         }
       })
       .reduce((acc, val) => ({ ...acc, [val.id]: val }), {}),
-    assessments: model.assessments.reduce((acc, val) => ({ ...acc, [val.modelElementId]: val }), {}),
+    assessments: assessments.reduce((acc, val) => ({ ...acc, [val.modelElementId]: val }), {}),
     interactive: {
-      elements: model.interactive.elements.reduce((acc, val) => ({ ...acc, [val]: true }), {}),
-      relationships: model.interactive.relationships.reduce((acc, val) => ({ ...acc, [val]: true }), {}),
+      elements: interactive.elements.reduce((acc, val) => ({ ...acc, [val]: true }), {}),
+      relationships: interactive.relationships.reduce((acc, val) => ({ ...acc, [val]: true }), {}),
     },
   };
 }

--- a/src/tests/unit/compat/v2/transform-test.ts
+++ b/src/tests/unit/compat/v2/transform-test.ts
@@ -1,0 +1,12 @@
+import { v2ModeltoV3Model } from '../../../../main/compat/v2/transform';
+
+
+describe('test v2 to v3 model conversion', () => {
+  it('handles corrupt models.', () => {
+    expect(() => v2ModeltoV3Model({} as any)).not.toThrow();
+    expect(() => v2ModeltoV3Model({ elements: {} } as any)).not.toThrow();
+    expect(() => v2ModeltoV3Model({ elements: [], relationships: {} } as any)).not.toThrow();
+    expect(() => v2ModeltoV3Model({ assessments: {} } as any)).not.toThrow();
+  });
+});
+

--- a/src/tests/unit/compat/v2/transform-test.ts
+++ b/src/tests/unit/compat/v2/transform-test.ts
@@ -1,6 +1,5 @@
 import { v2ModeltoV3Model } from '../../../../main/compat/v2/transform';
 
-
 describe('test v2 to v3 model conversion', () => {
   it('handles corrupt models.', () => {
     expect(() => v2ModeltoV3Model({} as any)).not.toThrow();
@@ -9,4 +8,3 @@ describe('test v2 to v3 model conversion', () => {
     expect(() => v2ModeltoV3Model({ assessments: {} } as any)).not.toThrow();
   });
 });
-


### PR DESCRIPTION
### Checklist
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes
- [x] I translated all the newly inserted strings into German and English

### Motivation and Context
I was working on integrating Apollon v3 with Artemis, and realised that sometimes v2 models are stored with the wrong format, which causes errors when Apollon 3 tries to load them and convert them to v3 schema.

### Description
It can happen that v2 models are stored with the wrong format / typing, which will cause errors to be thrown by the backwards compatibility code that tries to convert the corrupt v2 model to v3. For example, essential fields of the model might be absent (e.g. `elements`, `assessments`, etc) or of the wrong type (e.g. an empty object instead of an array).


### Steps for Testing
Basically create a corrupted JSON diagram.

1. Run locally (`npm start`)
2. Create and save the diagram
3. Corrupt the diagram: open developer console on browser and type the following:
  ```js
  localStorage.setItem('apollon', "{\"version\": \"2.0.0\"\}")
  ```
4. Reload the page, you'll see an error thrown in the console due to the corrupt model.

### Test Coverage

| File | Branch | Line |
|------|-------:|-----:|
|main/compat/v2/transform.ts|100%|100%|

