### PR TITLE
fix merge issue with nested layouts

### DIFF
--- a/src/main/components/store/merge.ts
+++ b/src/main/components/store/merge.ts
@@ -16,9 +16,7 @@ export function merge(oldState: ModelState, newState: ModelState): ModelState {
     ...oldState,
     diagram: {
       ...oldState.diagram,
-      ownedElements: oldState.diagram.ownedElements.filter(
-        (id) => !!newState.elements[id] && !newState.elements[id].owner,
-      ),
+      ownedElements: Object.keys(newState.elements).filter((id) => !newState.elements[id].owner),
       ownedRelationships: oldState.diagram.ownedRelationships.filter((id) => !!newState.elements[id]),
     },
     elements: Object.keys(newState.elements).reduce((acc, id) => {

--- a/src/tests/unit/components/store/merge-test.ts
+++ b/src/tests/unit/components/store/merge-test.ts
@@ -2,6 +2,7 @@ import { merge } from '../../../../main/components/store/merge';
 import { ModelState } from '../../../../main/components/store/model-state';
 import diagram from '../../test-resources/class-diagram.json';
 import diagram3 from '../../test-resources/class-diagram-3.json';
+import diagram4 from '../../test-resources/class-diagram-4.json';
 
 describe('merge', () => {
   const pkgId = 'c10b995a-036c-4e9e-aa67-0570ada5cb6a';
@@ -19,4 +20,15 @@ describe('merge', () => {
     expect(merged.elements[class2Id]).toBeDefined();
     expect(merged.elements[class1Id].owner).toBeNull();
   });
+
+  test('calculates the correct owned elements.', () => {
+    const oldState = ModelState.fromModel(diagram as any) as ModelState;
+    const newState = ModelState.fromModel(diagram4 as any) as ModelState;
+
+    const merged = merge(oldState, newState);
+
+    expect(merged.diagram.ownedElements).toContain(class1Id);
+    expect(merged.diagram.ownedElements).toContain(class2Id);
+    expect(merged.diagram.ownedElements).toContain(pkgId);
+  })
 });

--- a/src/tests/unit/components/store/merge-test.ts
+++ b/src/tests/unit/components/store/merge-test.ts
@@ -30,5 +30,5 @@ describe('merge', () => {
     expect(merged.diagram.ownedElements).toContain(class1Id);
     expect(merged.diagram.ownedElements).toContain(class2Id);
     expect(merged.diagram.ownedElements).toContain(pkgId);
-  })
+  });
 });

