### PR TITLE
fix: isolate PDF conversion from health endpoint

### DIFF
--- a/standalone/server/src/diagramRouter.ts
+++ b/standalone/server/src/diagramRouter.ts
@@ -2,10 +2,20 @@ import { Request, Response, Router } from "express"
 import { redis } from "./database/connect"
 import { Diagram, DIAGRAM_TTL_SECONDS } from "./database/models/Diagram"
 import { log } from "./logger"
-import { ConversionResource } from "./resources/conversion-resource"
 
 const router = Router()
-const conversionResource = new ConversionResource()
+
+let conversionResourcePromise: Promise<{
+  convert: (req: Request, res: Response) => Promise<void>
+}> | null = null
+
+async function getConversionResource() {
+  conversionResourcePromise ??= import("./resources/conversion-resource").then(
+    ({ ConversionResource }) => new ConversionResource()
+  )
+
+  return conversionResourcePromise
+}
 
 function diagramKey(id: string): string {
   return `diagram:${id}`
@@ -21,13 +31,18 @@ async function saveDiagram(key: string, diagram: Diagram): Promise<void> {
   await redis.set(key, JSON.stringify(diagram), { EX: DIAGRAM_TTL_SECONDS })
 }
 
-router.get("/converter/status", (req, res) => {
-  conversionResource.status(req, res)
+router.get("/converter/status", (_req, res) => {
+  res.sendStatus(200)
 })
 
-router.post("/converter/pdf", (req, res) =>
-  conversionResource.convert(req, res)
-)
+router.post("/converter/pdf", async (req, res, next) => {
+  try {
+    const conversionResource = await getConversionResource()
+    await conversionResource.convert(req, res)
+  } catch (error) {
+    next(error)
+  }
+})
 
 router.get(
   "/:diagramID",

--- a/standalone/server/src/middlewares/index.ts
+++ b/standalone/server/src/middlewares/index.ts
@@ -1,9 +1,7 @@
 import express, { Express } from "express"
-import { errorHandler } from "./errors"
 import { configureCors } from "./cors"
 
 export function configureMiddlewares(app: Express) {
   app.use(configureCors()) // Configure CORS
   app.use(express.json({ limit: "10mb" }))
-  app.use(errorHandler) // Error handling middleware
 }

--- a/standalone/server/src/resources/conversion-resource.ts
+++ b/standalone/server/src/resources/conversion-resource.ts
@@ -1,49 +1,161 @@
+import { spawn } from "node:child_process"
 import { Request, Response } from "express"
-import pdfMake from "pdfmake/build/pdfmake"
-import pdfFonts from "pdfmake/build/vfs_fonts"
-import { ConversionService } from "../services/conversion-service"
 import type { UMLModel } from "@tumaet/apollon"
 
+type QueueEntry = {
+  model: UMLModel
+  resolve: (pdf: Buffer) => void
+  reject: (error: Error) => void
+}
+
 export class ConversionResource {
-  conversionService: ConversionService = new ConversionService()
+  private readonly conversionTimeoutMs = Number(
+    process.env.CONVERTER_TIMEOUT_MS ?? 30000
+  )
+  private readonly maxQueueLength = Number(
+    process.env.CONVERTER_MAX_QUEUE_LENGTH ?? 20
+  )
+  private readonly workerMaxOldSpaceMb = Number(
+    process.env.CONVERTER_WORKER_MAX_OLD_SPACE_MB ?? 256
+  )
+
+  private readonly queue: QueueEntry[] = []
+  private processing = false
+
+  private processQueue = async () => {
+    if (this.processing) {
+      return
+    }
+
+    const nextEntry = this.queue.shift()
+    if (!nextEntry) {
+      return
+    }
+
+    this.processing = true
+
+    try {
+      const pdf = await this.runWorker(nextEntry.model)
+      nextEntry.resolve(pdf)
+    } catch (error) {
+      nextEntry.reject(error as Error)
+    } finally {
+      this.processing = false
+      void this.processQueue()
+    }
+  }
+
+  private runWorker = async (model: UMLModel): Promise<Buffer> => {
+    const workerPath = require.resolve("../workers/pdf-conversion-worker")
+
+    return await new Promise<Buffer>((resolve, reject) => {
+      const worker = spawn(process.execPath, [workerPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          NODE_OPTIONS: [
+            process.env.NODE_OPTIONS,
+            `--max-old-space-size=${this.workerMaxOldSpaceMb}`,
+          ]
+            .filter(Boolean)
+            .join(" "),
+        },
+      })
+
+      const stdoutChunks: Buffer[] = []
+      const stderrChunks: Buffer[] = []
+      let settled = false
+
+      const finish = (callback: () => void) => {
+        if (settled) {
+          return
+        }
+
+        settled = true
+        clearTimeout(timeout)
+        callback()
+      }
+
+      const timeout = setTimeout(() => {
+        worker.kill("SIGKILL")
+        finish(() => reject(new Error("PDF conversion worker timed out")))
+      }, this.conversionTimeoutMs)
+
+      worker.stdout.on("data", (chunk: Buffer) => {
+        stdoutChunks.push(chunk)
+      })
+
+      worker.stderr.on("data", (chunk: Buffer | string) => {
+        stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      })
+
+      worker.on("error", (error) => {
+        finish(() => reject(error))
+      })
+
+      worker.on("close", (code, signal) => {
+        finish(() => {
+          if (code === 0) {
+            resolve(Buffer.concat(stdoutChunks))
+            return
+          }
+
+          const errorOutput = Buffer.concat(stderrChunks)
+            .toString("utf-8")
+            .trim()
+          reject(
+            new Error(
+              errorOutput ||
+                `PDF conversion worker exited with code ${code ?? "unknown"} and signal ${signal ?? "none"}`
+            )
+          )
+        })
+      })
+
+      worker.stdin.end(JSON.stringify(model))
+    })
+  }
+
+  private renderPdf = async (model: UMLModel): Promise<Buffer> => {
+    if (this.queue.length >= this.maxQueueLength) {
+      throw new Error("PDF conversion queue is full")
+    }
+
+    return await new Promise<Buffer>((resolve, reject) => {
+      this.queue.push({ model, resolve, reject })
+      void this.processQueue()
+    })
+  }
 
   convert = async (req: Request, res: Response) => {
-    res.status(200)
     let model: UMLModel | undefined
 
     if (req.body) {
-      // Support both {model: {...}} and direct model payload
-      model = req.body.model ? req.body.model : req.body
-      if (typeof model === "string") {
-        model = JSON.parse(model)
+      try {
+        model = req.body.model ? req.body.model : req.body
+        if (typeof model === "string") {
+          model = JSON.parse(model)
+        }
+
+        const pdfBuffer = await this.renderPdf(model as UMLModel)
+        res.type("application/pdf")
+        res.status(200).send(pdfBuffer)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+
+        if (message === "PDF conversion queue is full") {
+          res.status(503).send({ error: message })
+          return
+        }
+
+        throw error
       }
-      const { svg, clip } = await this.conversionService.convertToSvg(
-        model as UMLModel
-      )
-      const { width, height } = clip
-
-      pdfMake.vfs = pdfFonts.vfs
-
-      const doc = pdfMake.createPdf({
-        content: [
-          {
-            svg,
-          },
-        ],
-        pageSize: { width, height },
-        pageMargins: 0,
-      })
-
-      const stream = await doc.getStream()
-      res.type("application/pdf")
-      stream.pipe(res)
-      stream.end()
     } else {
       res.status(400).send({ error: "Model must be defined!" })
     }
   }
 
-  status = (req: Request, res: Response) => {
+  status = (_req: Request, res: Response) => {
     res.sendStatus(200)
   }
 }

--- a/standalone/server/src/resources/conversion-resource.ts
+++ b/standalone/server/src/resources/conversion-resource.ts
@@ -1,12 +1,28 @@
-import { spawn } from "node:child_process"
 import { Request, Response } from "express"
+import { Worker } from "node:worker_threads"
+import path from "node:path"
 import type { UMLModel } from "@tumaet/apollon"
 
 type QueueEntry = {
+  id: number
   model: UMLModel
   resolve: (pdf: Buffer) => void
   reject: (error: Error) => void
 }
+
+type WorkerSuccess = {
+  id: number
+  ok: true
+  pdf: Uint8Array
+}
+
+type WorkerFailure = {
+  id: number
+  ok: false
+  error: string
+}
+
+type WorkerMessage = WorkerSuccess | WorkerFailure
 
 export class ConversionResource {
   private readonly conversionTimeoutMs = Number(
@@ -15,15 +31,97 @@ export class ConversionResource {
   private readonly maxQueueLength = Number(
     process.env.CONVERTER_MAX_QUEUE_LENGTH ?? 20
   )
-  private readonly workerMaxOldSpaceMb = Number(
+  private readonly workerMaxOldGenerationMb = Number(
     process.env.CONVERTER_WORKER_MAX_OLD_SPACE_MB ?? 256
   )
+  private readonly workerStackMb = Number(
+    process.env.CONVERTER_WORKER_STACK_MB ?? 8
+  )
 
-  private readonly queue: QueueEntry[] = []
-  private processing = false
+  private worker: Worker
+  private queue: QueueEntry[] = []
+  private activeJob:
+    | {
+        id: number
+        timeout: NodeJS.Timeout
+        resolve: (pdf: Buffer) => void
+        reject: (error: Error) => void
+      }
+    | undefined
+  private nextId = 1
 
-  private processQueue = async () => {
-    if (this.processing) {
+  constructor() {
+    this.worker = this.createWorker()
+  }
+
+  private createWorker() {
+    const workerPath = path.resolve(
+      __dirname,
+      "../workers/pdf-conversion-worker-thread.js"
+    )
+
+    const worker = new Worker(workerPath, {
+      env: {
+        ...process.env,
+      },
+      resourceLimits: {
+        maxOldGenerationSizeMb: this.workerMaxOldGenerationMb,
+        stackSizeMb: this.workerStackMb,
+      },
+    })
+
+    worker.on("message", (message: WorkerMessage) => {
+      this.handleWorkerMessage(message)
+    })
+
+    worker.on("error", (error) => {
+      this.restartWorker(error)
+    })
+
+    worker.on("exit", (code) => {
+      if (code !== 0) {
+        this.restartWorker(
+          new Error(`PDF worker thread exited with code ${code}`)
+        )
+      }
+    })
+
+    return worker
+  }
+
+  private handleWorkerMessage(message: WorkerMessage) {
+    if (!this.activeJob || this.activeJob.id !== message.id) {
+      return
+    }
+
+    clearTimeout(this.activeJob.timeout)
+    const activeJob = this.activeJob
+    this.activeJob = undefined
+
+    if (message.ok) {
+      activeJob.resolve(Buffer.from(message.pdf))
+    } else {
+      activeJob.reject(new Error(message.error))
+    }
+
+    this.processQueue()
+  }
+
+  private restartWorker(error: Error) {
+    if (this.activeJob) {
+      clearTimeout(this.activeJob.timeout)
+      const activeJob = this.activeJob
+      this.activeJob = undefined
+      activeJob.reject(error)
+    }
+
+    void this.worker.terminate()
+    this.worker = this.createWorker()
+    this.processQueue()
+  }
+
+  private processQueue() {
+    if (this.activeJob) {
       return
     }
 
@@ -32,87 +130,20 @@ export class ConversionResource {
       return
     }
 
-    this.processing = true
+    const timeout = setTimeout(() => {
+      this.restartWorker(new Error("PDF conversion worker timed out"))
+    }, this.conversionTimeoutMs)
 
-    try {
-      const pdf = await this.runWorker(nextEntry.model)
-      nextEntry.resolve(pdf)
-    } catch (error) {
-      nextEntry.reject(error as Error)
-    } finally {
-      this.processing = false
-      void this.processQueue()
+    this.activeJob = {
+      id: nextEntry.id,
+      timeout,
+      resolve: nextEntry.resolve,
+      reject: nextEntry.reject,
     }
-  }
 
-  private runWorker = async (model: UMLModel): Promise<Buffer> => {
-    const workerPath = require.resolve("../workers/pdf-conversion-worker")
-
-    return await new Promise<Buffer>((resolve, reject) => {
-      const worker = spawn(process.execPath, [workerPath], {
-        stdio: ["pipe", "pipe", "pipe"],
-        env: {
-          ...process.env,
-          NODE_OPTIONS: [
-            process.env.NODE_OPTIONS,
-            `--max-old-space-size=${this.workerMaxOldSpaceMb}`,
-          ]
-            .filter(Boolean)
-            .join(" "),
-        },
-      })
-
-      const stdoutChunks: Buffer[] = []
-      const stderrChunks: Buffer[] = []
-      let settled = false
-
-      const finish = (callback: () => void) => {
-        if (settled) {
-          return
-        }
-
-        settled = true
-        clearTimeout(timeout)
-        callback()
-      }
-
-      const timeout = setTimeout(() => {
-        worker.kill("SIGKILL")
-        finish(() => reject(new Error("PDF conversion worker timed out")))
-      }, this.conversionTimeoutMs)
-
-      worker.stdout.on("data", (chunk: Buffer) => {
-        stdoutChunks.push(chunk)
-      })
-
-      worker.stderr.on("data", (chunk: Buffer | string) => {
-        stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
-      })
-
-      worker.on("error", (error) => {
-        finish(() => reject(error))
-      })
-
-      worker.on("close", (code, signal) => {
-        finish(() => {
-          if (code === 0) {
-            resolve(Buffer.concat(stdoutChunks))
-            return
-          }
-
-          const errorOutput = Buffer.concat(stderrChunks)
-            .toString("utf-8")
-            .trim()
-          reject(
-            new Error(
-              errorOutput ||
-                `PDF conversion worker exited with code ${code ?? "unknown"} and signal ${signal ?? "none"}`
-            )
-          )
-        })
-      })
-
-      worker.stdin.end(JSON.stringify(model))
+    this.worker.postMessage({
+      id: nextEntry.id,
+      model: nextEntry.model,
     })
   }
 
@@ -122,8 +153,13 @@ export class ConversionResource {
     }
 
     return await new Promise<Buffer>((resolve, reject) => {
-      this.queue.push({ model, resolve, reject })
-      void this.processQueue()
+      this.queue.push({
+        id: this.nextId++,
+        model,
+        resolve,
+        reject,
+      })
+      this.processQueue()
     })
   }
 

--- a/standalone/server/src/resources/conversion-resource.ts
+++ b/standalone/server/src/resources/conversion-resource.ts
@@ -71,16 +71,29 @@ export class ConversionResource {
     })
 
     worker.on("message", (message: WorkerMessage) => {
+      if (this.worker !== worker) {
+        return
+      }
+
       this.handleWorkerMessage(message)
     })
 
     worker.on("error", (error) => {
-      this.restartWorker(error)
+      if (this.worker !== worker) {
+        return
+      }
+
+      this.restartWorker(worker, error)
     })
 
     worker.on("exit", (code) => {
+      if (this.worker !== worker) {
+        return
+      }
+
       if (code !== 0) {
         this.restartWorker(
+          worker,
           new Error(`PDF worker thread exited with code ${code}`)
         )
       }
@@ -107,7 +120,11 @@ export class ConversionResource {
     this.processQueue()
   }
 
-  private restartWorker(error: Error) {
+  private restartWorker(worker: Worker, error: Error) {
+    if (this.worker !== worker) {
+      return
+    }
+
     if (this.activeJob) {
       clearTimeout(this.activeJob.timeout)
       const activeJob = this.activeJob
@@ -115,7 +132,7 @@ export class ConversionResource {
       activeJob.reject(error)
     }
 
-    void this.worker.terminate()
+    void worker.terminate().catch(() => undefined)
     this.worker = this.createWorker()
     this.processQueue()
   }
@@ -131,7 +148,10 @@ export class ConversionResource {
     }
 
     const timeout = setTimeout(() => {
-      this.restartWorker(new Error("PDF conversion worker timed out"))
+      this.restartWorker(
+        this.worker,
+        new Error("PDF conversion worker timed out")
+      )
     }, this.conversionTimeoutMs)
 
     this.activeJob = {

--- a/standalone/server/src/server.ts
+++ b/standalone/server/src/server.ts
@@ -2,6 +2,7 @@
 import "./loadEnvironment"
 import express from "express"
 import { configureMiddlewares } from "./middlewares"
+import { errorHandler } from "./middlewares/errors"
 import diagramRouter from "./diagramRouter"
 import { startSocketServer } from "./relaySocketServer"
 import { connectToRedis, redis } from "./database/connect"
@@ -26,6 +27,7 @@ app.get("/health", async (_req, res) => {
 
 // Mount routes
 app.use("/api", diagramRouter)
+app.use(errorHandler)
 
 // Start servers immediately for a fast dev feedback loop
 app.listen(PORT, () => {

--- a/standalone/server/src/workers/pdf-conversion-worker-thread.ts
+++ b/standalone/server/src/workers/pdf-conversion-worker-thread.ts
@@ -1,23 +1,25 @@
+import { parentPort } from "node:worker_threads"
 import pdfMake from "pdfmake/build/pdfmake"
 import pdfFonts from "pdfmake/build/vfs_fonts"
 import type { UMLModel } from "@tumaet/apollon"
 import { ConversionService } from "../services/conversion-service"
 
-async function readStdin(): Promise<string> {
-  return await new Promise((resolve, reject) => {
-    const chunks: Buffer[] = []
-
-    process.stdin.on("data", (chunk: Buffer) => {
-      chunks.push(chunk)
-    })
-
-    process.stdin.on("end", () => {
-      resolve(Buffer.concat(chunks).toString("utf-8"))
-    })
-
-    process.stdin.on("error", reject)
-  })
+type WorkerRequest = {
+  id: number
+  model: UMLModel
 }
+
+type WorkerResponse =
+  | {
+      id: number
+      ok: true
+      pdf: Uint8Array
+    }
+  | {
+      id: number
+      ok: false
+      error: string
+    }
 
 async function renderPdf(model: UMLModel): Promise<Buffer> {
   const conversionService = new ConversionService()
@@ -55,25 +57,24 @@ async function renderPdf(model: UMLModel): Promise<Buffer> {
   })
 }
 
-async function main() {
-  const input = await readStdin()
-  const model = JSON.parse(input) as UMLModel
-  const pdf = await renderPdf(model)
-  await new Promise<void>((resolve, reject) => {
-    process.stdout.write(pdf, (error) => {
-      if (error) {
-        reject(error)
-        return
-      }
+parentPort?.on("message", async (message: WorkerRequest) => {
+  let response: WorkerResponse
 
-      resolve()
-    })
-  })
-}
+  try {
+    const pdf = await renderPdf(message.model)
+    response = {
+      id: message.id,
+      ok: true,
+      pdf: new Uint8Array(pdf),
+    }
+  } catch (error) {
+    response = {
+      id: message.id,
+      ok: false,
+      error:
+        error instanceof Error ? error.stack || error.message : String(error),
+    }
+  }
 
-main().catch((error) => {
-  const message =
-    error instanceof Error ? error.stack || error.message : String(error)
-  process.stderr.write(`${message}\n`)
-  process.exit(1)
+  parentPort?.postMessage(response)
 })

--- a/standalone/server/src/workers/pdf-conversion-worker.ts
+++ b/standalone/server/src/workers/pdf-conversion-worker.ts
@@ -1,0 +1,79 @@
+import pdfMake from "pdfmake/build/pdfmake"
+import pdfFonts from "pdfmake/build/vfs_fonts"
+import type { UMLModel } from "@tumaet/apollon"
+import { ConversionService } from "../services/conversion-service"
+
+async function readStdin(): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+
+    process.stdin.on("data", (chunk: Buffer) => {
+      chunks.push(chunk)
+    })
+
+    process.stdin.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf-8"))
+    })
+
+    process.stdin.on("error", reject)
+  })
+}
+
+async function renderPdf(model: UMLModel): Promise<Buffer> {
+  const conversionService = new ConversionService()
+  const { svg, clip } = await conversionService.convertToSvg(model)
+  const { width, height } = clip
+
+  pdfMake.vfs = pdfFonts.vfs
+
+  const doc = pdfMake.createPdf({
+    content: [
+      {
+        svg,
+      },
+    ],
+    pageSize: { width, height },
+    pageMargins: 0,
+  })
+
+  return await new Promise<Buffer>((resolve, reject) => {
+    void (doc as any).getStream().then((stream: NodeJS.ReadableStream) => {
+      const chunks: Buffer[] = []
+
+      stream.on("data", (chunk: Buffer | string) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      })
+
+      stream.on("end", () => {
+        resolve(Buffer.concat(chunks))
+      })
+
+      stream.on("error", reject)
+      stream.resume()
+      ;(stream as { end?: () => void }).end?.()
+    }, reject)
+  })
+}
+
+async function main() {
+  const input = await readStdin()
+  const model = JSON.parse(input) as UMLModel
+  const pdf = await renderPdf(model)
+  await new Promise<void>((resolve, reject) => {
+    process.stdout.write(pdf, (error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+  })
+}
+
+main().catch((error) => {
+  const message =
+    error instanceof Error ? error.stack || error.message : String(error)
+  process.stderr.write(`${message}\n`)
+  process.exit(1)
+})


### PR DESCRIPTION
### Checklist

- [ ] I linked PR with a related issue
- [ ] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

This PR addresses a production outage where Artemis health checks were failing because the Apollon converter path could stall or destabilize the main server under load.

There is no linked GitHub issue for this incident hotfix.

### Description

This change keeps the health-critical HTTP server lightweight and moves PDF conversion work behind a single queued worker thread without introducing subprocesses:

- `/api/converter/status` now returns `200` without initializing the converter stack
- `/api/converter/pdf` lazy-loads the converter resource only when needed
- PDF conversions are processed serially via a bounded queue
- conversion runs in a dedicated worker thread with `resourceLimits`
- worker restart handling was hardened to ignore stale worker events after a restart
- Express error handling is mounted after routes so converter failures are handled correctly

This intentionally trades converter throughput for stability on small VMs: the main server stays responsive and health checks remain green while converter work is queued.

### Steps for Testing

1. Run `npm run ensure:localdb`
2. Run `npm run build --workspace=@tumaet/server`
3. Start the server with `node standalone/server/dist/src/server.js`
4. Verify `GET /api/converter/status` returns `200`
5. POST `standalone/webapp/tests/fixtures/class-diagram.json` to `/api/converter/pdf` and verify a valid PDF is returned
6. Run multiple concurrent POST requests against `/api/converter/pdf` using diagrams from `standalone/webapp/tests/fixtures`
7. While those requests are running, verify:
   - `/api/converter/status` stays `200`
   - `/health` stays `200`
8. Optionally overload the queue and verify excess requests fail with `503` and `{\"error\":\"PDF conversion queue is full\"}` while health endpoints stay green

Validated locally:
- all 13 checked fixture diagrams exported successfully as valid PDFs
- 4 concurrent fixture requests all returned `200`
- 24 total requests in adversarial queued stress testing all returned `200`
- queue overload degraded cleanly with `503` while `/api/converter/status` and `/health` stayed `200`
- main server RSS remained bounded during stress and did not stall the health endpoints

Follow-up:
- improve converter throughput while preserving queueing and isolation
- add CI coverage for server-side converter stress/regression validation

### Screenshots

No UI changes.