### PR TITLE
fix: edge type theme issue

### DIFF
--- a/library/lib/components/svgs/edges/InlineMarker.tsx
+++ b/library/lib/components/svgs/edges/InlineMarker.tsx
@@ -33,6 +33,8 @@ export interface MarkerProps {
 const isMarkerId = (id: string): id is keyof typeof MARKER_CONFIGS =>
   id in MARKER_CONFIGS
 
+const THEME_BACKGROUND_COLOR = "var(--apollon-background, #ffffff)"
+
 /**
  * Extract marker ID from a url() reference.
  * e.g., "url(#black-arrow)" -> "black-arrow"
@@ -117,7 +119,7 @@ export function InlineMarker({
       return (
         <path
           d={`M${tip.x},${tip.y} L${left.x},${left.y} L${right.x},${right.y} Z`}
-          fill={filled ? strokeColor : FILL_COLOR}
+          fill={filled ? strokeColor : THEME_BACKGROUND_COLOR}
           stroke={strokeColor}
           strokeWidth={strokeW}
           data-inline-marker="true"
@@ -181,7 +183,7 @@ export function InlineMarker({
       return (
         <path
           d={`M${front.x},${front.y} L${right.x},${right.y} L${back.x},${back.y} L${left.x},${left.y} Z`}
-          fill={filled ? strokeColor : FILL_COLOR}
+          fill={filled ? strokeColor : THEME_BACKGROUND_COLOR}
           stroke={strokeColor}
           strokeWidth={strokeW}
           data-inline-marker="true"

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
     },
     "library": {
       "name": "@tumaet/apollon",
-      "version": "4.2.12",
+      "version": "4.2.14",
       "dependencies": {
         "@emotion/react": "11.11.1",
         "@emotion/styled": "11.11.0",


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

- [ ] I linked PR with a related issue
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->


### Description

<!-- Describe your changes in detail -->
Edge type was using static color for Aggregation(white-rhombus and triangle)
### Steps for Testing

<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a Class Diagram
2. Add Class nodes
3. Link the two class nodes with an edge type (aggregation) another with (composition)
4. Switch between (Light/Dark) modes

### Screenshots
<img width="600" height="600" alt="Screenshot 2026-04-08 at 14 04 44" src="https://github.com/user-attachments/assets/56c20f0b-eccc-4bce-8b45-7ba7ead26749" />
<img width="600" height="600" alt="Screenshot 2026-04-08 at 14 04 50" src="https://github.com/user-attachments/assets/3b322d4c-1aac-4051-b162-a032b4355915" />

<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
