### PR TITLE
ci: namespace standalone release tags as standalone-vX.Y.Z

### DIFF
--- a/.github/workflows/release-standalone.yml
+++ b/.github/workflows/release-standalone.yml
@@ -43,7 +43,7 @@ jobs:
             echo "::error::standalone version $WEBAPP is not strict SemVer MAJOR.MINOR.PATCH."
             exit 1
           fi
-          if gh release view "v$WEBAPP" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          if gh release view "standalone-v$WEBAPP" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "release=false" >> "$GITHUB_OUTPUT"
           else
             echo "release=true" >> "$GITHUB_OUTPUT"
@@ -92,8 +92,8 @@ jobs:
           VERSION: ${{ needs.check.outputs.version }}
           COMMIT_SHA: ${{ needs.check.outputs.sha }}
         run: |
-          gh release create "v${VERSION}" \
-            --title "v${VERSION}" \
+          gh release create "standalone-v${VERSION}" \
+            --title "standalone-v${VERSION}" \
             --target "$COMMIT_SHA" \
             --generate-notes \
             --notes "\`ghcr.io/ls1intum/apollon/apollon-{webapp,server}:${VERSION}\` — cosign-signed, retagged from \`sha-${COMMIT_SHA}\`."

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -51,7 +51,7 @@ jobs:
             LAST=$(git tag --list '@tumaet/apollon@*' --sort=-v:refname | head -n1)
             PATH_PATTERN=library/
           else
-            LAST=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+            LAST=$(git tag --list 'standalone-v*' --sort=-v:refname | head -n1)
             PATH_PATTERN=standalone/
           fi
           if [ -n "$LAST" ] && git diff --quiet "$LAST"..HEAD -- "$PATH_PATTERN"; then
@@ -153,13 +153,13 @@ jobs:
           Merging this PR publishes **both** artifacts automatically:
 
           - \`@tumaet/apollon@${LIB_VERSION}\` to npm (via \`Release Library\`)
-          - Docker images tagged \`${STANDALONE_VERSION}\` (via \`Release Standalone\`, patch-bumped so the new library code can be cut as a Docker release)
+          - \`standalone-v${STANDALONE_VERSION}\` — Docker images tagged \`${STANDALONE_VERSION}\` (via \`Release Standalone\`, mirrored so the new library code ships as a Docker release)
           PR_BODY
           else
             cat > /tmp/pr-body.md <<PR_BODY
           **Scope:** \`standalone\` (\`${BUMP}\`)
 
-          Merging this PR cuts the standalone release automatically — \`Release Standalone\` retags Docker images as \`${STANDALONE_VERSION}\` and creates the GitHub Release. The library is untouched.
+          Merging this PR cuts \`standalone-v${STANDALONE_VERSION}\` automatically — \`Release Standalone\` retags Docker images as \`${STANDALONE_VERSION}\` and creates the GitHub Release. The library is untouched.
           PR_BODY
           fi
 

--- a/docs/deployment/npm-publishing.md
+++ b/docs/deployment/npm-publishing.md
@@ -5,7 +5,9 @@ Two independently versioned artifacts, each with its own release workflow:
 | Artifact | Version source | Tag | Workflow |
 | -------- | -------------- | --- | -------- |
 | `@tumaet/apollon` (npm) | `library/package.json` | `@tumaet/apollon@X.Y.Z` | `release-library.yml` |
-| Standalone Docker images | `standalone/{webapp,server}/package.json` | `vX.Y.Z` | `release-standalone.yml` |
+| Standalone Docker images | `standalone/{webapp,server}/package.json` | `standalone-vX.Y.Z` | `release-standalone.yml` |
+
+Standalone tags are prefixed because plain `vX.Y.Z` tags collide with legacy Apollon releases on this repo's history.
 
 Both workflows trigger automatically when their version changes on `main`. There is **one** manual step per release: merge the bump PR.
 
@@ -16,7 +18,7 @@ Both workflows trigger automatically when their version changes on `main`. There
    - **`standalone`** bumps only `standalone/{webapp,server}/package.json`; the library is untouched.
 2. On merge:
    - `release-library.yml` fires when `library/package.json` changes: `npm publish --provenance` → tag `@tumaet/apollon@X.Y.Z` → GitHub Release. Skipped if the version is already on npm.
-   - `release-standalone.yml` fires after the push-to-main Docker build succeeds: retag `sha-<commit>` → `X.Y.Z` → cosign-sign → tag `vX.Y.Z` → GitHub Release. Staging is already running the same digest under the `sha-<commit>` tag from the push-to-main deploy, so no second deploy is needed. Skipped if a release for that version already exists.
+   - `release-standalone.yml` fires after the push-to-main Docker build succeeds: retag `sha-<commit>` → `X.Y.Z` → cosign-sign → tag `standalone-vX.Y.Z` → GitHub Release. Staging is already running the same digest under the `sha-<commit>` tag from the push-to-main deploy, so no second deploy is needed. Skipped if a release for that version already exists.
 3. Promote to production: Actions → **Deploy to Production** → `image-tag: X.Y.Z`.
 
 ## Verify a Docker image signature


### PR DESCRIPTION
Follow-up to #592. The first attempt to cut a \`v3.0.1\` standalone release (PR #609) correctly skipped — legacy Apollon already has \`v3.0.1\` (and a full \`v3.x\`/\`v4.x\` set) as library releases from the pre-rewrite era, so \`gh release view "v3.0.1"\` returned success and \`release-standalone.yml\` set \`release=false\`. Safe no-op, but every standalone bump would be one forever.

Fix: namespace standalone tags as \`standalone-vX.Y.Z\`. Symmetric with the library track's \`@tumaet/apollon@X.Y.Z\`. Docker image tag inside the registry stays \`<version>\` (no prefix) — that's what operators type into **Deploy to Production**; only the GitHub Release tag gets the prefix.

### Changes

- \`release-standalone.yml\`: \`gh release view\` / \`create\` now use \`standalone-v\${VERSION}\`.
- \`version-bump.yml\`: empty-bump guard walks \`standalone-v*\` tags instead of \`v*\`, and the auto-opened PR body references \`standalone-v\${STANDALONE_VERSION}\`.
- \`docs/deployment/npm-publishing.md\`: updated tag column, prose, and a one-liner explaining the prefix.

### Next test after merge

\`\`\`sh
gh workflow run version-bump.yml -f scope=standalone -f bump=patch
# → standalone/*/package.json bumped to 3.0.2
# → merge PR
# → release-standalone.yml creates `standalone-v3.0.2` — no collision
\`\`\`