### PR TITLE
Add support for BPMN data objects

### DIFF
--- a/src/main/i18n/de.json
+++ b/src/main/i18n/de.json
@@ -140,7 +140,8 @@
       "BPMNCallConversation": "Aufruf-Konversation",
       "BPMNSequenceFlow": "Sequenz",
       "BPMNMessageFlow": "Nachricht",
-      "BPMNAssociationFlow": "Assoziation"
+      "BPMNAssociationFlow": "Assoziation",
+      "BPMNDataObject": "Datenobjekt"
     }
   }
 }

--- a/src/main/i18n/en.json
+++ b/src/main/i18n/en.json
@@ -140,7 +140,8 @@
       "BPMNCallConversation": "Call Conversation",
       "BPMNSequenceFlow": "Sequence",
       "BPMNMessageFlow": "Message",
-      "BPMNAssociationFlow": "Association"
+      "BPMNAssociationFlow": "Association",
+      "BPMNDataObject": "Data Object"
     }
   }
 }

--- a/src/main/i18n/en.json
+++ b/src/main/i18n/en.json
@@ -141,7 +141,7 @@
       "BPMNSequenceFlow": "Sequence",
       "BPMNMessageFlow": "Message",
       "BPMNAssociationFlow": "Association",
-      "BPMNDataObject": "Data Object"
+      "BPMNDataObject": "Data Object",
       "BPMNGroup": "Group"
     }
   }

--- a/src/main/packages/bpmn/bpmn-data-object/bpmn-data-object-component.tsx
+++ b/src/main/packages/bpmn/bpmn-data-object/bpmn-data-object-component.tsx
@@ -1,0 +1,34 @@
+import React, { FunctionComponent } from 'react';
+import { ThemedPath, ThemedPolyline, ThemedRect } from '../../../components/theme/themedComponents';
+import { Multiline } from '../../../utils/svg/multiline';
+import { BPMNDataObject } from './bpmn-data-object';
+
+export const BPMNDataObjectComponent: FunctionComponent<Props> = ({ element }) => (
+  <g>
+    <ThemedPolyline
+      points={`0 0, 0 ${element.bounds.height}, ${element.bounds.width} ${element.bounds.height}, ${
+        element.bounds.width
+      } 15, ${element.bounds.width - 15} 0, ${element.bounds.width - 15} 15, ${element.bounds.width} 15, ${
+        element.bounds.width - 15
+      } 0, 0 0`}
+      strokeColor={element.strokeColor}
+      fillColor={element.fillColor}
+    />
+    <Multiline
+      x={element.bounds.width / 2}
+      y={element.bounds.height / 2}
+      width={element.bounds.width}
+      height={element.bounds.height}
+      fontWeight="bold"
+      fill={element.textColor}
+      lineHeight={16}
+      capHeight={11}
+    >
+      {element.name}
+    </Multiline>
+  </g>
+);
+
+interface Props {
+  element: BPMNDataObject;
+}

--- a/src/main/packages/bpmn/bpmn-data-object/bpmn-data-object.ts
+++ b/src/main/packages/bpmn/bpmn-data-object/bpmn-data-object.ts
@@ -1,0 +1,19 @@
+import { BPMNElementType } from '..';
+import { ILayer } from '../../../services/layouter/layer';
+import { ILayoutable } from '../../../services/layouter/layoutable';
+import { calculateNameBounds } from '../../../utils/name-bounds';
+import { UMLElementType } from '../../uml-element-type';
+import { UMLElementFeatures } from '../../../services/uml-element/uml-element-features';
+import { UMLElement } from '../../../services/uml-element/uml-element';
+import { UMLContainer } from '../../../services/uml-container/uml-container';
+
+export class BPMNDataObject extends UMLContainer {
+  static features: UMLElementFeatures = { ...UMLContainer.features };
+
+  type: UMLElementType = BPMNElementType.BPMNDataObject;
+
+  render(canvas: ILayer): ILayoutable[] {
+    this.bounds = calculateNameBounds(this, canvas);
+    return [this];
+  }
+}

