### PR TITLE
fix: update docker image paths from apollon2 to apollon

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -63,11 +63,11 @@ jobs:
         include:
           - name: Webapp
             dockerfile: ./standalone/webapp/Dockerfile
-            image: ghcr.io/ls1intum/apollon2/apollon-webapp
+            image: ghcr.io/ls1intum/apollon/apollon-webapp
             context: .
           - name: Server
             dockerfile: ./standalone/server/Dockerfile
-            image: ghcr.io/ls1intum/apollon2/apollon-server
+            image: ghcr.io/ls1intum/apollon/apollon-server
             context: .
     uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@main
     with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -30,7 +30,7 @@ jobs:
     with:
       environment: Production
       docker-compose-file: "./docker/compose.db.yml"
-      main-image-name: ghcr.io/ls1intum/apollon2/apollon-server
+      main-image-name: ghcr.io/ls1intum/apollon/apollon-server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/db"
     secrets: inherit
@@ -41,7 +41,7 @@ jobs:
     with:
       environment: Production
       docker-compose-file: "./docker/compose.proxy.yml"
-      main-image-name: ghcr.io/ls1intum/apollon2/apollon-server
+      main-image-name: ghcr.io/ls1intum/apollon/apollon-server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/proxy"
     secrets: inherit
@@ -52,7 +52,7 @@ jobs:
     with:
       environment: Production
       docker-compose-file: "./docker/compose.app.yml"
-      main-image-name: ghcr.io/ls1intum/apollon2/apollon-server
+      main-image-name: ghcr.io/ls1intum/apollon/apollon-server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/app"
     secrets: inherit

--- a/docker/compose.app.yml
+++ b/docker/compose.app.yml
@@ -1,6 +1,6 @@
 services:
   webapp:
-    image: "ghcr.io/ls1intum/apollon2/apollon-webapp:${IMAGE_TAG:-latest}"
+    image: "ghcr.io/ls1intum/apollon/apollon-webapp:${IMAGE_TAG:-latest}"
     restart: unless-stopped
     expose:
       - "8080"
@@ -23,7 +23,7 @@ services:
         max-file: "5"
 
   server:
-    image: "ghcr.io/ls1intum/apollon2/apollon-server:${IMAGE_TAG:-latest}"
+    image: "ghcr.io/ls1intum/apollon/apollon-server:${IMAGE_TAG:-latest}"
     expose:
       - "8000"
       - "4444"


### PR DESCRIPTION
## Summary

Update all GHCR image paths after repo migration from `ls1intum/Apollon2` to `ls1intum/Apollon`.

`ghcr.io/ls1intum/apollon2/` → `ghcr.io/ls1intum/apollon/`

7 references across 3 files:
- `.github/workflows/build-and-push.yml` (webapp + server images)
- `.github/workflows/deploy-prod.yml` (3 deploy jobs)
- `docker/compose.app.yml` (webapp + server images)

After merge, the build workflow will push images to the new path. First deploy will need all three boxes checked (db, proxy, app) since the compose file references the new image names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)