### PR TITLE
Fix SVG id collisions by using random UUIDs instead of element ID

### DIFF
--- a/src/main/packages/bpmn/bpmn-flow/bpmn-flow-component.tsx
+++ b/src/main/packages/bpmn/bpmn-flow/bpmn-flow-component.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, SVGProps } from 'react';
 import { Point } from '../../../utils/geometry/point';
 import { BPMNFlow } from './bpmn-flow';
 import { ThemedCircle, ThemedPath, ThemedPolyline } from '../../../components/theme/themedComponents';
+import { uuid } from '../../../utils/uuid';
 
 export const BPMNFlowComponent: FunctionComponent<Props> = ({ element }) => {
   let position = { x: 0, y: 0 };
@@ -45,11 +46,12 @@ export const BPMNFlowComponent: FunctionComponent<Props> = ({ element }) => {
     }
   };
 
+  const id = uuid();
   return (
     <g>
       {element.flowType === 'message' && (
         <marker
-          id={`marker-start-${element.id}`}
+          id={`marker-start-${id}`}
           viewBox={`0 0 ${10} ${10}`}
           markerWidth={10}
           markerHeight={10}
@@ -63,7 +65,7 @@ export const BPMNFlowComponent: FunctionComponent<Props> = ({ element }) => {
       )}
       {(element.flowType === 'sequence' || element.flowType === 'message') && (
         <marker
-          id={`marker-end-${element.id}`}
+          id={`marker-end-${id}`}
           viewBox={`0 0 ${10} ${5}`}
           markerWidth={10}
           markerHeight={10}
@@ -82,7 +84,7 @@ export const BPMNFlowComponent: FunctionComponent<Props> = ({ element }) => {
       )}
       {element.flowType === 'data association' && (
         <marker
-          id={`marker-end-${element.id}`}
+          id={`marker-end-${id}`}
           viewBox={`0 0 ${10} ${5}`}
           markerWidth={10}
           markerHeight={10}
@@ -105,8 +107,8 @@ export const BPMNFlowComponent: FunctionComponent<Props> = ({ element }) => {
         strokeColor={element.strokeColor}
         fillColor="none"
         strokeWidth={1}
-        markerStart={element.flowType === 'message' ? `url(#marker-start-${element.id})` : undefined}
-        markerEnd={element.flowType !== 'association' ? `url(#marker-end-${element.id})` : undefined}
+        markerStart={element.flowType === 'message' ? `url(#marker-start-${id})` : undefined}
+        markerEnd={element.flowType !== 'association' ? `url(#marker-end-${id})` : undefined}
         strokeDasharray={element.flowType !== 'sequence' ? 4 : undefined}
       />
       <text

--- a/src/main/packages/common/uml-association/uml-association-component.tsx
+++ b/src/main/packages/common/uml-association/uml-association-component.tsx
@@ -5,6 +5,7 @@ import { ClassRelationshipType } from '../../uml-class-diagram';
 import { UMLAssociation } from './uml-association';
 import { UMLRelationshipType } from '../../uml-relationship-type';
 import { ThemedPath, ThemedPathContrast, ThemedPolyline } from '../../../components/theme/themedComponents';
+import { uuid } from '../../../utils/uuid';
 
 const Marker = {
   Arrow: (id: string, color?: string) => (
@@ -137,7 +138,7 @@ export const UMLAssociationComponent: FunctionComponent<Props> = ({ element }) =
   const path = element.path.map((point) => new Point(point.x, point.y));
   const source: Point = computeTextPositionForUMLAssociation(path);
   const target: Point = computeTextPositionForUMLAssociation(path.reverse(), !!marker);
-  const id = `marker-${element.id}`;
+  const id = `marker-${uuid()}`;
 
   const textFill = element.textColor ? { fill: element.textColor } : {};
   return (

--- a/src/main/packages/common/uml-dependency/uml-dependency-component.tsx
+++ b/src/main/packages/common/uml-dependency/uml-dependency-component.tsx
@@ -1,31 +1,35 @@
 import React, { FunctionComponent } from 'react';
 import { UMLDependency } from './uml-component-dependency';
 import { ThemedPath, ThemedPolyline } from '../../../components/theme/themedComponents';
+import { uuid } from '../../../utils/uuid';
 
-export const UMLDependencyComponent: FunctionComponent<Props> = ({ element }) => (
-  <g>
-    <marker
-      id={`marker-${element.id}`}
-      viewBox="0 0 30 30"
-      markerWidth="22"
-      markerHeight="30"
-      refX="30"
-      refY="15"
-      orient="auto"
-      markerUnits="strokeWidth"
-    >
-      <ThemedPath d="M0,29 L30,15 L0,1" fillColor="none" strokeColor={element.strokeColor} />
-    </marker>
-    <ThemedPolyline
-      points={element.path.map((point) => `${point.x} ${point.y}`).join(',')}
-      strokeColor={element.strokeColor}
-      fillColor="none"
-      strokeWidth={1}
-      strokeDasharray={7}
-      markerEnd={`url(#marker-${element.id})`}
-    />
-  </g>
-);
+export const UMLDependencyComponent: FunctionComponent<Props> = ({ element }) => {
+  const id = uuid();
+  return (
+    <g>
+      <marker
+        id={`marker-${id}`}
+        viewBox="0 0 30 30"
+        markerWidth="22"
+        markerHeight="30"
+        refX="30"
+        refY="15"
+        orient="auto"
+        markerUnits="strokeWidth"
+      >
+        <ThemedPath d="M0,29 L30,15 L0,1" fillColor="none" strokeColor={element.strokeColor} />
+      </marker>
+      <ThemedPolyline
+        points={element.path.map((point) => `${point.x} ${point.y}`).join(',')}
+        strokeColor={element.strokeColor}
+        fillColor="none"
+        strokeWidth={1}
+        strokeDasharray={7}
+        markerEnd={`url(#marker-${id})`}
+      />
+    </g>
+  );
+};
 
 interface Props {
   element: UMLDependency;

--- a/src/main/packages/common/uml-interface-required/uml-interface-required-component.tsx
+++ b/src/main/packages/common/uml-interface-required/uml-interface-required-component.tsx
@@ -6,6 +6,7 @@ import { Direction, getOppositeDirection } from '../../../services/uml-element/u
 import { Point } from '../../../utils/geometry/point';
 import { REQUIRED_INTERFACE_MARKER_SIZE, REQUIRED_INTERFACE_MARKER_TYPE } from './uml-interface-requires-constants';
 import { ThemedPath, ThemedPolyline } from '../../../components/theme/themedComponents';
+import { uuid } from '../../../utils/uuid';
 
 type OwnProps = {
   element: UMLInterfaceRequired;
@@ -89,10 +90,11 @@ const UMLInterfaceRequiredC: FunctionComponent<Props> = (props: Props) => {
     return path;
   };
 
+  const id = uuid();
   return (
     <g>
       <marker
-        id={`marker-${element.id}`}
+        id={`marker-${id}`}
         viewBox={`0 0 ${REQUIRED_INTERFACE_MARKER_SIZE} ${REQUIRED_INTERFACE_MARKER_SIZE}`}
         markerWidth={REQUIRED_INTERFACE_MARKER_SIZE}
         markerHeight={REQUIRED_INTERFACE_MARKER_SIZE}
@@ -116,7 +118,7 @@ const UMLInterfaceRequiredC: FunctionComponent<Props> = (props: Props) => {
         strokeColor={element.strokeColor}
         fillColor="none"
         strokeWidth={1.0}
-        markerEnd={`url(#marker-${element.id})`}
+        markerEnd={`url(#marker-${id})`}
       />
     </g>
   );

--- a/src/main/packages/flowchart/flowchart-flowline/flowchart-flowline-component.tsx
+++ b/src/main/packages/flowchart/flowchart-flowline/flowchart-flowline-component.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react';
 import { Point } from '../../../utils/geometry/point';
 import { FlowchartFlowline } from './flowchart-flowline';
 import { ThemedPath, ThemedPolyline } from '../../../components/theme/themedComponents';
+import { uuid } from '../../../utils/uuid';
 
 export const FlowchartFlowlineComponent: FunctionComponent<Props> = ({ element }) => {
   let position = { x: 0, y: 0 };
@@ -42,10 +43,11 @@ export const FlowchartFlowlineComponent: FunctionComponent<Props> = ({ element }
   };
   const fill = element.textColor ? { fill: element.textColor } : {};
 
+  const id = uuid();
   return (
     <g>
       <marker
-        id={`marker-${element.id}`}
+        id={`marker-${id}`}
         viewBox="0 0 30 30"
         markerWidth="22"
         markerHeight="30"
@@ -61,7 +63,7 @@ export const FlowchartFlowlineComponent: FunctionComponent<Props> = ({ element }
         strokeColor={element.strokeColor}
         fillColor="none"
         strokeWidth={1}
-        markerEnd={`url(#marker-${element.id})`}
+        markerEnd={`url(#marker-${id})`}
       />
       <text x={position.x} y={position.y} {...layoutText(direction)} pointerEvents="none" style={{ ...fill }}>
         {element.name}

--- a/src/main/packages/uml-activity-diagram/uml-activity-control-flow/uml-activity-control-flow-component.tsx
+++ b/src/main/packages/uml-activity-diagram/uml-activity-control-flow/uml-activity-control-flow-component.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react';
 import { Point } from '../../../utils/geometry/point';
 import { UMLActivityControlFlow } from './uml-activity-control-flow';
 import { ThemedPath, ThemedPolyline } from '../../../components/theme/themedComponents';
+import { uuid } from '../../../utils/uuid';
 
 export const UMLActivityControlFlowComponent: FunctionComponent<Props> = ({ element }) => {
   let position = { x: 0, y: 0 };
@@ -43,10 +44,11 @@ export const UMLActivityControlFlowComponent: FunctionComponent<Props> = ({ elem
 
   const fill = element.textColor ? { fill: element.textColor } : {};
 
+  const id = uuid();
   return (
     <g>
       <marker
-        id={`marker-${element.id}`}
+        id={`marker-${id}`}
         viewBox="0 0 30 30"
         markerWidth="22"
         markerHeight="30"
@@ -62,7 +64,7 @@ export const UMLActivityControlFlowComponent: FunctionComponent<Props> = ({ elem
         strokeColor={element.strokeColor}
         fillColor="none"
         strokeWidth={1}
-        markerEnd={`url(#marker-${element.id})`}
+        markerEnd={`url(#marker-${id})`}
       />
       <text x={position.x} y={position.y} {...layoutText(direction)} pointerEvents="none" style={{ ...fill }}>
         {element.name}

--- a/src/main/packages/uml-petri-net/uml-petri-net-arc/uml-petri-net-arc-component.tsx
+++ b/src/main/packages/uml-petri-net/uml-petri-net-arc/uml-petri-net-arc-component.tsx
@@ -3,6 +3,7 @@ import { Text } from '../../../components/controls/text/text';
 import { Point } from '../../../utils/geometry/point';
 import { UMLPetriNetArc } from './uml-petri-net-arc';
 import { ThemedPathContrast, ThemedPolyline } from '../../../components/theme/themedComponents';
+import { uuid } from '../../../utils/uuid';
 
 export const UMLPetriNetArcComponent: FunctionComponent<Props> = ({ element }) => {
   const [start, end] = element.path.map((p) => new Point(p.x, p.y));
@@ -12,10 +13,11 @@ export const UMLPetriNetArcComponent: FunctionComponent<Props> = ({ element }) =
 
   const displayMultiplicity = element.name !== UMLPetriNetArc.defaultMultiplicity;
 
+  const id = uuid();
   return (
     <g>
       <marker
-        id={`marker-${element.id}`}
+        id={`marker-${id}`}
         viewBox="0 0 30 30"
         markerWidth="22"
         markerHeight="30"
@@ -27,7 +29,7 @@ export const UMLPetriNetArcComponent: FunctionComponent<Props> = ({ element }) =
         <ThemedPathContrast d="M0,1 L0,29 L30,15 z" fill={element.strokeColor} />
       </marker>
       <path
-        id={`textpath-${element.id}`}
+        id={`textpath-${id}`}
         d={`
         M ${start.x} ${start.y - 10}
         L ${end.x} ${end.y - 10}
@@ -49,7 +51,7 @@ export const UMLPetriNetArcComponent: FunctionComponent<Props> = ({ element }) =
               : undefined
           }
         >
-          <textPath xlinkHref={`#textpath-${element.id}`} startOffset="50%">
+          <textPath xlinkHref={`#textpath-${id}`} startOffset="50%">
             {element.name}
           </textPath>
         </Text>
@@ -59,7 +61,7 @@ export const UMLPetriNetArcComponent: FunctionComponent<Props> = ({ element }) =
         strokeColor={element.strokeColor}
         fillColor="none"
         strokeWidth={1}
-        markerEnd={`url(#marker-${element.id})`}
+        markerEnd={`url(#marker-${id})`}
       />
     </g>
   );

--- a/src/main/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-component.tsx
+++ b/src/main/packages/uml-reachability-graph/uml-reachability-graph-arc/uml-reachability-graph-arc-component.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react';
 import { Point } from '../../../utils/geometry/point';
 import { UMLReachabilityGraphArc } from './uml-reachability-graph-arc';
 import { ThemedPath, ThemedPolyline } from '../../../components/theme/themedComponents';
+import { uuid } from '../../../utils/uuid';
 
 export const UMLReachabilityGraphArcComponent: FunctionComponent<Props> = ({ element }) => {
   let position = { x: 0, y: 0 };
@@ -43,10 +44,11 @@ export const UMLReachabilityGraphArcComponent: FunctionComponent<Props> = ({ ele
 
   const textColor = element.textColor ? { fill: element.textColor } : {};
 
+  const id = uuid();
   return (
     <g>
       <marker
-        id={`marker-${element.id}`}
+        id={`marker-${id}`}
         viewBox={`0 0 ${30} ${30}`}
         markerWidth={22}
         markerHeight={30}
@@ -62,7 +64,7 @@ export const UMLReachabilityGraphArcComponent: FunctionComponent<Props> = ({ ele
         strokeColor={element.strokeColor}
         fillColor="none"
         strokeWidth={1}
-        markerEnd={`url(#marker-${element.id})`}
+        markerEnd={`url(#marker-${id})`}
       />
       <text x={position.x} y={position.y} {...layoutText(direction)} pointerEvents="none" style={{ ...textColor }}>
         {element.name}

--- a/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-component.tsx
+++ b/src/main/packages/uml-reachability-graph/uml-reachability-graph-marking/uml-reachability-graph-marking-component.tsx
@@ -2,54 +2,58 @@ import React, { FunctionComponent } from 'react';
 import { UMLReachabilityGraphMarking } from './uml-reachability-graph-marking';
 import { Multiline } from '../../../utils/svg/multiline';
 import { ThemedPath, ThemedPolyline, ThemedRect } from '../../../components/theme/themedComponents';
+import { uuid } from '../../../utils/uuid';
 
-export const UMLReachabilityGraphMarkingComponent: FunctionComponent<Props> = ({ element, fillColor }) => (
-  <g>
-    <ThemedRect
-      rx={10}
-      ry={10}
-      width="100%"
-      height="100%"
-      strokeColor={element.strokeColor}
-      fillColor={fillColor || element.fillColor}
-    />
-    <Multiline
-      x={element.bounds.width / 2}
-      y={element.bounds.height / 2}
-      width={element.bounds.width}
-      height={element.bounds.height}
-      fontWeight="bold"
-      fill={element.textColor}
-      lineHeight={16}
-      capHeight={11}
-    >
-      {element.name}
-    </Multiline>
-    {element.isInitialMarking && (
-      <g>
-        <marker
-          id={`marker-${element.id}`}
-          viewBox={`0 0 ${30} ${30}`}
-          markerWidth={22}
-          markerHeight={30}
-          refX={30}
-          refY={15}
-          orient="auto"
-          markerUnits="strokeWidth"
-        >
-          <ThemedPath d={`M0,${29} L${30},${15} L0,${1}`} fillColor="none" strokeColor={element.strokeColor} />
-        </marker>
-        <ThemedPolyline
-          points={`-${50},-${50} ${3},${3}`}
-          strokeColor={element.strokeColor}
-          fillColor="none"
-          strokeWidth={1}
-          markerEnd={`url(#marker-${element.id})`}
-        />
-      </g>
-    )}
-  </g>
-);
+export const UMLReachabilityGraphMarkingComponent: FunctionComponent<Props> = ({ element, fillColor }) => {
+  const id = uuid();
+  return (
+    <g>
+      <ThemedRect
+        rx={10}
+        ry={10}
+        width="100%"
+        height="100%"
+        strokeColor={element.strokeColor}
+        fillColor={fillColor || element.fillColor}
+      />
+      <Multiline
+        x={element.bounds.width / 2}
+        y={element.bounds.height / 2}
+        width={element.bounds.width}
+        height={element.bounds.height}
+        fontWeight="bold"
+        fill={element.textColor}
+        lineHeight={16}
+        capHeight={11}
+      >
+        {element.name}
+      </Multiline>
+      {element.isInitialMarking && (
+        <g>
+          <marker
+            id={`marker-${id}`}
+            viewBox={`0 0 ${30} ${30}`}
+            markerWidth={22}
+            markerHeight={30}
+            refX={30}
+            refY={15}
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+            <ThemedPath d={`M0,${29} L${30},${15} L0,${1}`} fillColor="none" strokeColor={element.strokeColor} />
+          </marker>
+          <ThemedPolyline
+            points={`-${50},-${50} ${3},${3}`}
+            strokeColor={element.strokeColor}
+            fillColor="none"
+            strokeWidth={1}
+            markerEnd={`url(#marker-${id})`}
+          />
+        </g>
+      )}
+    </g>
+  );
+};
 
 interface Props {
   element: UMLReachabilityGraphMarking;

--- a/src/main/packages/uml-use-case-diagram/uml-use-case-extend/uml-use-case-extend-component.tsx
+++ b/src/main/packages/uml-use-case-diagram/uml-use-case-extend/uml-use-case-extend-component.tsx
@@ -3,49 +3,54 @@ import { Text } from '../../../components/controls/text/text';
 import { Point } from '../../../utils/geometry/point';
 import { UMLUseCaseExtend } from './uml-use-case-extend';
 import { ThemedPath } from '../../../components/theme/themedComponents';
+import { uuid } from '../../../utils/uuid';
 
-const Arrow: FunctionComponent<{ id: string; color?: string; d: string }> = ({ id, color, d }) => (
-  <g>
-    <marker
-      id={`marker-${id}`}
-      viewBox="0 0 30 30"
-      markerWidth="22"
-      markerHeight="30"
-      refX="30"
-      refY="15"
-      orient="auto"
-      markerUnits="strokeWidth"
-    >
-      <ThemedPath d="M0,29 L30,15 L0,1" fillColor="none" strokeColor={color} />
-    </marker>
-    <ThemedPath d={d} strokeDasharray={7} markerEnd={`url(#marker-${id})`} strokeColor={color} />
-  </g>
-);
+const Arrow: FunctionComponent<{ color?: string; d: string }> = ({ color, d }) => {
+  const id = uuid();
+  return (
+    <g>
+      <marker
+        id={`marker-${id}`}
+        viewBox="0 0 30 30"
+        markerWidth="22"
+        markerHeight="30"
+        refX="30"
+        refY="15"
+        orient="auto"
+        markerUnits="strokeWidth"
+      >
+        <ThemedPath d="M0,29 L30,15 L0,1" fillColor="none" strokeColor={color} />
+      </marker>
+      <ThemedPath d={d} strokeDasharray={7} markerEnd={`url(#marker-${id})`} strokeColor={color} />
+    </g>
+  );
+};
 
 export const UMLUseCaseExtendComponent: FunctionComponent<Props> = ({ element }) => {
   const [start, end] = element.path.map((p) => new Point(p.x, p.y));
   const line = end.subtract(start);
 
   if (line.length <= 100) {
-    return <Arrow id={element.id} color={element.strokeColor} d={`M ${start.x} ${start.y} L ${end.x} ${end.y}`} />;
+    return <Arrow color={element.strokeColor} d={`M ${start.x} ${start.y} L ${end.x} ${end.y}`} />;
   }
 
   const norm = line.normalize();
   const center = start.add(norm.scale(0.5 * line.length));
   const startSection = start.add(norm.scale(0.5 * line.length - 40));
   const endSection = end.subtract(norm.scale(0.5 * line.length - 40));
+
+  const id = uuid();
   return (
     <g>
       <Arrow
         color={element.strokeColor}
-        id={element.id}
         d={`
           M ${start.x} ${start.y} L ${startSection.x} ${startSection.y}
           M ${endSection.x} ${endSection.y} L ${end.x} ${end.y}
         `}
       />
       <path
-        id={`textpath-${element.id}`}
+        id={`textpath-${id}`}
         d={`
           M ${startSection.x} ${startSection.y}
           L ${endSection.x} ${endSection.y}
@@ -65,7 +70,7 @@ export const UMLUseCaseExtendComponent: FunctionComponent<Props> = ({ element })
             : undefined
         }
       >
-        <textPath xlinkHref={`#textpath-${element.id}`} startOffset="50%">
+        <textPath xlinkHref={`#textpath-${id}`} startOffset="50%">
           «extend»
         </textPath>
       </Text>

--- a/src/main/packages/uml-use-case-diagram/uml-use-case-generalization/uml-use-case-generalization-component.tsx
+++ b/src/main/packages/uml-use-case-diagram/uml-use-case-generalization/uml-use-case-generalization-component.tsx
@@ -1,30 +1,34 @@
 import React, { FunctionComponent } from 'react';
 import { UMLUseCaseGeneralization } from './uml-use-case-generalization';
 import { ThemedPath, ThemedPolyline } from '../../../components/theme/themedComponents';
+import { uuid } from '../../../utils/uuid';
 
-export const UMLUseCaseGeneralizationComponent: FunctionComponent<Props> = ({ element }) => (
-  <g>
-    <marker
-      id={`marker-${element.id}`}
-      viewBox="0 0 30 30"
-      markerWidth="22"
-      markerHeight="30"
-      refX="30"
-      refY="15"
-      orient="auto"
-      markerUnits="strokeWidth"
-    >
-      <ThemedPath d="M0,1 L0,29 L30,15 z" strokeColor={element.strokeColor} />
-    </marker>
-    <ThemedPolyline
-      points={element.path.map((point) => `${point.x} ${point.y}`).join(',')}
-      strokeColor={element.strokeColor}
-      fillColor="none"
-      strokeWidth={1}
-      markerEnd={`url(#marker-${element.id})`}
-    />
-  </g>
-);
+export const UMLUseCaseGeneralizationComponent: FunctionComponent<Props> = ({ element }) => {
+  const id = uuid();
+  return (
+    <g>
+      <marker
+        id={`marker-${id}`}
+        viewBox="0 0 30 30"
+        markerWidth="22"
+        markerHeight="30"
+        refX="30"
+        refY="15"
+        orient="auto"
+        markerUnits="strokeWidth"
+      >
+        <ThemedPath d="M0,1 L0,29 L30,15 z" strokeColor={element.strokeColor} />
+      </marker>
+      <ThemedPolyline
+        points={element.path.map((point) => `${point.x} ${point.y}`).join(',')}
+        strokeColor={element.strokeColor}
+        fillColor="none"
+        strokeWidth={1}
+        markerEnd={`url(#marker-${id})`}
+      />
+    </g>
+  );
+};
 
 interface Props {
   element: UMLUseCaseGeneralization;

--- a/src/main/packages/uml-use-case-diagram/uml-use-case-include/uml-use-case-include-component.tsx
+++ b/src/main/packages/uml-use-case-diagram/uml-use-case-include/uml-use-case-include-component.tsx
@@ -3,41 +3,46 @@ import { Text } from '../../../components/controls/text/text';
 import { Point } from '../../../utils/geometry/point';
 import { UMLUseCaseInclude } from './uml-use-case-include';
 import { ThemedPath } from '../../../components/theme/themedComponents';
+import { uuid } from '../../../utils/uuid';
 
-const Arrow: FunctionComponent<{ id: string; color?: string; d: string }> = ({ id, color, d }) => (
-  <g>
-    <marker
-      id={`marker-${id}`}
-      viewBox="0 0 30 30"
-      markerWidth="22"
-      markerHeight="30"
-      refX="30"
-      refY="15"
-      orient="auto"
-      markerUnits="strokeWidth"
-    >
-      <ThemedPath d="M0,29 L30,15 L0,1" fillColor="none" strokeColor={color} />
-    </marker>
-    <ThemedPath d={d} strokeColor={color} strokeDasharray={7} markerEnd={`url(#marker-${id})`} />
-  </g>
-);
+const Arrow: FunctionComponent<{ color?: string; d: string }> = ({ color, d }) => {
+  const id = uuid();
+  return (
+    <g>
+      <marker
+        id={`marker-${id}`}
+        viewBox="0 0 30 30"
+        markerWidth="22"
+        markerHeight="30"
+        refX="30"
+        refY="15"
+        orient="auto"
+        markerUnits="strokeWidth"
+      >
+        <ThemedPath d="M0,29 L30,15 L0,1" fillColor="none" strokeColor={color} />
+      </marker>
+      <ThemedPath d={d} strokeColor={color} strokeDasharray={7} markerEnd={`url(#marker-${id})`} />
+    </g>
+  );
+};
 
 export const UMLUseCaseIncludeComponent: FunctionComponent<Props> = ({ element }) => {
   const [start, end] = element.path.map((p) => new Point(p.x, p.y));
   const line = end.subtract(start);
 
   if (line.length <= 100) {
-    return <Arrow id={element.id} color={element.strokeColor} d={`M ${start.x} ${start.y} L ${end.x} ${end.y}`} />;
+    return <Arrow color={element.strokeColor} d={`M ${start.x} ${start.y} L ${end.x} ${end.y}`} />;
   }
 
   const norm = line.normalize();
   const center = start.add(norm.scale(0.5 * line.length));
   const startSection = start.add(norm.scale(0.5 * line.length - 40));
   const endSection = end.subtract(norm.scale(0.5 * line.length - 40));
+
+  const id = uuid();
   return (
     <g>
       <Arrow
-        id={element.id}
         color={element.strokeColor}
         d={`
           M ${start.x} ${start.y} L ${startSection.x} ${startSection.y}
@@ -45,7 +50,7 @@ export const UMLUseCaseIncludeComponent: FunctionComponent<Props> = ({ element }
         `}
       />
       <path
-        id={`textpath-${element.id}`}
+        id={`textpath-${id}`}
         d={`
           M ${startSection.x} ${startSection.y}
           L ${endSection.x} ${endSection.y}
@@ -65,7 +70,7 @@ export const UMLUseCaseIncludeComponent: FunctionComponent<Props> = ({ element }
             : undefined
         }
       >
-        <textPath xlinkHref={`#textpath-${element.id}`} startOffset="50%">
+        <textPath xlinkHref={`#textpath-${id}`} startOffset="50%">
           «include»
         </textPath>
       </Text>


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I documented the TypeScript code using JSDoc style.
- [ ] ~~I added multiple screenshots/screencasts of my UI changes~~
- [ ] ~~I translated all the newly inserted strings into German and English~~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In [ls1intum/Artemis#8823](https://github.com/ls1intum/Artemis/issues/8823) some markers are missing from the solution diagram.

References for this issue:
https://stackoverflow.com/questions/37000385/multiple-svg-with-same-ids
https://stackoverflow.com/questions/54349169/svg-marker-disappears-when-svg-with-identical-definition-is-hidden

### Description
<!-- Describe your changes in detail -->

To prevent such id collisions on the same page in the future, I changed it to use a random UUID instead of the `element.id`.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Check if the `<marker>` elements have now a random uuid, by exporting multiple times.

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see package.json). -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| File | Branch | Line |
|------|-------:|-----:|
<!--
| uml-activity-fork-node-component.ts | 85% | 77% |
| uml-activity-action-node-component.ts | 13% | 95% |
-->
no change

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
no change