### PR TITLE
fix failing test

### DIFF
--- a/src/main/components/assessment/assessment-dropInfo-tooltip.tsx
+++ b/src/main/components/assessment/assessment-dropInfo-tooltip.tsx
@@ -4,7 +4,7 @@ import { Button } from '../controls/button/button';
 import { LinkIcon } from '../controls/icon/link';
 import { TrashIcon } from '../controls/icon/trash';
 import { I18nContext } from '../i18n/i18n-context';
-import { Tooltip } from 'react-tooltip';
+import Tooltip from 'react-tooltip';
 import { AssessmentRepository } from '../../services/assessment/assessment-repository';
 import { compose } from 'redux';
 import { localized } from '../i18n/localized';

--- a/src/main/components/assessment/assessment-section.tsx
+++ b/src/main/components/assessment/assessment-section.tsx
@@ -18,7 +18,7 @@ import { ModelState } from '../store/model-state';
 import { styled } from '../theme/styles';
 import { UMLElementRepository } from '../../services/uml-element/uml-element-repository';
 import { AssessmentDropInfoTooltip } from './assessment-dropInfo-tooltip';
-import { Tooltip } from 'react-tooltip';
+import Tooltip from 'react-tooltip';
 
 const Flex = styled.div`
   display: flex;

--- a/src/main/components/store/util.ts
+++ b/src/main/components/store/util.ts
@@ -26,4 +26,23 @@ export function arrayToInclusionMap(array: string[]): Record<string, boolean> {
   return array.reduce<Record<string, boolean>>((acc, val) => ({ ...acc, [val]: true }), {});
 }
 
-export type TextLayout = Pick<React.SVGProps<SVGTextElement>, 'dx' | 'dy' | 'textAnchor' | 'dominantBaseline'>;
+// Keep this in sync with `Text` component props to avoid widening to string|number from React.SVGProps
+export type TextLayout =
+  Pick<React.SVGProps<SVGTextElement>, 'dx' | 'dy'> & {
+    textAnchor?: 'end' | 'start' | 'middle' | 'inherit';
+    dominantBaseline?:
+      | 'alphabetic'
+      | 'hanging'
+      | 'ideographic'
+      | 'mathematical'
+      | 'auto'
+      | 'text-before-edge'
+      | 'middle'
+      | 'central'
+      | 'text-after-edge'
+      | 'inherit'
+      | 'use-script'
+      | 'no-change'
+      | 'reset-size'
+      | undefined;
+  };

--- a/src/main/packages/sfc/sfc-transition/sfc-transition-update.tsx
+++ b/src/main/packages/sfc/sfc-transition/sfc-transition-update.tsx
@@ -56,7 +56,7 @@ const SfcTransitionUpdateComponent: FunctionComponent<Props & I18nContext> = ({ 
     <Container>
       <section>
         <Row style={{ gap: 5 }}>
-          <Textfield style={{ flex: '1', textDecoration }} value={displayName} onChange={handleNameChange} autoFocus />
+          <Textfield style={{ flex: '1 1 0%', textDecoration }} value={displayName} onChange={handleNameChange} autoFocus />
           <Button color={negationButtonColor} style={{ textDecoration: 'overline' }} onClick={() => handleNegation()}>
             X
           </Button>

--- a/src/tests/unit/test-utils/setup-test.ts
+++ b/src/tests/unit/test-utils/setup-test.ts
@@ -5,3 +5,23 @@ import { ILayer } from '../../../main/services/layouter/layer';
 Text.size = (layer: ILayer, value: string, styles?: Partial<CSSStyleDeclaration>) => {
   return { width: 0, height: 0 };
 };
+
+// jsdom doesn't implement crypto.randomUUID; provide a light-weight fallback for tests
+try {
+  const c = (window as any).crypto;
+  if (c && typeof c.randomUUID !== 'function') {
+    c.randomUUID = () => {
+      let dt = Date.now();
+      if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+        dt += performance.now();
+      }
+      return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (ch) => {
+        const r = (dt + Math.random() * 16) % 16 | 0;
+        dt = Math.floor(dt / 16);
+        return (ch === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+      });
+    };
+  }
+} catch {
+  // ignore
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2024",
+    "target": "es2022",
     "module": "es2022",
     "moduleResolution": "node",
-    "lib": ["es2024", "dom"],
+    "lib": ["es2023", "dom"],
     "jsx": "react",
     "outDir": "lib/es6",
     "declaration": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Currently there is a test failing on develop.

### Description
<!-- Describe your changes in detail -->

This pull request introduces several improvements and fixes across the codebase, focusing on type safety, dependency imports, layout consistency, and test reliability. The most significant changes are grouped below by theme.

**Type Safety and Consistency:**

* Refined the `TextLayout` type in `store/util.ts` to more accurately match the `Text` component's props, avoiding overly broad types and ensuring better type safety for SVG text properties.

**Dependency Import Updates:**

* Updated the import style for `react-tooltip` in both `assessment-dropInfo-tooltip.tsx` and `assessment-section.tsx` to use the default import syntax, ensuring compatibility and consistency with the library's export. [[1]](diffhunk://#diff-25fc906cca86e6749e64914c6ba11a7ab11704b02cadf8ebc7f0d3921f2f0125L7-R7) [[2]](diffhunk://#diff-5d38ba6ed322d7506bed5aa198127c7346c25bf8aebdad66219832e153f715f0L21-R21)

**Test Environment Improvements:**

* Added a lightweight polyfill for `crypto.randomUUID` in `setup-test.ts` to ensure tests run reliably in environments (like jsdom) where this API is not implemented.

**Layout and Styling Fixes:**

* Adjusted the `flex` property for the `Textfield` in `sfc-transition-update.tsx` to use a more explicit flex-basis (`flex: '1 1 0%'`), improving layout behavior and consistency.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Run locally and check if everything is still working as expected
