### PR TITLE
Fix  sidebar spacing issues

### DIFF
--- a/public/index.html.ejs
+++ b/public/index.html.ejs
@@ -86,7 +86,7 @@
       </section>
     </aside>
     <div class="apollon-container">
-    <main id="apollon"></main>
+      <main id="apollon"></main>
     </div>
   </div>
 </body>

--- a/src/main/components/create-pane/create-pane.tsx
+++ b/src/main/components/create-pane/create-pane.tsx
@@ -145,6 +145,7 @@ class CreatePaneComponent extends Component<Props, State> {
     };
 
     const { previews, utils } = this.state;
+
     const elements = [...previews, ...utils].reduce<UMLElementState>(
       (state, preview) => ({
         ...state,
@@ -155,7 +156,10 @@ class CreatePaneComponent extends Component<Props, State> {
 
     return (
       <StoreProvider initialState={{ elements, editor: { features } }}>
-        {this.getElementArray(previews)}
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8,  }}>
+          {this.getElementArray(previews)}
+        </div>
+
         {utils && utils.length > 0 ? (
           <>
             <Separator />

--- a/src/main/components/create-pane/create-pane.tsx
+++ b/src/main/components/create-pane/create-pane.tsx
@@ -156,7 +156,7 @@ class CreatePaneComponent extends Component<Props, State> {
 
     return (
       <StoreProvider initialState={{ elements, editor: { features } }}>
-        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8,  }}>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
           {this.getElementArray(previews)}
         </div>
 

--- a/src/main/components/create-pane/preview-element-component.tsx
+++ b/src/main/components/create-pane/preview-element-component.tsx
@@ -19,7 +19,7 @@ export const Preview = styled(hoverable(CanvasElement)).attrs((props: { scale?: 
   overflow: visible;
   fill: white;
   scale: ${(props) => props.scale ?? 0.8};
-  transform-origin: center center;
+  transform-origin: center;
 `;
 
 export class PreviewElementComponent extends Component<Props> {

--- a/src/main/packages/common/uml-interface/uml-interface-component.tsx
+++ b/src/main/packages/common/uml-interface/uml-interface-component.tsx
@@ -13,7 +13,7 @@ export const UMLInterfaceComponent: FunctionComponent<Props> = ({ element, fillC
       strokeWidth={2}
       fillColor={fillColor || element.fillColor}
     />
-    <Text noY x={'25px'} dominantBaseline="auto" textAnchor="start" fill={element.textColor}>
+    <Text x={25} noY dominantBaseline="auto" textAnchor="start" fill={element.textColor}>
       {element.name}
     </Text>
   </g>

--- a/src/main/packages/uml-component-diagram/component-preview.ts
+++ b/src/main/packages/uml-component-diagram/component-preview.ts
@@ -1,6 +1,6 @@
 import { ILayer } from '../../services/layouter/layer';
 import { UMLElement } from '../../services/uml-element/uml-element';
-import { ComposePreview } from '../compose-preview';
+import { ComposePreview, PreviewElement } from '../compose-preview';
 import { UMLComponentInterface } from './uml-component-interface/uml-component-interface';
 import { UMLComponentComponent } from './uml-component/uml-component-component';
 import { UMLSubsystem } from './uml-component-subsystem/uml-component-subsystem';
@@ -8,8 +8,8 @@ import { UMLSubsystem } from './uml-component-subsystem/uml-component-subsystem'
 export const composeComponentPreview: ComposePreview = (
   layer: ILayer,
   translate: (id: string) => string,
-): UMLElement[] => {
-  const elements: UMLElement[] = [];
+): PreviewElement[] => {
+  const elements: PreviewElement[] = [];
 
   // UML Component
   const umlComponent = new UMLComponentComponent({ name: translate('packages.ComponentDiagram.Component') });
@@ -38,7 +38,8 @@ export const composeComponentPreview: ComposePreview = (
     width: umlComponentInterface.bounds.width,
     height: umlComponentInterface.bounds.height,
   };
-  const [umlInterface] = umlComponentInterface.render(layer) as [UMLElement];
+  const [umlInterface] = umlComponentInterface.render(layer) as [PreviewElement];
+  umlInterface.styles = { paddingTop: 8 };
   elements.push(umlInterface);
 
   return elements;

--- a/src/tests/unit/packages/uml-component-diagram/uml-component-interface/__snapshots__/uml-component-interface-test.tsx.snap
+++ b/src/tests/unit/packages/uml-component-diagram/uml-component-interface/__snapshots__/uml-component-interface-test.tsx.snap
@@ -19,7 +19,7 @@ exports[`render the uml-component-component 1`] = `
           font-weight="bold"
           pointer-events="none"
           text-anchor="start"
-          x="25px"
+          x="25"
         >
           TestComponentComponent
         </text>

--- a/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-interface/__snapshots__/uml-deployment-interface-test.tsx.snap
+++ b/src/tests/unit/packages/uml-deployment-diagram/uml-deployment-interface/__snapshots__/uml-deployment-interface-test.tsx.snap
@@ -19,7 +19,7 @@ exports[`render the uml-deployment-interface-component 1`] = `
           font-weight="bold"
           pointer-events="none"
           text-anchor="start"
-          x="25px"
+          x="25"
         >
           TestDeploymentComponent
         </text>


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes
- [ ] I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

PR for github issue https://github.com/ls1intum/Apollon/issues/370

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Change Diagram Type from the left menu to (Component Diagram or any.)
2. Review the spacing of the preview items in the sidebar.

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see package.json). -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| File | Branch | Line |
|------|-------:|-----:|
<!--
| uml-activity-fork-node-component.ts | 85% | 77% |
| uml-activity-action-node-component.ts | 13% | 95% |
-->
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

<table>

<tr>
<td>
Before
</td>

<td>
After
</td>

</tr>

<tr>
<td>

![Screenshot 2024-08-10 at 19 03 11](https://github.com/user-attachments/assets/dcc8fcce-e3b7-4d48-8b00-3b2587dd31ac)



</td>

<td>

![Screenshot 2024-08-10 at 18 58 42](https://github.com/user-attachments/assets/88f99eee-72f0-4624-9b37-7d03cf293861)


</td>


</tr>

</tr>

<tr>
<td>


![Screenshot 2024-08-10 at 19 03 29](https://github.com/user-attachments/assets/5b00ac20-d45b-4d5d-9d4a-d088ba6c5503)
</td>

<td>

![Screenshot 2024-08-10 at 18 58 38](https://github.com/user-attachments/assets/79516da1-6a97-4083-a0aa-8e51d21eaec6)
</td>



</tr>
</table>

