### PR TITLE
Fix failing tooltip test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -90,6 +90,12 @@ module.exports = {
 
   // A preset that is used as a base for Jest's configuration
   preset: 'ts-jest',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.jest.json',
+      isolatedModules: true,
+    },
+  },
 
   // Run tests from one or more projects
   // projects: undefined,

--- a/src/tests/unit/components/assessment/assessment-dropInfo-tooltip-test.tsx
+++ b/src/tests/unit/components/assessment/assessment-dropInfo-tooltip-test.tsx
@@ -122,6 +122,9 @@ describe('test AssessmentDropInfoTooltip', () => {
     );
 
     const linkButton = getByRole('button');
+    act(() => {
+      fireEvent.mouseEnter(linkButton);
+    });
     const displayedMessage = getByText(dropInfo.tooltipMessage);
     expect(displayedMessage).not.toBeNull();
 

--- a/src/tests/unit/test-utils/setup-test.ts
+++ b/src/tests/unit/test-utils/setup-test.ts
@@ -5,3 +5,12 @@ import { ILayer } from '../../../main/services/layouter/layer';
 Text.size = (layer: ILayer, value: string, styles?: Partial<CSSStyleDeclaration>) => {
   return { width: 0, height: 0 };
 };
+
+// jsdom does not implement ResizeObserver; mock a minimal no-op implementation for libraries relying on it
+if (typeof (window as any).ResizeObserver === 'undefined') {
+  (window as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["es2023", "dom"],
+    "jsx": "react",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "strict": true
+  },
+  "include": [
+    "src/main/**/*",
+    "src/tests/**/*"
+  ]
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes
- [ ] I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Failing test on develop

### Description
<!-- Describe your changes in detail -->

This pull request introduces improvements to the test environment setup and adds a new TypeScript configuration for Jest. The most important changes are grouped below:

**Test Environment Enhancements:**

* Added a minimal mock implementation of `ResizeObserver` in `setup-test.ts` to handle cases where `jsdom` does not provide it, ensuring compatibility with libraries that rely on this API.
* Updated the `assessment-dropInfo-tooltip-test.tsx` test to simulate a mouse enter event on the tooltip button, improving the accuracy of tooltip display testing.

**Configuration Updates:**

* Added a new `tsconfig.jest.json` file with strict TypeScript settings tailored for Jest, including modern ECMAScript targets, React JSX support, and inclusion of both main and test source files.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Make sure Apollon still works
