### PR TITLE
fix(proxy): replace broken caddy healthcheck and enable init

### DIFF
--- a/docker/compose.proxy.yml
+++ b/docker/compose.proxy.yml
@@ -3,6 +3,7 @@ services:
     image: caddy:2.9-alpine
     container_name: apollon-caddy
     restart: unless-stopped
+    init: true
     ports:
       - "80:80"
       - "443:443"

--- a/docker/compose.proxy.yml
+++ b/docker/compose.proxy.yml
@@ -25,9 +25,9 @@ services:
     security_opt:
       - no-new-privileges:true
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:80/"]
+      test: ["CMD", "caddy", "version"]
       interval: 30s
-      timeout: 3s
+      timeout: 10s
       retries: 3
 
 configs:


### PR DESCRIPTION
## Summary

The caddy container's healthcheck had two compounding bugs that together put the production host one memory spike from OOM. This PR fixes the root cause and adds a defense-in-depth belt.

## Evidence from production (apollon.aet.cit.tum.de)

`docker ps` showed `apollon-caddy ... Up 2 days (unhealthy)` — the healthcheck had been failing the whole time. Running it by hand:

```
$ docker exec apollon-caddy wget --no-verbose --tries=1 --spider http://localhost:80/
Connecting to localhost:80 ([::1]:80)
Connecting to localhost ([::1]:443)
...ssl3_read_bytes:tlsv1 alert internal error
ssl_client: SSL_connect
wget: error getting response: Connection reset by peer
exit 1
```

Inside the container, `ls /proc | grep -c ^[0-9]` = **7 653** — of which 7 649 were `[ssl_client] <defunct>` zombies parented to caddy (PID 1). Host available memory at the time: **83 MiB of 1.9 GiB**, with 387 MiB of swap in use. Restarting caddy brought the host from 1.7 GiB used back to 346 MiB.

## Root causes, in order

1. **Broken probe semantically** — `wget --spider http://localhost:80/` follows Caddy's HTTP→HTTPS redirect, and the resulting TLS handshake against `localhost:443` fails against the Let's Encrypt cert issued for `apollon.*.tum.de`. Every probe returned exit 1.
2. **Upstream busybox bug** — busybox `wget` forks `ssl_client` for HTTPS and exits without reaping it. Known, unfixed: [busybox #15967](https://lists.busybox.net/pipermail/busybox-cvs/2024-March/041777.html), same class of issue as [spinnaker#4479](https://github.com/spinnaker/spinnaker/issues/4479) and [gluetun#1494](https://github.com/qdm12/gluetun/issues/1494).
3. **Caddy-as-PID-1 doesn't reap** — with no init process, every orphaned `ssl_client` stayed a zombie. Math checks out: container up ~65 h / 30 s interval ≈ 7 800 probes ≈ 7 649 zombies.

## Fix

- Replace the healthcheck with `["CMD", "caddy", "version"]` — the [Caddy community-recommended pattern](https://caddy.community/t/what-is-the-best-practise-for-doing-a-health-check-for-caddy-containers/12995). No network, no fork-to-helper, no redirect, no `ssl_client`. Weaker semantically (tests the binary, not the listener) but a probe that never passes is strictly worse than a smaller one that tells the truth.
- Bump `timeout` to 10 s to match the community-recommended default.
- Keep `init: true` so docker-init (tini) is PID 1 and any future `exec`'d helper cannot accumulate zombies again. Same mechanism `app-server` already uses via its image's tini ENTRYPOINT.

Considered but rejected:
- `wget --max-redirect=0` — would fail on the 3xx that Caddy returns for healthy states.
- Hitting Caddy's admin endpoint at `:2019` — refused in this build, so not free.
- Adding a dedicated `/healthz` route in the Caddyfile — worth doing eventually, but requires a plain-HTTP listener that coexists with auto-HTTPS, and this PR should stay scoped to the incident.

## Test plan

- [ ] `docker compose -f docker/compose.proxy.yml up -d caddy && sleep 120 && docker inspect apollon-caddy --format '{{.State.Health.Status}}'` reports `healthy`
- [ ] `docker exec apollon-caddy sh -c 'ps -ef | grep -c defunct'` stays at 0 for 24 h
- [ ] After production rollout, `MemAvailable` on apollon.aet.cit.tum.de recovers and stays flat

## References

- [busybox #15967 — wget applet leaks defunct ssl_client](https://lists.busybox.net/pipermail/busybox-cvs/2024-March/041777.html)
- [Caddy community — healthcheck best practice](https://caddy.community/t/what-is-the-best-practise-for-doing-a-health-check-for-caddy-containers/12995)
- [gluetun#1494 — wget healthcheck → hundreds of zombie processes](https://github.com/qdm12/gluetun/issues/1494)
- [spinnaker#4479 — gate container creating defunct ssl_client](https://github.com/spinnaker/spinnaker/issues/4479)

🤖 Generated with [Claude Code](https://claude.com/claude-code)