--- a/src/tests/unit/test-resources/class-diagram-4.json
+++ b/src/tests/unit/test-resources/class-diagram-4.json
@@ -1,0 +1,88 @@
+{
+  "version": "3.0.0",
+  "type": "ClassDiagram",
+  "size": { "width": 860, "height": 260 },
+  "interactive": { "elements": {}, "relationships": {} },
+  "elements": {
+    "c10b995a-036c-4e9e-aa67-0570ada5cb6a": {
+      "id": "c10b995a-036c-4e9e-aa67-0570ada5cb6a",
+      "name": "Package",
+      "type": "Package",
+      "owner": null,
+      "bounds": { "x": 0, "y": 0, "width": 350, "height": 220 }
+    },
+    "04d3509e-0dce-458b-bf62-f3555497a5a4": {
+      "id": "04d3509e-0dce-458b-bf62-f3555497a5a4",
+      "name": "Class",
+      "type": "Class",
+      "owner": null,
+      "bounds": { "x": 80, "y": 70, "width": 200, "height": 100 },
+      "attributes": ["90f94404-1fc6-4121-97ed-6b2c6d57d525"],
+      "methods": ["12d8bb82-e4e5-4505-a0eb-48ddab0fc0a0"]
+    },
+    "90f94404-1fc6-4121-97ed-6b2c6d57d525": {
+      "id": "90f94404-1fc6-4121-97ed-6b2c6d57d525",
+      "name": "+ attribute: Type",
+      "type": "ClassAttribute",
+      "owner": "04d3509e-0dce-458b-bf62-f3555497a5a4",
+      "bounds": { "x": 80, "y": 110, "width": 200, "height": 30 }
+    },
+    "12d8bb82-e4e5-4505-a0eb-48ddab0fc0a0": {
+      "id": "12d8bb82-e4e5-4505-a0eb-48ddab0fc0a0",
+      "name": "+ method()",
+      "type": "ClassMethod",
+      "owner": "04d3509e-0dce-458b-bf62-f3555497a5a4",
+      "bounds": { "x": 80, "y": 140, "width": 200, "height": 30 }
+    },
+    "9eadc4f6-caa0-4835-a24c-71c0c1ccbc39": {
+      "id": "9eadc4f6-caa0-4835-a24c-71c0c1ccbc39",
+      "name": "Class",
+      "type": "Class",
+      "owner": null,
+      "bounds": { "x": 620, "y": 90, "width": 200, "height": 100 },
+      "attributes": ["dbd4193a-4483-43df-8934-77192be006c2"],
+      "methods": ["e7ef41ee-290e-4df2-a535-199f1c5521fd"]
+    },
+    "dbd4193a-4483-43df-8934-77192be006c2": {
+      "id": "dbd4193a-4483-43df-8934-77192be006c2",
+      "name": "+ attribute: Type",
+      "type": "ClassAttribute",
+      "owner": "9eadc4f6-caa0-4835-a24c-71c0c1ccbc39",
+      "bounds": { "x": 620, "y": 130, "width": 200, "height": 30 }
+    },
+    "e7ef41ee-290e-4df2-a535-199f1c5521fd": {
+      "id": "e7ef41ee-290e-4df2-a535-199f1c5521fd",
+      "name": "+ method()",
+      "type": "ClassMethod",
+      "owner": "9eadc4f6-caa0-4835-a24c-71c0c1ccbc39",
+      "bounds": { "x": 620, "y": 160, "width": 200, "height": 30 }
+    }
+  },
+  "relationships": {
+    "f5c4e20d-8347-4136-bc02-b7a016e017f5": {
+      "id": "f5c4e20d-8347-4136-bc02-b7a016e017f5",
+      "name": "",
+      "type": "ClassBidirectional",
+      "owner": null,
+      "bounds": { "x": 280, "y": 130, "width": 340, "height": 1 },
+      "path": [
+        { "x": 340, "y": 0 },
+        { "x": 0, "y": 0 }
+      ],
+      "source": {
+        "direction": "Left",
+        "element": "9eadc4f6-caa0-4835-a24c-71c0c1ccbc39",
+        "multiplicity": "",
+        "role": ""
+      },
+      "target": {
+        "direction": "Right",
+        "element": "04d3509e-0dce-458b-bf62-f3555497a5a4",
+        "multiplicity": "",
+        "role": ""
+      },
+      "isManuallyLayouted": false
+    }
+  },
+  "assessments": {}
+}


### PR DESCRIPTION
### Checklist
- [x] ~~I documented the TypeScript code using JSDoc style~~ (NA).
- [x] I added multiple screenshots/screencasts of my UI changes
- [x] ~~I translated all the newly inserted strings into German and English~~ (NA)

### Motivation and Context

There was an issue with merging two states wherein layout information for nested elements wouldn't be recalculated properly.

### Description

While merging two states, elements that used to have a parent in the old state but are without a parent in the new state wouldn't be calculated properly. This is used by the client for quickly accessing the root elements for rendering, and while it triggers on its own as a result of re-renders and layout updates, it sometimes caused elements to vanish momentarily after state merges (e.g. during realtime collaboration).

### Steps for Testing

1. Clone [Apollon standalone](https://github.com/ls1intum/Apollon_standalone) and [link local Apollon](https://github.com/ls1intum/Apollon_standalone#link-local-project-of-apollon).
2. Create a diagram and open it in collaboration mode in another browser window.
3. Create a class element and a package element.
4. Drag the class element inside the package, then drag it back outside.
5. Without this fix, it is possible that the class will vanish. With this fix, this won't happen.

### Test Coverage

| File | Branch | Line |
|------|-------:|-----:|
| components/store/merge.ts | 100% | 100% |

### Screenshots

Without this fix:

![ScreenRecording2024-01-22at07 53 16-ezgif com-video-to-gif-converter](https://github.com/ls1intum/Apollon/assets/13572283/48571928-6117-4c03-8fe9-f0e915d6cdac)

With this fix:

![ScreenRecording2024-01-22at07 55 04-ezgif com-video-to-gif-converter](https://github.com/ls1intum/Apollon/assets/13572283/ef345440-7324-4236-9445-deb36c1f7bd5)
