### PR TITLE
fix: Remove global :root CSS declarations to allow host app theming

### DIFF
--- a/library/lib/App.tsx
+++ b/library/lib/App.tsx
@@ -87,12 +87,13 @@ function App({ onReactFlowInit }: AppProps) {
 
   return (
     <div
+      className="apollon-editor"
       style={{
         display: "flex",
         height: "100%",
         width: "100%",
         overflow: "hidden",
-        backgroundColor: "var(--apollon-background)",
+        backgroundColor: "var(--apollon-background, white)",
         position: "relative",
       }}
     >

--- a/library/lib/components/AssessmentSelectionDebug.tsx
+++ b/library/lib/components/AssessmentSelectionDebug.tsx
@@ -69,7 +69,7 @@ export function AssessmentSelectionDebug() {
               <div
                 key={id}
                 style={{
-                  border: "2px solid var(--apollon-grid)",
+                  border: "2px solid var(--apollon-grid, rgba(36, 39, 36, 0.1))",
                   padding: "4px",
                 }}
               >

--- a/library/lib/components/AssessmentSelectionDebug.tsx
+++ b/library/lib/components/AssessmentSelectionDebug.tsx
@@ -69,7 +69,8 @@ export function AssessmentSelectionDebug() {
               <div
                 key={id}
                 style={{
-                  border: "2px solid var(--apollon-grid, rgba(36, 39, 36, 0.1))",
+                  border:
+                    "2px solid var(--apollon-grid, rgba(36, 39, 36, 0.1))",
                   padding: "4px",
                 }}
               >

--- a/library/lib/components/CustomBackground.tsx
+++ b/library/lib/components/CustomBackground.tsx
@@ -6,14 +6,14 @@ export const CustomBackground = () => {
       <Background
         id="1"
         gap={10}
-        color="var(--apollon-gray)"
+        color="var(--apollon-gray, #e9ecef)"
         variant={BackgroundVariant.Lines}
       />
 
       <Background
         id="2"
         gap={50}
-        color="var(--apollon-grid)"
+        color="var(--apollon-grid, rgba(36, 39, 36, 0.1))"
         variant={BackgroundVariant.Lines}
       />
     </>

--- a/library/lib/components/CustomControls.tsx
+++ b/library/lib/components/CustomControls.tsx
@@ -48,8 +48,8 @@ export const CustomControls = () => {
                 height={16}
                 fill={
                   canUndo
-                    ? "var(--apollon-primary-contrast)"
-                    : "var(--apollon-secondary)"
+                    ? "var(--apollon-primary-contrast, #000000)"
+                    : "var(--apollon-secondary, #6c757d)"
                 }
               />
             </button>
@@ -70,8 +70,8 @@ export const CustomControls = () => {
                 height={16}
                 fill={
                   canRedo
-                    ? "var(--apollon-primary-contrast)"
-                    : "var(--apollon-secondary)"
+                    ? "var(--apollon-primary-contrast, #000000)"
+                    : "var(--apollon-secondary, #6c757d)"
                 }
               />
             </button>
@@ -81,7 +81,7 @@ export const CustomControls = () => {
       <div
         style={{
           userSelect: "none",
-          border: "1px solid var(--apollon-primary-contrast)",
+          border: "1px solid var(--apollon-primary-contrast, #000000)",
           borderRadius: 8,
           paddingLeft: 4,
           paddingRight: 4,
@@ -90,7 +90,7 @@ export const CustomControls = () => {
           height: "100%",
           alignItems: "center",
           justifyContent: "center",
-          color: "var(--apollon-primary-contrast)",
+          color: "var(--apollon-primary-contrast, #000000)",
         }}
         onClick={() => zoomTo(1)}
       >

--- a/library/lib/components/CustomMiniMap.tsx
+++ b/library/lib/components/CustomMiniMap.tsx
@@ -77,7 +77,7 @@ export const CustomMiniMap = () => {
   if (minimapCollapsed) {
     return (
       <Panel position="bottom-right" onClick={() => setMinimapCollapsed(false)}>
-        <MapIcon fill="var(--apollon-primary-contrast)" />
+        <MapIcon fill="var(--apollon-primary-contrast, #000000)" />
       </Panel>
     )
   }
@@ -96,7 +96,7 @@ export const CustomMiniMap = () => {
           display: "flex",
           zIndex: ZINDEX.PANEL,
           padding: 8,
-          backgroundColor: "var(--apollon-background)",
+          backgroundColor: "var(--apollon-background, white)",
           borderRadius: "4px",
           justifyContent: "center",
           alignItems: "center",
@@ -104,7 +104,7 @@ export const CustomMiniMap = () => {
           boxShadow: "0 0 4px 0 rgb(0 0 0 / 0.2)",
         }}
       >
-        <SouthEastArrowIcon fill="var(--apollon-primary-contrast)" />
+        <SouthEastArrowIcon fill="var(--apollon-primary-contrast, #000000)" />
       </div>
 
       <MiniMap

--- a/library/lib/components/Sidebar.tsx
+++ b/library/lib/components/Sidebar.tsx
@@ -34,7 +34,7 @@ export const Sidebar = () => {
         width: "180px",
         minWidth: "180px",
         height: "100%",
-        backgroundColor: "var(--apollon-background)",
+        backgroundColor: "var(--apollon-background, white)",
         display: "flex",
         flexDirection: "column",
         padding: "10px",

--- a/library/lib/components/popovers/GenericPopover.tsx
+++ b/library/lib/components/popovers/GenericPopover.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react"
+import React, { ReactNode, useMemo } from "react"
 import { Popover, PopoverOrigin, Paper } from "@mui/material"
 
 interface GenericPopoverProps {
@@ -27,7 +27,18 @@ export const GenericPopover: React.FC<GenericPopoverProps> = ({
   maxWidth = 278,
   minWidth = 200,
   style,
-}) => (
+}) => {
+  // Resolve the closest .apollon-editor container so the popover portal
+  // inherits the scoped CSS custom properties (theme variables).
+  const container = useMemo(() => {
+    if (!anchorEl) return undefined
+    const el = anchorEl instanceof SVGElement
+      ? anchorEl.closest(".apollon-editor") ?? anchorEl.ownerSVGElement?.closest(".apollon-editor")
+      : anchorEl.closest(".apollon-editor")
+    return (el as HTMLElement) ?? undefined
+  }, [anchorEl])
+
+  return (
   <Popover
     id={open ? id : undefined}
     open={open}
@@ -35,6 +46,7 @@ export const GenericPopover: React.FC<GenericPopoverProps> = ({
     onClose={onClose}
     anchorOrigin={anchorOrigin}
     transformOrigin={transformOrigin}
+    container={container}
     style={{ maxHeight, width: "100%", ...style }}
     onClick={(e) => {
       e.stopPropagation()
@@ -51,10 +63,11 @@ export const GenericPopover: React.FC<GenericPopoverProps> = ({
         display: "flex",
         flex: 1,
         flexDirection: "column",
-        backgroundColor: "var(--apollon-background-variant)",
+        backgroundColor: "var(--apollon-background-variant, #f8f9fa)",
       }}
     >
       {children}
     </Paper>
   </Popover>
-)
+  )
+}

--- a/library/lib/components/popovers/GenericPopover.tsx
+++ b/library/lib/components/popovers/GenericPopover.tsx
@@ -32,42 +32,44 @@ export const GenericPopover: React.FC<GenericPopoverProps> = ({
   // inherits the scoped CSS custom properties (theme variables).
   const container = useMemo(() => {
     if (!anchorEl) return undefined
-    const el = anchorEl instanceof SVGElement
-      ? anchorEl.closest(".apollon-editor") ?? anchorEl.ownerSVGElement?.closest(".apollon-editor")
-      : anchorEl.closest(".apollon-editor")
+    const el =
+      anchorEl instanceof SVGElement
+        ? (anchorEl.closest(".apollon-editor") ??
+          anchorEl.ownerSVGElement?.closest(".apollon-editor"))
+        : anchorEl.closest(".apollon-editor")
     return (el as HTMLElement) ?? undefined
   }, [anchorEl])
 
   return (
-  <Popover
-    id={open ? id : undefined}
-    open={open}
-    anchorEl={anchorEl}
-    onClose={onClose}
-    anchorOrigin={anchorOrigin}
-    transformOrigin={transformOrigin}
-    container={container}
-    style={{ maxHeight, width: "100%", ...style }}
-    onClick={(e) => {
-      e.stopPropagation()
-    }}
-  >
-    <Paper
-      elevation={2}
-      sx={{
-        width: "100%",
-        maxWidth,
-        minWidth,
-        px: 1,
-        py: 1.25,
-        display: "flex",
-        flex: 1,
-        flexDirection: "column",
-        backgroundColor: "var(--apollon-background-variant, #f8f9fa)",
+    <Popover
+      id={open ? id : undefined}
+      open={open}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={anchorOrigin}
+      transformOrigin={transformOrigin}
+      container={container}
+      style={{ maxHeight, width: "100%", ...style }}
+      onClick={(e) => {
+        e.stopPropagation()
       }}
     >
-      {children}
-    </Paper>
-  </Popover>
+      <Paper
+        elevation={2}
+        sx={{
+          width: "100%",
+          maxWidth,
+          minWidth,
+          px: 1,
+          py: 1.25,
+          display: "flex",
+          flex: 1,
+          flexDirection: "column",
+          backgroundColor: "var(--apollon-background-variant, #f8f9fa)",
+        }}
+      >
+        {children}
+      </Paper>
+    </Popover>
   )
 }

--- a/library/lib/components/popovers/GiveFeedbackAssessmentBox.tsx
+++ b/library/lib/components/popovers/GiveFeedbackAssessmentBox.tsx
@@ -73,8 +73,8 @@ export const GiveFeedbackAssessmentBox = ({ elementId, name, type }: Props) => {
               borderRadius: "4px",
               padding: "4px",
               flex: 1,
-              backgroundColor: "var(--apollon-background)",
-              color: "var(--apollon-primary-contrast)",
+              backgroundColor: "var(--apollon-background, white)",
+              color: "var(--apollon-primary-contrast, #000000)",
             }}
             maxLength={20}
             type="number"
@@ -99,8 +99,8 @@ export const GiveFeedbackAssessmentBox = ({ elementId, name, type }: Props) => {
               padding: "4px",
               flex: 1,
               resize: "vertical",
-              backgroundColor: "var(--apollon-background)",
-              color: "var(--apollon-primary-contrast)",
+              backgroundColor: "var(--apollon-background, white)",
+              color: "var(--apollon-primary-contrast, #000000)",
             }}
             placeholder="You can enter feedback here..."
             maxLength={500}

--- a/library/lib/components/popovers/edgePopovers/CommunicationDiagramEdgeEditPopover.tsx
+++ b/library/lib/components/popovers/edgePopovers/CommunicationDiagramEdgeEditPopover.tsx
@@ -163,12 +163,12 @@ export const CommunicationDiagramEdgeEditPopover: React.FC<PopoverProps> = ({
               {message.direction === "target" ? (
                 <ArrowForwardIcon
                   fontSize="small"
-                  fill="var(--apollon-primary-contrast)"
+                  fill="var(--apollon-primary-contrast, #000000)"
                 />
               ) : (
                 <ArrowBackIcon
                   fontSize="small"
-                  fill="var(--apollon-primary-contrast)"
+                  fill="var(--apollon-primary-contrast, #000000)"
                 />
               )}
             </IconButton>

--- a/library/lib/components/svgs/StyledElements.tsx
+++ b/library/lib/components/svgs/StyledElements.tsx
@@ -2,8 +2,8 @@ import { LAYOUT } from "@/constants"
 import React from "react"
 
 export const StyledRect: React.FC<React.SVGProps<SVGRectElement>> = ({
-  stroke = "var(--apollon-primary-contrast)",
-  fill = "var(--apollon-background)",
+  stroke = "var(--apollon-primary-contrast, #000000)",
+  fill = "var(--apollon-background, white)",
   ...props
 }) => {
   return (

--- a/library/lib/components/svgs/nodes/CustomText.tsx
+++ b/library/lib/components/svgs/nodes/CustomText.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export const CustomText: FC<Props & Record<string, unknown>> = ({
   children,
-  fill = "var(--apollon-primary-contrast)",
+  fill = "var(--apollon-primary-contrast, #000000)",
   x = "50%",
   y = "50%",
   dominantBaseline = "central",

--- a/library/lib/components/svgs/nodes/HeaderSection.tsx
+++ b/library/lib/components/svgs/nodes/HeaderSection.tsx
@@ -22,7 +22,7 @@ export const HeaderSection: FC<HeaderSectionProps> = ({
   headerHeight,
   isUnderlined = false,
   textColor,
-  fill = "var(--apollon-background)",
+  fill = "var(--apollon-background, white)",
 }) => {
   return (
     <>

--- a/library/lib/components/svgs/nodes/SeparationLine.tsx
+++ b/library/lib/components/svgs/nodes/SeparationLine.tsx
@@ -10,7 +10,7 @@ interface SeparationLineProps {
 export const SeparationLine: FC<SeparationLineProps> = ({
   y,
   width,
-  strokeColor = "var(--apollon-primary-contrast)",
+  strokeColor = "var(--apollon-primary-contrast, #000000)",
 }) => (
   <line
     x1="0"

--- a/library/lib/components/svgs/nodes/activityDiagram/ActivityFinalNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/activityDiagram/ActivityFinalNodeSVG.tsx
@@ -29,14 +29,14 @@ export const ActivityFinalNodeSVG: React.FC<SVGComponentProps> = ({
         cx={width / 2}
         cy={height / 2}
         r={width / 2}
-        fill="var(--apollon-primary-contrast)"
+        fill="var(--apollon-primary-contrast, #000000)"
       />
       <circle
         cx={width / 2}
         cy={height / 2}
         r={(width / 2) * 0.8}
-        fill="var(--apollon-primary-contrast)"
-        stroke="var(--apollon-background)"
+        fill="var(--apollon-primary-contrast, #000000)"
+        stroke="var(--apollon-background, white)"
         strokeWidth={LAYOUT.LINE_WIDTH}
       />
 

--- a/library/lib/components/svgs/nodes/activityDiagram/ActivityForkNodeHorizontalSVG.tsx
+++ b/library/lib/components/svgs/nodes/activityDiagram/ActivityForkNodeHorizontalSVG.tsx
@@ -24,7 +24,7 @@ export const ActivityForkNodeHorizontalSVG: React.FC<
   const scaledWidth = width * (SIDEBAR_PREVIEW_SCALE ?? 1)
   const scaledHeight = height * (SIDEBAR_PREVIEW_SCALE ?? 1)
 
-  const fillColor = data.fillColor || "var(--apollon-primary-contrast)"
+  const fillColor = data.fillColor || "var(--apollon-primary-contrast, #000000)"
   return (
     <svg
       width={scaledWidth}

--- a/library/lib/components/svgs/nodes/activityDiagram/ActivityForkNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/activityDiagram/ActivityForkNodeSVG.tsx
@@ -21,7 +21,7 @@ export const ActivityForkNodeSVG: React.FC<ActivityForkNodeSVGProps> = ({
   const scaledWidth = width * (SIDEBAR_PREVIEW_SCALE ?? 1)
   const scaledHeight = height * (SIDEBAR_PREVIEW_SCALE ?? 1)
 
-  const fillColor = data.fillColor || "var(--apollon-primary-contrast)"
+  const fillColor = data.fillColor || "var(--apollon-primary-contrast, #000000)"
 
   return (
     <svg

--- a/library/lib/components/svgs/nodes/activityDiagram/ActivityInitialNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/activityDiagram/ActivityInitialNodeSVG.tsx
@@ -28,7 +28,7 @@ export const ActivityInitialNodeSVG: React.FC<SVGComponentProps> = ({
         cx={width / 2}
         cy={height / 2}
         r={width / 2}
-        fill="var(--apollon-primary-contrast)"
+        fill="var(--apollon-primary-contrast, #000000)"
       />
 
       {showAssessmentResults && (

--- a/library/lib/components/svgs/nodes/classDiagram/PackageSVG.tsx
+++ b/library/lib/components/svgs/nodes/classDiagram/PackageSVG.tsx
@@ -29,7 +29,8 @@ export const PackageSVG: React.FC<PackageSVGProps> = ({
   const scaledWidth = width * (SIDEBAR_PREVIEW_SCALE ?? 1)
   const scaledHeight = height * (SIDEBAR_PREVIEW_SCALE ?? 1)
 
-  const strokeColor = data.strokeColor || "var(--apollon-primary-contrast, #000000)"
+  const strokeColor =
+    data.strokeColor || "var(--apollon-primary-contrast, #000000)"
   const fillColor = data.fillColor || "var(--apollon-background, white)"
   const textColor = data.textColor || "var(--apollon-primary-contrast, #000000)"
 

--- a/library/lib/components/svgs/nodes/classDiagram/PackageSVG.tsx
+++ b/library/lib/components/svgs/nodes/classDiagram/PackageSVG.tsx
@@ -29,9 +29,9 @@ export const PackageSVG: React.FC<PackageSVGProps> = ({
   const scaledWidth = width * (SIDEBAR_PREVIEW_SCALE ?? 1)
   const scaledHeight = height * (SIDEBAR_PREVIEW_SCALE ?? 1)
 
-  const strokeColor = data.strokeColor || "var(--apollon-primary-contrast)"
-  const fillColor = data.fillColor || "var(--apollon-background)"
-  const textColor = data.textColor || "var(--apollon-primary-contrast)"
+  const strokeColor = data.strokeColor || "var(--apollon-primary-contrast, #000000)"
+  const fillColor = data.fillColor || "var(--apollon-background, white)"
+  const textColor = data.textColor || "var(--apollon-primary-contrast, #000000)"
 
   return (
     <svg

--- a/library/lib/components/svgs/nodes/classDiagram/TitleAndDescriptionSVG.tsx
+++ b/library/lib/components/svgs/nodes/classDiagram/TitleAndDescriptionSVG.tsx
@@ -83,9 +83,9 @@ export const TitleAndDescriptionSVG: React.FC<TitleAndDescriptionSVGProps> = ({
         y={padding / 2}
         width={width - padding}
         height={height - padding}
-        stroke="var(--apollon-primary-contrast)"
+        stroke="var(--apollon-primary-contrast, #000000)"
         strokeWidth={LAYOUT.LINE_WIDTH}
-        fill="var(--apollon-background)"
+        fill="var(--apollon-background, white)"
       />
 
       {/* Title */}
@@ -94,7 +94,7 @@ export const TitleAndDescriptionSVG: React.FC<TitleAndDescriptionSVGProps> = ({
         y={padding + titleHeight / 2}
         fontSize="16"
         fontWeight="bold"
-        fill="var(--apollon-primary-contrast)"
+        fill="var(--apollon-primary-contrast, #000000)"
         textAnchor="middle"
         alignmentBaseline="middle"
       >
@@ -107,7 +107,7 @@ export const TitleAndDescriptionSVG: React.FC<TitleAndDescriptionSVGProps> = ({
         x2={width - padding / 2}
         y1={padding + titleHeight}
         y2={padding + titleHeight}
-        stroke="var(--apollon-primary-contrast)"
+        stroke="var(--apollon-primary-contrast, #000000)"
         strokeWidth={LAYOUT.LINE_WIDTH}
       />
 
@@ -118,7 +118,7 @@ export const TitleAndDescriptionSVG: React.FC<TitleAndDescriptionSVGProps> = ({
           x={padding}
           y={descriptionStartY + index * lineHeight}
           fontSize="14"
-          fill="var(--apollon-primary-contrast)"
+          fill="var(--apollon-primary-contrast, #000000)"
           alignmentBaseline="hanging"
         >
           {line}

--- a/library/lib/components/svgs/nodes/sfcDiagram/SfcTransitionBranchNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/sfcDiagram/SfcTransitionBranchNodeSVG.tsx
@@ -29,7 +29,7 @@ export const SfcTransitionBranchNodeSVG: React.FC<Props> = ({
   const radius = Math.min(width, height) / 2
 
   const { strokeColor } = getCustomColorsFromData(data)
-  const fillColor = data.fillColor || "var(--apollon-primary-contrast)"
+  const fillColor = data.fillColor || "var(--apollon-primary-contrast, #000000)"
   return (
     <svg
       width={scaledWidth}

--- a/library/lib/components/toolbars/edgeToolBar/CustomEdgeToolBar.tsx
+++ b/library/lib/components/toolbars/edgeToolBar/CustomEdgeToolBar.tsx
@@ -46,8 +46,8 @@ export const CustomEdgeToolbar: React.FC<CustomEdgeToolbarProps> = ({
       {showToolbar && (
         <Box
           sx={{
-            backgroundColor: "var(--apollon-background)",
-            boxShadow: "0 0 4px 0 var(--apollon-background-variant)",
+            backgroundColor: "var(--apollon-background, white)",
+            boxShadow: "0 0 4px 0 var(--apollon-background-variant, #f8f9fa)",
             borderRadius: "8px",
             padding: "8px",
             display: "flex",
@@ -68,7 +68,7 @@ export const CustomEdgeToolbar: React.FC<CustomEdgeToolbarProps> = ({
             sx={{
               width: "16px",
               height: "16px",
-              backgroundColor: "var(--apollon-background)",
+              backgroundColor: "var(--apollon-background, white)",
               borderRadius: 1,
               display: "flex",
               justifyContent: "center",
@@ -85,7 +85,7 @@ export const CustomEdgeToolbar: React.FC<CustomEdgeToolbarProps> = ({
             sx={{
               width: "16px",
               height: "16px",
-              backgroundColor: "var(--apollon-background)",
+              backgroundColor: "var(--apollon-background, white)",
               borderRadius: 1,
               display: "flex",
               justifyContent: "center",

--- a/library/lib/components/ui/DividerLine.tsx
+++ b/library/lib/components/ui/DividerLine.tsx
@@ -11,7 +11,7 @@ export const DividerLine: React.FC<DividerLineProps> = ({
   width = "100%",
   height = "1px",
   style,
-  backgroundColor = "var(--apollon-primary-contrast)",
+  backgroundColor = "var(--apollon-primary-contrast, #000000)",
 }) => (
   <div
     style={{

--- a/library/lib/components/ui/HeaderSwitchElement.tsx
+++ b/library/lib/components/ui/HeaderSwitchElement.tsx
@@ -18,10 +18,10 @@ export const HeaderSwitchElement: React.FC<Props> = ({
         alignItems: "center",
         justifyContent: "center",
         zIndex: ZINDEX.HEADER_SWITCH,
-        color: "var(--apollon-primary-contrast)",
+        color: "var(--apollon-primary-contrast, #000000)",
         ...(isComponentHeaderShown && {
           background:
-            "linear-gradient(to top right, transparent calc(50% - 1px), var(--apollon-primary-contrast) 50%, transparent calc(50% + 1px))",
+            "linear-gradient(to top right, transparent calc(50% - 1px), var(--apollon-primary-contrast, #000000) 50%, transparent calc(50% + 1px))",
         }),
       }}
     >

--- a/library/lib/components/ui/PrimaryButton.tsx
+++ b/library/lib/components/ui/PrimaryButton.tsx
@@ -9,9 +9,9 @@ const buttonBaseStyle: React.CSSProperties = {
   padding: "4px 8px",
   fontWeight: 500,
   fontSize: "0.875rem",
-  border: "1px solid var(--apollon-primary)",
-  backgroundColor: "var(--apollon-background)",
-  color: "var(--apollon-primary)",
+  border: "1px solid var(--apollon-primary, #3e8acc)",
+  backgroundColor: "var(--apollon-background, white)",
+  color: "var(--apollon-primary, #3e8acc)",
   cursor: "pointer",
 }
 
@@ -24,9 +24,9 @@ export const PrimaryButton: React.FC<Props> = ({
   const buttonStyle: React.CSSProperties = {
     ...buttonBaseStyle,
     backgroundColor: isSelected
-      ? "var(--apollon-primary)"
-      : "var(--apollon-background)",
-    color: isSelected ? "var(--apollon-background)" : "var(--apollon-primary)",
+      ? "var(--apollon-primary, #3e8acc)"
+      : "var(--apollon-background, white)",
+    color: isSelected ? "var(--apollon-background, white)" : "var(--apollon-primary, #3e8acc)",
     ...style,
   }
 

--- a/library/lib/components/ui/PrimaryButton.tsx
+++ b/library/lib/components/ui/PrimaryButton.tsx
@@ -26,7 +26,9 @@ export const PrimaryButton: React.FC<Props> = ({
     backgroundColor: isSelected
       ? "var(--apollon-primary, #3e8acc)"
       : "var(--apollon-background, white)",
-    color: isSelected ? "var(--apollon-background, white)" : "var(--apollon-primary, #3e8acc)",
+    color: isSelected
+      ? "var(--apollon-background, white)"
+      : "var(--apollon-primary, #3e8acc)",
     ...style,
   }
 

--- a/library/lib/components/ui/StereotypeButtonGroup.tsx
+++ b/library/lib/components/ui/StereotypeButtonGroup.tsx
@@ -62,7 +62,7 @@ export const StereotypeButtonGroup: React.FC<StereotypeButtonGroupProps> = ({
         <PrimaryButton
           style={
             index === 0
-              ? { borderLeft: "1px solid var(--apollon-primary)" }
+              ? { borderLeft: "1px solid var(--apollon-primary, #3e8acc)" }
               : {}
           }
           key={stereotype}

--- a/library/lib/components/ui/StyleEditor/EdgeStyleEditor.tsx
+++ b/library/lib/components/ui/StyleEditor/EdgeStyleEditor.tsx
@@ -28,8 +28,8 @@ const styles = {
     flexDirection: "column" as const,
     marginTop: 10,
     marginBottom: 10,
-    backgroundColor: "var(--apollon-background)",
-    border: "1px solid var(--apollon-gray)",
+    backgroundColor: "var(--apollon-background, white)",
+    border: "1px solid var(--apollon-gray, #e9ecef)",
     paddingBottom: 10,
   },
   colorOption: {
@@ -48,9 +48,9 @@ const styles = {
   resetButton: {
     marginTop: 12,
     padding: "6px 12px",
-    backgroundColor: "var(--apollon-background)",
-    color: "var(--apollon-primary-contrast)",
-    border: "1px solid var(--apollon-gray)",
+    backgroundColor: "var(--apollon-background, white)",
+    color: "var(--apollon-primary-contrast, #000000)",
+    border: "1px solid var(--apollon-gray, #e9ecef)",
     cursor: "pointer",
     borderRadius: 4,
     width: "fit-content",
@@ -123,7 +123,7 @@ export const EdgeStyleEditor: React.FC<EdgeStyleEditorProps> = ({
                   onSelect={() => toggleColorField(key)}
                 />
                 {key !== colorFields[colorFields.length - 1].key && (
-                  <DividerLine backgroundColor="var(--apollon-gray)" />
+                  <DividerLine backgroundColor="var(--apollon-gray, #e9ecef)" />
                 )}
               </>
             ))
@@ -140,7 +140,7 @@ export const EdgeStyleEditor: React.FC<EdgeStyleEditorProps> = ({
                   {colorFields.find((f) => f.key === activeColorField)?.label}
                 </Typography>
                 <CrossIcon
-                  fill="var(--apollon-primary-contrast)"
+                  fill="var(--apollon-primary-contrast, #000000)"
                   onClick={() => setActiveColorField(null)}
                 />
               </div>

--- a/library/lib/components/ui/StyleEditor/NodeStyleEditor.tsx
+++ b/library/lib/components/ui/StyleEditor/NodeStyleEditor.tsx
@@ -30,8 +30,8 @@ const styles = {
     flexDirection: "column" as const,
     marginTop: 10,
     marginBottom: 10,
-    backgroundColor: "var(--apollon-background)",
-    border: "1px solid var(--apollon-gray)",
+    backgroundColor: "var(--apollon-background, white)",
+    border: "1px solid var(--apollon-gray, #e9ecef)",
     paddingBottom: 10,
   },
   colorOption: {
@@ -50,9 +50,9 @@ const styles = {
   resetButton: {
     marginTop: 12,
     padding: "6px 12px",
-    backgroundColor: "var(--apollon-background)",
-    color: "var(--apollon-primary-contrast)",
-    border: "1px solid var(--apollon-gray)",
+    backgroundColor: "var(--apollon-background, white)",
+    color: "var(--apollon-primary-contrast, #000000)",
+    border: "1px solid var(--apollon-gray, #e9ecef)",
     cursor: "pointer",
     borderRadius: 4,
     width: "fit-content",
@@ -152,7 +152,7 @@ export const NodeStyleEditor: React.FC<NodeStyleEditorProps> = ({
                   onSelect={() => toggleColorField(key)}
                 />
                 {key !== colorFields[colorFields.length - 1].key && (
-                  <DividerLine backgroundColor="var(--apollon-gray)" />
+                  <DividerLine backgroundColor="var(--apollon-gray, #e9ecef)" />
                 )}
               </React.Fragment>
             ))
@@ -169,7 +169,7 @@ export const NodeStyleEditor: React.FC<NodeStyleEditorProps> = ({
                   {colorFields.find((f) => f.key === activeColorField)?.label}
                 </Typography>
                 <CrossIcon
-                  fill="var(--apollon-primary-contrast)"
+                  fill="var(--apollon-primary-contrast, #000000)"
                   onClick={() => setActiveColorField(null)}
                 />
               </div>

--- a/library/lib/components/ui/TextField.tsx
+++ b/library/lib/components/ui/TextField.tsx
@@ -6,9 +6,9 @@ export const TextField: React.FC<TextFieldProps> = ({ sx, ...props }) => {
     <MUITextField
       sx={{
         ...sx,
-        bgcolor: "var(--apollon-background)",
+        bgcolor: "var(--apollon-background, white)",
         input: {
-          color: "var(--apollon-primary-contrast)",
+          color: "var(--apollon-primary-contrast, #000000)",
           border: "none",
         },
       }}

--- a/library/lib/components/ui/Typography.tsx
+++ b/library/lib/components/ui/Typography.tsx
@@ -4,7 +4,7 @@ import { Typography as MUITypography, TypographyProps } from "@mui/material"
 export const Typography: React.FC<TypographyProps> = ({ sx, ...props }) => {
   return (
     <MUITypography
-      sx={{ ...sx, color: "var(--apollon-primary-contrast)" }}
+      sx={{ ...sx, color: "var(--apollon-primary-contrast, #000000)" }}
       {...props}
     />
   )

--- a/library/lib/edges/labelTypes/EdgeEndLabels.tsx
+++ b/library/lib/edges/labelTypes/EdgeEndLabels.tsx
@@ -29,7 +29,7 @@ export const EdgeEndLabels = ({
   targetY,
   sourcePosition,
   targetPosition,
-  textColor = "var(--apollon-primary-contrast)",
+  textColor = "var(--apollon-primary-contrast, #000000)",
 }: EdgeEndLabelsProps) => {
   const sourceLabels = useMemo(() => {
     if (activePoints.length < 2) {

--- a/library/lib/edges/labelTypes/EdgeIncludeExtendLabel.tsx
+++ b/library/lib/edges/labelTypes/EdgeIncludeExtendLabel.tsx
@@ -45,7 +45,7 @@ export const EdgeIncludeExtendLabel = ({
               className="edge-label"
               style={{
                 fontSize: "12px",
-                fill: "var(--apollon-primary-contrast)",
+                fill: "var(--apollon-primary-contrast, #000000)",
                 fontStyle: "italic",
                 userSelect: "none",
                 fontWeight: "bold",

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -1,38 +1,11 @@
-:root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-  /* box-sizing: border-box; */
-
-  --apollon-primary: #3e8acc;
-  --apollon-primary-contrast: #000000;
-  --apollon-secondary: #6c757d;
-  --apollon-alert-warning-yellow: #ffc107;
-  --apollon-alert-warning-background: #fff3cd;
-  --apollon-alert-warning-border: #ffeeba;
-  --apollon-background: white;
-  --apollon-background-inverse: #000000;
-  --apollon-background-variant: #f8f9fa;
-  --apollon-gray: #e9ecef;
-  --apollon-grid: rgba(36, 39, 36, 0.1);
-  --apollon-gray-variant: #495057;
-  --apollon-alert-danger-color: #721c24;
-  --apollon-alert-danger-background: #f8d7da;
-  --apollon-alert-danger-border: #f5c6cb;
-  --apollon-switch-box-border-color: #dee2e6;
-  --apollon-list-group-color: #ffffff;
-  --apollon-btn-outline-secondary-color: #6c757d;
-  --apollon-modal-bottom-border: #e9ecef;
-  --xy-controls-button-background-color: var(--apollon-background);
-}
-
 .react-flow {
-  --panel-background: var(--apollon-background);
-  --panel-shadow: 0 0 4px 0 var(--apollon-background-variant);
-  --text: var(--apollon-primary-contrast);
-  --xy-edge-stroke: var(--apollon-primary-contrast);
+  --panel-background: var(--apollon-background, white);
+  --panel-shadow: 0 0 4px 0 var(--apollon-background-variant, #f8f9fa);
+  --text: var(--apollon-primary-contrast, #000000);
+  --xy-edge-stroke: var(--apollon-primary-contrast, #000000);
   --xy-edge-stroke-width: 2px;
   --xy-minimap-mask-background-color-props: #00000020;
+  --xy-controls-button-background-color: var(--apollon-background, white);
 }
 .react-flow__controls-button {
   background: none;
@@ -172,8 +145,8 @@ svg.react-flow__connectionline {
 }
 
 .control-button {
-  background-color: var(--apollon-background);
-  border: 1px solid var(--apollon-gray-variant);
+  background-color: var(--apollon-background, white);
+  border: 1px solid var(--apollon-gray-variant, #495057);
   border-radius: 8px;
   padding: 6px 8px;
   cursor: pointer;
@@ -189,7 +162,7 @@ svg.react-flow__connectionline {
 }
 
 .control-button:hover:not(.disabled) {
-  background-color: var(--apollon-background-variant);
+  background-color: var(--apollon-background-variant, #f8f9fa);
 }
 
 .control-button.disabled {
@@ -198,9 +171,7 @@ svg.react-flow__connectionline {
 }
 
 .control-button.disabled:hover {
-  background-color: var(
-    --apollon-background
-  ); /* Prevent hover effect when disabled */
+  background-color: var(--apollon-background, white);
 }
 
 .horizontally-not-resizable .react-flow__resize-control.top.line:hover {
@@ -216,17 +187,17 @@ svg.react-flow__connectionline {
   cursor: grab;
 }
 
-.MuiSelect-select {
-  color: var(--apollon-primary-contrast) !important;
+.apollon-editor .MuiSelect-select {
+  color: var(--apollon-primary-contrast, #000000) !important;
 }
-.MuiFormLabel-root {
-  color: var(--apollon-primary-contrast) !important;
+.apollon-editor .MuiFormLabel-root {
+  color: var(--apollon-primary-contrast, #000000) !important;
 }
-.MuiOutlinedInput-notchedOutline {
-  border-color: var(--apollon-primary-contrast) !important;
+.apollon-editor .MuiOutlinedInput-notchedOutline {
+  border-color: var(--apollon-primary-contrast, #000000) !important;
 }
-.MuiSvgIcon-root {
-  color: var(--apollon-primary-contrast) !important;
+.apollon-editor .MuiSvgIcon-root {
+  color: var(--apollon-primary-contrast, #000000) !important;
 }
 .scroll-overlay {
   position: absolute;
@@ -254,8 +225,8 @@ svg.react-flow__connectionline {
 }
 
 .scroll-overlay-hint-content {
-  background-color: var(--apollon-background);
-  border: 2px solid var(--apollon-primary);
+  background-color: var(--apollon-background, white);
+  border: 2px solid var(--apollon-primary, #3e8acc);
   border-radius: 8px;
   padding: 16px 24px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
@@ -266,7 +237,7 @@ svg.react-flow__connectionline {
 
 .scroll-overlay-hint-text {
   margin: 0;
-  color: var(--apollon-primary);
+  color: var(--apollon-primary, #3e8acc);
   font-weight: 600;
   font-size: 14px;
   text-align: center;


### PR DESCRIPTION
## Problem

The library's `app.css` declared all `--apollon-*` CSS custom properties on `:root` with hardcoded light-mode defaults:

```css
:root {
  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
  line-height: 1.5;
  font-weight: 400;
  --apollon-background: white;
  --apollon-primary-contrast: #000000;
  /* ... 20+ more variables */
}
```

This caused two issues:

1. **Dark mode broken in host apps.** When Artemis set `--apollon-background` on `html` for dark mode, the `:root` declaration silently won due to CSS specificity (`:root` is `0,1,0` vs `html` at `0,0,1`). The editor always rendered in light mode regardless of host theme. Nodes appeared as black rectangles in assessment views.

2. **Global style pollution.** The `:root` block set `font-family`, `line-height`, and `font-weight` globally, overriding the host application's typography. These were leftover from Vite's default scaffolding and don't belong in a library.

Additionally, MUI Popovers were portaled to `document.body` by default, placing them outside the themed container and preventing them from inheriting any theme variables.

## Solution

**Remove all CSS variable declarations from the library.** Instead, add inline fallback values to every `var()` usage:

```css
/* Before — blocks host overrides */
:root { --apollon-background: white; }
.control-button { background-color: var(--apollon-background); }

/* After — host overrides cascade naturally */
.control-button { background-color: var(--apollon-background, white); }
```

This is the only CSS approach that simultaneously:
- Provides sensible defaults when no host theme is set
- Allows host apps to override via CSS variables on any ancestor (`html`, `body`, a wrapper div)
- Works in all browsers today

### Why not put defaults on `.apollon-editor` or use `@layer`?

CSS custom properties set directly on an element **always** win over inherited values, regardless of ancestor specificity. So `.apollon-editor { --apollon-background: white; }` would block overrides from `html` just as badly as `:root` did. CSS `@layer` affects cascade priority but not inheritance — same problem. The `var()` fallback parameter is the designed mechanism for this.

## Changes

**`app.css`**
- Removed `:root` block (variable declarations + global font overrides)
- Added fallback values to all `var(--apollon-*)` usages
- Scoped MUI selectors (`.MuiSelect-select`, etc.) to `.apollon-editor` to avoid polluting host app
- Moved `--xy-controls-button-background-color` into `.react-flow` block

**`App.tsx`**
- Added `className="apollon-editor"` to wrapper div (needed for MUI selector scoping and popover container resolution)

**`GenericPopover.tsx`**
- Set MUI `Popover` `container` to nearest `.apollon-editor` ancestor, so popover portals inherit theme variables

**29 component files**
- Added fallback values to all `var(--apollon-*)` inline style usages

## How host apps customize themes

Two mechanisms, both still work:

1. **CSS variables** — set on any ancestor element:
   ```css
   html { --apollon-background: #181a18; --apollon-primary-contrast: white; }
   ```
   Values cascade via inheritance. The `var()` fallbacks are only used when no ancestor defines the variable.

2. **`theme` option** — passed to the `ApollonEditor` constructor:
   ```ts
   new ApollonEditor(element, {
     theme: { color: { background: '#181a18', primaryContrast: '#ffffff' } }
   });
   ```
   Programmatic override that replaces the `var()` strings entirely.

## Test plan

- [ ] Light mode in standalone app renders unchanged
- [ ] Dark mode toggle in standalone app applies to editor, sidebar, controls, and popovers
- [ ] Artemis dark mode renders the Apollon editor with correct theme colors
- [ ] MUI popovers (edit node, give/see feedback) use correct theme colors in both modes
- [ ] Drag-and-drop from sidebar still works
- [ ] SVG export produces correct colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)