--- a/src/main/packages/bpmn/bpmn-diagram-preview.ts
+++ b/src/main/packages/bpmn/bpmn-diagram-preview.ts
@@ -11,6 +11,7 @@ import { BPMNTransaction } from './bpmn-transaction/bpmn-transaction';
 import { BPMNCallActivity } from './bpmn-call-activity/bpmn-call-activity';
 import { BPMNAnnotation } from './bpmn-annotation/bpmn-annotation';
 import { BPMNConversation } from './bpmn-conversation/bpmn-conversation';
+import { BPMNDataObject } from './bpmn-data-object/bpmn-data-object';
 
 export const composeBPMNPreview: ComposePreview = (
   layer: ILayer,
@@ -83,9 +84,8 @@ export const composeBPMNPreview: ComposePreview = (
   );
 
   elements.push(
-    new BPMNConversation({
-      name: translate('packages.BPMN.BPMNConversation'),
-      bounds: { x: 0, y: 0, width: 40, height: 40 },
+    new BPMNDataObject({
+      bounds: { x: 0, y: 0, width: 50, height: 60 },
     }),
   );
 

--- a/src/main/packages/bpmn/index.ts
+++ b/src/main/packages/bpmn/index.ts
@@ -11,6 +11,7 @@ export const BPMNElementType = {
   BPMNEndEvent: 'BPMNEndEvent',
   BPMNGateway: 'BPMNGateway',
   BPMNConversation: 'BPMNConversation',
+  BPMNDataObject: 'BPMNDataObject',
 } as const;
 
 export const BPMNRelationshipType = {

--- a/src/main/packages/components.ts
+++ b/src/main/packages/components.ts
@@ -59,6 +59,7 @@ import { BPMNTransactionComponent } from './bpmn/bpmn-transaction/bpmn-transacti
 import { BPMNCallActivityComponent } from './bpmn/bpmn-call-activity/bpmn-call-activity-component';
 import { BPMNAnnotationComponent } from './bpmn/bpmn-annotation/bpmn-annotation-component';
 import { BPMNConversationComponent } from './bpmn/bpmn-conversation/bpmn-conversation-component';
+import { BPMNDataObjectComponent } from './bpmn/bpmn-data-object/bpmn-data-object-component';
 
 export const Components: {
   [key in UMLElementType | UMLRelationshipType]:
@@ -115,6 +116,7 @@ export const Components: {
   [UMLElementType.BPMNEndEvent]: BPMNEndEventComponent,
   [UMLElementType.BPMNGateway]: BPMNGatewayComponent,
   [UMLElementType.BPMNConversation]: BPMNConversationComponent,
+  [UMLElementType.BPMNDataObject]: BPMNDataObjectComponent,
   [UMLRelationshipType.ClassAggregation]: UMLAssociationComponent,
   [UMLRelationshipType.ClassBidirectional]: UMLAssociationComponent,
   [UMLRelationshipType.ClassComposition]: UMLAssociationComponent,

--- a/src/main/packages/popups.ts
+++ b/src/main/packages/popups.ts
@@ -83,6 +83,7 @@ export const Popups: { [key in UMLElementType | UMLRelationshipType]: ComponentT
   [UMLElementType.BPMNEndEvent]: DefaultPopup,
   [UMLElementType.BPMNGateway]: BPMNGatewayUpdate,
   [UMLElementType.BPMNConversation]: BPMNConversationUpdate,
+  [UMLElementType.BPMNDataObject]: DefaultPopup,
   // Relationships
   [UMLRelationshipType.ClassAggregation]: UMLClassAssociationUpdate,
   [UMLRelationshipType.ClassBidirectional]: UMLClassAssociationUpdate,

--- a/src/main/packages/uml-elements.ts
+++ b/src/main/packages/uml-elements.ts
@@ -49,6 +49,7 @@ import { BPMNTransaction } from './bpmn/bpmn-transaction/bpmn-transaction';
 import { BPMNCallActivity } from './bpmn/bpmn-call-activity/bpmn-call-activity';
 import { BPMNAnnotation } from './bpmn/bpmn-annotation/bpmn-annotation';
 import { BPMNConversation } from './bpmn/bpmn-conversation/bpmn-conversation';
+import { BPMNDataObject } from './bpmn/bpmn-data-object/bpmn-data-object';
 
 export const UMLElements = {
   [UMLElementType.Package]: UMLClassPackage,
@@ -101,4 +102,5 @@ export const UMLElements = {
   [UMLElementType.BPMNEndEvent]: BPMNEndEvent,
   [UMLElementType.BPMNGateway]: BPMNGateway,
   [UMLElementType.BPMNConversation]: BPMNConversation,
+  [UMLElementType.BPMNDataObject]: BPMNDataObject,
 };

--- a/src/tests/unit/packages/bpmn/bpmn-data-object/__snapshots__/bpmn-data-object-test.tsx.snap
+++ b/src/tests/unit/packages/bpmn/bpmn-data-object/__snapshots__/bpmn-data-object-test.tsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render the bpmn-transaction-component 1`] = `
+<body>
+  <div>
+    <svg>
+      <g>
+        <polyline
+          class="sc-aXZVg bUvEJV"
+          fill="white"
+          points="0 0, 0 100, 200 100, 200 15, 185 0, 185 15, 200 15, 185 0, 0 0"
+          stroke="black"
+        />
+        <text
+          font-weight="bold"
+          height="100"
+          pointer-events="none"
+          text-anchor="middle"
+          width="200"
+          x="100"
+          y="50"
+        >
+          <tspan
+            dy="5.5"
+            x="100"
+          >
+            Data Object
+          </tspan>
+        </text>
+      </g>
+    </svg>
+  </div>
+</body>
+`;

--- a/src/tests/unit/packages/bpmn/bpmn-data-object/bpmn-data-object-test.tsx
+++ b/src/tests/unit/packages/bpmn/bpmn-data-object/bpmn-data-object-test.tsx
@@ -1,0 +1,15 @@
+import { wrappedRender } from '../../../test-utils/render';
+import * as React from 'react';
+import { BPMNDataObject } from '../../../../../main/packages/bpmn/bpmn-data-object/bpmn-data-object';
+import { BPMNDataObjectComponent } from '../../../../../main/packages/bpmn/bpmn-data-object/bpmn-data-object-component';
+
+it('render the bpmn-transaction-component', () => {
+  const dataObject: BPMNDataObject = new BPMNDataObject({ name: 'Data Object' });
+  const { getByText, baseElement } = wrappedRender(
+    <svg>
+      <BPMNDataObjectComponent element={dataObject} />
+    </svg>,
+  );
+  expect(getByText(dataObject.name)).toBeInTheDocument();
+  expect(baseElement).toMatchSnapshot();
+});


### PR DESCRIPTION
This change adds suport for BPMN data objects.

### Checklist
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes
- [x] I translated all the newly inserted strings into German and English

### Motivation and Context
Data objects are the most important artifact of BPMN diagrams and therefore need to be supported.

### Description
This change adds data objects to BPMN diagrams.

### Steps for Testing
1. Create a new BPMN diagram
2. Drop a data object onto the canvas
3. Change the data objects name
4. Remove the data object again

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see package.json). -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| File | % Stmts | % Branch | % Funcs | % Lines |
|------|-------:|-----:|-----:|-----:|
 main/packages/bpmn/bpmn-data-object                                    |   94.33 |      100 |   66.66 |   94.33 |                                                              
  bpmn-data-object-component.tsx                                        |     100 |      100 |     100 |     100 |                                                              
  bpmn-data-object.ts                                                   |   84.21 |      100 |      50 |   84.21 |

### Screenshots
<img width="1475" alt="Screenshot 2023-10-27 at 14 15 26" src="https://github.com/ls1intum/Apollon/assets/143808484/da3a40e3-c84a-4c1b-a04e-c613aa4a90b8">

