### PR TITLE
`General`: Reduce Sidebar Width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7269,9 +7269,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {

--- a/src/main/components/create-pane/create-pane.tsx
+++ b/src/main/components/create-pane/create-pane.tsx
@@ -35,6 +35,7 @@ type OwnProps = {};
 type StateProps = {
   type: UMLDiagramType;
   colorEnabled: boolean;
+  previewScaleFactor?: number;
 };
 
 type DispatchProps = {
@@ -121,7 +122,10 @@ class CreatePaneComponent extends Component<Props, State> {
       .map((preview, index) => {
         const { styles: previewStyles } = preview;
         return (
-          <div style={previewStyles} key={index}>
+          <div
+            style={{ ...previewStyles, height: preview.bounds.height * (this.props?.previewScaleFactor ?? 0.8) + 8 }}
+            key={index}
+          >
             <PreviewElementComponent element={preview} create={this.create} />
           </div>
         );

--- a/src/main/components/create-pane/preview-element-component.tsx
+++ b/src/main/components/create-pane/preview-element-component.tsx
@@ -17,6 +17,8 @@ export const Preview = styled(hoverable(CanvasElement)).attrs({
   margin: 8px;
   overflow: visible;
   fill: white;
+  scale: 0.8;
+  transform-origin: top left;
 `;
 
 export class PreviewElementComponent extends Component<Props> {

--- a/src/main/components/create-pane/preview-element-component.tsx
+++ b/src/main/components/create-pane/preview-element-component.tsx
@@ -14,11 +14,10 @@ type Props = {
 export const Preview = styled(hoverable(CanvasElement)).attrs({
   child: CanvasElement,
 })`
-  margin: 8px;
   overflow: visible;
   fill: white;
   scale: 0.8;
-  transform-origin: top left;
+  transform-origin: center left;
 `;
 
 export class PreviewElementComponent extends Component<Props> {

--- a/src/main/components/create-pane/preview-element-component.tsx
+++ b/src/main/components/create-pane/preview-element-component.tsx
@@ -9,15 +9,17 @@ import { hoverable } from '../uml-element/hoverable/hoverable';
 type Props = {
   element: UMLElement;
   create: (element: UMLElement, owner?: string) => void;
+  scale?: number;
 };
 
-export const Preview = styled(hoverable(CanvasElement)).attrs({
+export const Preview = styled(hoverable(CanvasElement)).attrs((props: { scale?: number }) => ({
   child: CanvasElement,
-})`
+  scale: props.scale,
+}))`
   overflow: visible;
   fill: white;
-  scale: 0.8;
-  transform-origin: center left;
+  scale: ${(props) => props.scale ?? 0.8};
+  transform-origin: center center;
 `;
 
 export class PreviewElementComponent extends Component<Props> {

--- a/src/main/components/sidebar/sidebar-styles.ts
+++ b/src/main/components/sidebar/sidebar-styles.ts
@@ -8,9 +8,11 @@ export const Container = styled.aside.attrs<ContainerProps>({})<ContainerProps>`
   height: 100%;
   min-height: inherit;
   max-height: inherit;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
+  align-items: center;
 
   svg {
     display: block;

--- a/src/main/components/sidebar/sidebar-styles.ts
+++ b/src/main/components/sidebar/sidebar-styles.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export type ContainerProps = {};
 
 export const Container = styled.aside.attrs<ContainerProps>({})<ContainerProps>`
-  flex: 0 0 230px;
+  flex: 0 0 148px;
   padding: 0 10px;
   height: 100%;
   min-height: inherit;

--- a/src/main/packages/common/color-legend/color-legend.ts
+++ b/src/main/packages/common/color-legend/color-legend.ts
@@ -9,7 +9,7 @@ export class ColorLegend extends UMLElement {
   type: UMLElementType = ColorLegendElementType.ColorLegend;
 
   constructor(values?: DeepPartial<IUMLElement>) {
-    super(values && !values.bounds ? { ...values, bounds: { x: 0, y: 0, width: 200, height: 50 } } : values);
+    super(values && !values.bounds ? { ...values, bounds: { x: 0, y: 0, width: 160, height: 50 } } : values);
   }
 
   render(canvas: ILayer): ILayoutable[] {

--- a/src/main/packages/flowchart/flowchart-diagram-preview.ts
+++ b/src/main/packages/flowchart/flowchart-diagram-preview.ts
@@ -12,7 +12,7 @@ export const composeFlowchartPreview: ComposePreview = (
   translate: (id: string) => string,
 ): PreviewElement[] => {
   const elements: PreviewElement[] = [];
-  const defaultBounds: IBoundary = { x: 0, y: 0, width: 150, height: computeDimension(1.0, 70) };
+  const defaultBounds: IBoundary = { x: 0, y: 0, width: 160, height: computeDimension(1.0, 70) };
 
   elements.push(
     new FlowchartTerminal({
@@ -38,7 +38,10 @@ export const composeFlowchartPreview: ComposePreview = (
   elements.push(
     new FlowchartInputOutput({
       name: translate('packages.Flowchart.FlowchartInputOutput'),
-      bounds: defaultBounds,
+      bounds: {
+        ...defaultBounds,
+        width: 140,
+      },
     }),
   );
 

--- a/src/main/packages/uml-reachability-graph/reachability-graph-preview.ts
+++ b/src/main/packages/uml-reachability-graph/reachability-graph-preview.ts
@@ -11,7 +11,7 @@ export const composeReachabilityGraphPreview: ComposePreview = (
 
   const umlReachabilityGraphMarking = new UMLReachabilityGraphMarking({
     name: translate('packages.ReachabilityGraph.ReachabilityGraphMarking'),
-    bounds: { x: 0, y: 0, width: 200, height: 100 },
+    bounds: { x: 0, y: 0, width: 160, height: 100 },
   });
 
   elements.push(umlReachabilityGraphMarking);

--- a/src/main/services/uml-element/uml-element.ts
+++ b/src/main/services/uml-element/uml-element.ts
@@ -82,7 +82,7 @@ export abstract class UMLElement implements IUMLElement, ILayoutable {
   id = uuid();
   name = '';
   abstract type: UMLElementType | UMLRelationshipType | UMLDiagramType;
-  bounds = { x: 0, y: 0, width: 200, height: 100 };
+  bounds = { x: 0, y: 0, width: 160, height: 100 };
   owner = null as string | null;
   highlight?: string;
   fillColor?: string;

--- a/src/tests/unit/components/uml-element/assessable/__snapshots__/assessable-test.tsx.snap
+++ b/src/tests/unit/components/uml-element/assessable/__snapshots__/assessable-test.tsx.snap
@@ -6,7 +6,7 @@ exports[`test assessable HOC display negative score 1`] = `
     <svg>
       <g
         pointer-events="none"
-        transform="translate(200 0)"
+        transform="translate(160 0)"
       >
         <circle
           class="sc-kpDqfm"
@@ -42,7 +42,7 @@ exports[`test assessable HOC display neutral score 1`] = `
     <svg>
       <g
         pointer-events="none"
-        transform="translate(200 0)"
+        transform="translate(160 0)"
       >
         <circle
           class="sc-kpDqfm"
@@ -78,7 +78,7 @@ exports[`test assessable HOC display positive score 1`] = `
     <svg>
       <g
         pointer-events="none"
-        transform="translate(200 0)"
+        transform="translate(160 0)"
       >
         <circle
           class="sc-kpDqfm"

--- a/src/tests/unit/packages/bpmn/bpmn-annotation/__snapshots__/bpmn-annotation-component-test.tsx.snap
+++ b/src/tests/unit/packages/bpmn/bpmn-annotation/__snapshots__/bpmn-annotation-component-test.tsx.snap
@@ -12,7 +12,7 @@ exports[`render the bpmn-annotation-component 1`] = `
           rx="10"
           ry="10"
           stroke="transparent"
-          width="200"
+          width="160"
         />
         <path
           class="sc-gEvEer JpXgg"
@@ -25,13 +25,13 @@ exports[`render the bpmn-annotation-component 1`] = `
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             Annotation
           </tspan>

--- a/src/tests/unit/packages/bpmn/bpmn-call-activity/__snapshots__/bpmn-call-activity-component-test.tsx.snap
+++ b/src/tests/unit/packages/bpmn/bpmn-call-activity/__snapshots__/bpmn-call-activity-component-test.tsx.snap
@@ -13,20 +13,20 @@ exports[`render the bpmn-call-activity-component 1`] = `
           ry="10"
           stroke="black"
           stroke-width="3"
-          width="200"
+          width="160"
         />
         <text
           font-weight="bold"
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             Call Activity
           </tspan>

--- a/src/tests/unit/packages/bpmn/bpmn-data-object/__snapshots__/bpmn-data-object-test.tsx.snap
+++ b/src/tests/unit/packages/bpmn/bpmn-data-object/__snapshots__/bpmn-data-object-test.tsx.snap
@@ -8,19 +8,19 @@ exports[`render the bpmn-data-object-component 1`] = `
         <polyline
           class="sc-aXZVg bUvEJV"
           fill="white"
-          points="0 0, 0 100, 200 100, 200 15, 185 0, 185 15, 200 15, 185 0, 0 0"
+          points="0 0, 0 100, 160 100, 160 15, 145 0, 145 15, 160 15, 145 0, 0 0"
           stroke="black"
         />
         <text
           pointer-events="none"
           text-anchor="middle"
-          width="400"
-          x="100"
+          width="320"
+          x="80"
           y="120"
         >
           <tspan
             dy="11"
-            x="100"
+            x="80"
           >
             Data Object
           </tspan>

--- a/src/tests/unit/packages/bpmn/bpmn-data-store/__snapshots__/bpmn-data-object-test.tsx.snap
+++ b/src/tests/unit/packages/bpmn/bpmn-data-store/__snapshots__/bpmn-data-object-test.tsx.snap
@@ -7,38 +7,38 @@ exports[`render the bpmn-data-store-component 1`] = `
       <g>
         <path
           class="sc-gEvEer fMgKSV"
-          d="M 0 10 L 0 90 A 100 10 0 0 0 200 90 L 200 10 A 100 10 180 0 0 0 10"
+          d="M 0 10 L 0 90 A 80 10 0 0 0 160 90 L 160 10 A 80 10 180 0 0 0 10"
           fill="white"
           stroke="black"
         />
         <path
           class="sc-gEvEer JpXgg"
-          d="M 0 30 A 100 10 0 0 0 200 30"
+          d="M 0 30 A 80 10 0 0 0 160 30"
           fill="transparent"
           stroke="black"
         />
         <path
           class="sc-gEvEer JpXgg"
-          d="M 0 20 A 100 10 0 0 0 200 20"
+          d="M 0 20 A 80 10 0 0 0 160 20"
           fill="transparent"
           stroke="black"
         />
         <path
           class="sc-gEvEer JpXgg"
-          d="M 0 10 A 100 10 0 0 0 200 10"
+          d="M 0 10 A 80 10 0 0 0 160 10"
           fill="transparent"
           stroke="black"
         />
         <text
           pointer-events="none"
           text-anchor="middle"
-          width="400"
-          x="100"
+          width="320"
+          x="80"
           y="120"
         >
           <tspan
             dy="11"
-            x="100"
+            x="80"
           >
             Data Store
           </tspan>

--- a/src/tests/unit/packages/bpmn/bpmn-group/__snapshots__/bpmn-group-component-test.tsx.snap
+++ b/src/tests/unit/packages/bpmn/bpmn-group/__snapshots__/bpmn-group-component-test.tsx.snap
@@ -20,13 +20,13 @@ exports[`render the bpmn-group-component 1`] = `
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             Group
           </tspan>

--- a/src/tests/unit/packages/bpmn/bpmn-pool/__snapshots__/bpmn-transaction-component-test.tsx.snap
+++ b/src/tests/unit/packages/bpmn/bpmn-pool/__snapshots__/bpmn-transaction-component-test.tsx.snap
@@ -18,7 +18,7 @@ exports[`render the bpmn-pool-component 1`] = `
           fill="white"
           height="100"
           stroke="black"
-          width="160"
+          width="120"
           x="40"
           y="0"
         />

--- a/src/tests/unit/packages/bpmn/bpmn-subprocess/__snapshots__/bpmn-subprocess-component-test.tsx.snap
+++ b/src/tests/unit/packages/bpmn/bpmn-subprocess/__snapshots__/bpmn-subprocess-component-test.tsx.snap
@@ -20,13 +20,13 @@ exports[`render the bpmn-subprocess-component 1`] = `
           height="14"
           stroke="black"
           width="14"
-          x="93"
+          x="73"
           y="86"
         />
         <polyline
           class="sc-aXZVg bUvEJV"
           fill="white"
-          points="96 93, 104 93"
+          points="76 93, 84 93"
           stroke="black"
           stroke-linecap="round"
           stroke-linejoin="round"
@@ -34,7 +34,7 @@ exports[`render the bpmn-subprocess-component 1`] = `
         <polyline
           class="sc-aXZVg bUvEJV"
           fill="white"
-          points="100 89, 100 97"
+          points="80 89, 80 97"
           stroke="black"
           stroke-linecap="round"
           stroke-linejoin="round"
@@ -44,13 +44,13 @@ exports[`render the bpmn-subprocess-component 1`] = `
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             SyntaxTreeTerminal
           </tspan>

--- a/src/tests/unit/packages/bpmn/bpmn-swimlane/__snapshots__/bpmn-swimlane-component-test.tsx.snap
+++ b/src/tests/unit/packages/bpmn/bpmn-swimlane/__snapshots__/bpmn-swimlane-component-test.tsx.snap
@@ -10,7 +10,7 @@ exports[`render the bpmn-swimlane-component 1`] = `
           fill="white"
           height="100"
           stroke="black"
-          width="200"
+          width="160"
         />
         <text
           alignment-baseline="middle"

--- a/src/tests/unit/packages/bpmn/bpmn-task/__snapshots__/bpmn-task-component-test.tsx.snap
+++ b/src/tests/unit/packages/bpmn/bpmn-task/__snapshots__/bpmn-task-component-test.tsx.snap
@@ -19,13 +19,13 @@ exports[`render the bpmn-task-component 1`] = `
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             Task
           </tspan>

--- a/src/tests/unit/packages/bpmn/bpmn-transaction/__snapshots__/bpmn-transaction-component-test.tsx.snap
+++ b/src/tests/unit/packages/bpmn/bpmn-transaction/__snapshots__/bpmn-transaction-component-test.tsx.snap
@@ -12,7 +12,7 @@ exports[`render the bpmn-transaction-component 1`] = `
           rx="10"
           ry="10"
           stroke="black"
-          width="200"
+          width="160"
         />
         <rect
           class="sc-fqkvVR kprGcp"
@@ -21,7 +21,7 @@ exports[`render the bpmn-transaction-component 1`] = `
           rx="7"
           ry="7"
           stroke="black"
-          width="194"
+          width="154"
           x="3"
           y="3"
         />
@@ -30,13 +30,13 @@ exports[`render the bpmn-transaction-component 1`] = `
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             Transaction
           </tspan>

--- a/src/tests/unit/packages/flowchart/flowchart-decision/__snapshots__/flowchart-decision-component-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-decision/__snapshots__/flowchart-decision-component-test.tsx.snap
@@ -8,7 +8,7 @@ exports[`render the flowchart-decision-component 1`] = `
         <polyline
           class="sc-aXZVg bUvEJV"
           fill="white"
-          points="100 0, 200 50, 100 100, 0 50, 100 0"
+          points="80 0, 160 50, 80 100, 0 50, 80 0"
           stroke="black"
         />
         <text
@@ -16,13 +16,13 @@ exports[`render the flowchart-decision-component 1`] = `
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             TestDecisionComponent
           </tspan>

--- a/src/tests/unit/packages/flowchart/flowchart-function-call/__snapshots__/flowchart-function-call-component-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-function-call/__snapshots__/flowchart-function-call-component-test.tsx.snap
@@ -18,7 +18,7 @@ exports[`render the flowchart-function-call-component 1`] = `
           fill="white"
           height="100%"
           stroke="black"
-          width="180"
+          width="140"
           x="10"
         />
         <rect
@@ -27,20 +27,20 @@ exports[`render the flowchart-function-call-component 1`] = `
           height="100%"
           stroke="black"
           width="10"
-          x="190"
+          x="150"
         />
         <text
           font-weight="bold"
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             TestFunctionCallComponent
           </tspan>

--- a/src/tests/unit/packages/flowchart/flowchart-input-output/__snapshots__/flowchart-input-output-component-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-input-output/__snapshots__/flowchart-input-output-component-test.tsx.snap
@@ -8,7 +8,7 @@ exports[`render the flowchart-input-output-component 1`] = `
         <polyline
           class="sc-aXZVg bUvEJV"
           fill="white"
-          points="220 0, 180 100, -20 100, 20 0, 220 0"
+          points="180 0, 140 100, -20 100, 20 0, 180 0"
           stroke="black"
         />
         <text
@@ -16,13 +16,13 @@ exports[`render the flowchart-input-output-component 1`] = `
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             TestInputOutputComponent
           </tspan>

--- a/src/tests/unit/packages/flowchart/flowchart-process/__snapshots__/flowchart-process-component-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-process/__snapshots__/flowchart-process-component-test.tsx.snap
@@ -17,13 +17,13 @@ exports[`render the flowchart-process-component 1`] = `
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             TestProcessComponent
           </tspan>

--- a/src/tests/unit/packages/flowchart/flowchart-terminal/__snapshots__/flowchart-terminal-component-test.tsx.snap
+++ b/src/tests/unit/packages/flowchart/flowchart-terminal/__snapshots__/flowchart-terminal-component-test.tsx.snap
@@ -19,13 +19,13 @@ exports[`render the flowchart-terminal-component 1`] = `
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             TestTerminalComponent
           </tspan>

--- a/src/tests/unit/packages/syntax-tree/syntax-tree-nonterminal/__snapshots__/nonterminal-component-test.tsx.snap
+++ b/src/tests/unit/packages/syntax-tree/syntax-tree-nonterminal/__snapshots__/nonterminal-component-test.tsx.snap
@@ -19,13 +19,13 @@ exports[`render the syntax-tree-nonterminal-component 1`] = `
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             TestActivityComponent
           </tspan>

--- a/src/tests/unit/packages/syntax-tree/syntax-tree-terminal/__snapshots__/terminal-component-test.tsx.snap
+++ b/src/tests/unit/packages/syntax-tree/syntax-tree-terminal/__snapshots__/terminal-component-test.tsx.snap
@@ -17,13 +17,13 @@ exports[`render the syntax-tree-terminal-component 1`] = `
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             SyntaxTreeTerminal
           </tspan>

--- a/src/tests/unit/packages/uml-activity-diagram/uml-activity-merge-node/__snapshots__/uml-activity-merge-node-component-test.tsx.snap
+++ b/src/tests/unit/packages/uml-activity-diagram/uml-activity-merge-node/__snapshots__/uml-activity-merge-node-component-test.tsx.snap
@@ -8,7 +8,7 @@ exports[`render the uml-activity-merge-node-component 1`] = `
         <polyline
           class="sc-aXZVg bUvEJV"
           fill="white"
-          points="100 0, 200 50, 100 100, 0 50, 100 0"
+          points="80 0, 160 50, 80 100, 0 50, 80 0"
           stroke="black"
         />
         <text
@@ -16,13 +16,13 @@ exports[`render the uml-activity-merge-node-component 1`] = `
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             TestActivityComponent
           </tspan>

--- a/src/tests/unit/packages/uml-activity-diagram/uml-activity-object-node/__snapshots__/uml-activity-object-node-component-test.tsx.snap
+++ b/src/tests/unit/packages/uml-activity-diagram/uml-activity-object-node/__snapshots__/uml-activity-object-node-component-test.tsx.snap
@@ -17,13 +17,13 @@ exports[`test render the uml-activity-object-node-component 1`] = `
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         >
           <tspan
             dy="5.5"
-            x="100"
+            x="80"
           >
             TestActivityComponent
           </tspan>

--- a/src/tests/unit/packages/uml-component-diagram/uml-component/__snapshots__/uml-component-component-test.tsx.snap
+++ b/src/tests/unit/packages/uml-component-diagram/uml-component/__snapshots__/uml-component-component-test.tsx.snap
@@ -15,7 +15,7 @@ exports[`render the uml-component-component 1`] = `
           width="100%"
         />
         <g
-          transform="translate(169, 7)"
+          transform="translate(129, 7)"
         >
           <path
             class="sc-gEvEer fMgKSV"

--- a/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-artifact/__snapshots__/uml-deployment-artifact-component-test.tsx.snap
+++ b/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-artifact/__snapshots__/uml-deployment-artifact-component-test.tsx.snap
@@ -23,7 +23,7 @@ exports[`render the uml-deplyoment-artifact-component 1`] = `
           TestDeploymentComponent
         </text>
         <g
-          transform="translate(174, 7)"
+          transform="translate(134, 7)"
         >
           <path
             class="sc-gEvEer fMgKSV"

--- a/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-node/__snapshots__/uml-deployment-node-component-test.tsx.snap
+++ b/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-node/__snapshots__/uml-deployment-node-component-test.tsx.snap
@@ -8,13 +8,13 @@ exports[`render the uml-deployment-node-component 1`] = `
         <g>
           <path
             class="sc-gEvEer fMgKSV"
-            d="M 0 8 l 8 -8 H 200 l -8 8 Z"
+            d="M 0 8 l 8 -8 H 160 l -8 8 Z"
             fill="white"
             stroke="black"
           />
           <path
             class="sc-gEvEer fMgKSV"
-            d="M 200 0 V 92 l -8 8 V 8 Z"
+            d="M 160 0 V 92 l -8 8 V 8 Z"
             fill="white"
             stroke="black"
           />
@@ -23,7 +23,7 @@ exports[`render the uml-deployment-node-component 1`] = `
             fill="white"
             height="91"
             stroke="black"
-            width="192"
+            width="152"
             x="0"
             y="8"
           />

--- a/src/tests/unit/packages/uml-reachability-graph/uml-reachability-graph-marking/__snapshots__/uml-reachability-graph-marking-component-test.tsx.snap
+++ b/src/tests/unit/packages/uml-reachability-graph/uml-reachability-graph-marking/__snapshots__/uml-reachability-graph-marking-component-test.tsx.snap
@@ -19,8 +19,8 @@ exports[`uml-reachability-graph-marking-component render the uml-reachability-gr
           height="100"
           pointer-events="none"
           text-anchor="middle"
-          width="200"
-          x="100"
+          width="160"
+          x="80"
           y="50"
         />
       </g>


### PR DESCRIPTION
This pull request reduces the width of Apollon's element sidebar to allow for more diagram editing space.

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
This change was made to occupy less space with Apollon's element sidebar especially when the editor is integrated into the Artemis Learning Management System.

### Description
The elements in the element sidebar are scaled by a factor of 0.8 via CSS transform. This scaling matches the default zoom level used by the editors element canvas. 

### Steps for Testing


### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see package.json). -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| File | Branch | Line |
|------|-------:|-----:|
<!--
| uml-activity-fork-node-component.ts | 85% | 77% |
| uml-activity-action-node-component.ts | 13% | 95% |
-->
### Screenshots
**Prior sidebar size:**

<img width="333" alt="Screenshot 2024-04-10 at 23 22 27" src="https://github.com/ls1intum/Apollon/assets/143808484/da4f35ba-d713-4dd4-ac90-79b612d13020"><img width="289" alt="Screenshot 2024-04-10 at 23 22 16" src="https://github.com/ls1intum/Apollon/assets/143808484/afc27439-6be9-49db-9955-71ea91340e9e">


**Reduced sidebar size:**
<img width="180" alt="Screenshot 2024-04-11 at 09 04 56" src="https://github.com/ls1intum/Apollon/assets/143808484/eb24f1a5-5aa6-4eb4-8db0-0022fecd9b7b"><img width="205" alt="Screenshot 2024-04-11 at 09 04 45" src="https://github.com/ls1intum/Apollon/assets/143808484/a7701597-62f1-4fa7-b553-a5d2c93e24c5">


