### PR TITLE
fix: restrict component interface connectors to NSEW

### DIFF
--- a/library/lib/nodes/componentDiagram/ComponentInterface.tsx
+++ b/library/lib/nodes/componentDiagram/ComponentInterface.tsx
@@ -1,5 +1,5 @@
 import { NodeProps, type Node } from "@xyflow/react"
-import { DefaultNodeWrapper, HandleId } from "../wrappers"
+import { DefaultNodeWrapper, FOUR_WAY_HANDLES_PRESET } from "../wrappers"
 import { DefaultNodeProps } from "@/types"
 import { useRef } from "react"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -25,16 +25,7 @@ export function ComponentInterface({
       width={width}
       height={height}
       elementId={id}
-      hiddenHandles={[
-        HandleId.TopLeft,
-        HandleId.TopRight,
-        HandleId.RightTop,
-        HandleId.RightBottom,
-        HandleId.BottomRight,
-        HandleId.BottomLeft,
-        HandleId.LeftBottom,
-        HandleId.LeftTop,
-      ]}
+      hiddenHandles={FOUR_WAY_HANDLES_PRESET}
     >
       <NodeToolbar elementId={id} />
 


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

- [ ] I linked PR with a related issue
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

The circular `Interface` node in the Component Diagram exposed more
connectors than intended. While only the four primary directional
handles (top / right / bottom / left) were visually rendered via the
`apollon-arc-handle` bands, the eight intermediate handles
(`top-mid-left`, `top-mid-right`, `right-mid-top`, `right-mid-bottom`,
`bottom-mid-left`, `bottom-mid-right`, `left-mid-top`, `left-mid-bottom`)
remained in the DOM as connectable drop targets, so users could drop
edges onto positions between the NSEW handles. Other circular nodes
(BPMN events, gateway, SFC transition branch) already use
`FOUR_WAY_HANDLES_PRESET` to avoid this.

### Description

`ComponentInterface` now passes `FOUR_WAY_HANDLES_PRESET` to
`DefaultNodeWrapper` instead of a hand-written list that only hid the
eight corner handles. This hides all sixteen non-NSEW handles, leaving
exactly four connectors: north, south, east, west.

### Steps for Testing

1. Start the library dev server (`npm run dev` in `library/`).
2. Open the Component Diagram and drop an `Interface` element on the canvas.
3. Hover the Interface — verify only four connector bands appear (top, right, bottom, left).
4. Drag an edge from another node toward the Interface — verify drop targets snap only to the four cardinal positions, not to intermediate points along each side.
5. Load an existing diagram that uses Interfaces to confirm existing edges still render correctly.

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. -->