### PR TITLE
chore: bump patch version to 4.2.17

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tumaet/apollon",
-  "version": "4.2.16",
+  "version": "4.2.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
     },
     "library": {
       "name": "@tumaet/apollon",
-      "version": "4.2.16",
+      "version": "4.2.17",
       "dependencies": {
         "@emotion/react": "11.11.1",
         "@emotion/styled": "11.11.0",


### PR DESCRIPTION
### Checklist

- [ ] I linked PR with a related issue
- [ ] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

Bump `@tumaet/apollon` from `4.2.16` to `4.2.17`. The release bundles
the fix from #597 (restrict component interface connectors to NSEW).
Version `4.2.17` has already been published to npm under the `latest`
tag.

### Description

- `library/package.json`: `4.2.16` → `4.2.17`
- Root `package-lock.json` updated for the workspace version bump

### Steps for Testing

1. `npm view @tumaet/apollon version` → should return `4.2.17`.
2. Install `@tumaet/apollon@4.2.17` in a consumer app and verify the Component Diagram's Interface only exposes four connectors (N/S/E/W).

### Screenshots

_No UI changes in this PR; the underlying UI fix ships with #597._