### PR TITLE
ci: revert standalone- prefix, align standalone to library version (4.2.18)

### DIFF
--- a/.github/workflows/release-standalone.yml
+++ b/.github/workflows/release-standalone.yml
@@ -43,7 +43,7 @@ jobs:
             echo "::error::standalone version $WEBAPP is not strict SemVer MAJOR.MINOR.PATCH."
             exit 1
           fi
-          if gh release view "standalone-v$WEBAPP" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          if gh release view "v$WEBAPP" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "release=false" >> "$GITHUB_OUTPUT"
           else
             echo "release=true" >> "$GITHUB_OUTPUT"
@@ -92,8 +92,8 @@ jobs:
           VERSION: ${{ needs.check.outputs.version }}
           COMMIT_SHA: ${{ needs.check.outputs.sha }}
         run: |
-          gh release create "standalone-v${VERSION}" \
-            --title "standalone-v${VERSION}" \
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
             --target "$COMMIT_SHA" \
             --generate-notes \
             --notes "\`ghcr.io/ls1intum/apollon/apollon-{webapp,server}:${VERSION}\` — cosign-signed, retagged from \`sha-${COMMIT_SHA}\`."

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -51,7 +51,7 @@ jobs:
             LAST=$(git tag --list '@tumaet/apollon@*' --sort=-v:refname | head -n1)
             PATH_PATTERN=library/
           else
-            LAST=$(git tag --list 'standalone-v*' --sort=-v:refname | head -n1)
+            LAST=$(git tag --list 'v*' --sort=-v:refname | head -n1)
             PATH_PATTERN=standalone/
           fi
           if [ -n "$LAST" ] && git diff --quiet "$LAST"..HEAD -- "$PATH_PATTERN"; then
@@ -153,13 +153,13 @@ jobs:
           Merging this PR publishes **both** artifacts automatically:
 
           - \`@tumaet/apollon@${LIB_VERSION}\` to npm (via \`Release Library\`)
-          - \`standalone-v${STANDALONE_VERSION}\` — Docker images tagged \`${STANDALONE_VERSION}\` (via \`Release Standalone\`, mirrored so the new library code ships as a Docker release)
+          - \`v${STANDALONE_VERSION}\` — Docker images tagged \`${STANDALONE_VERSION}\` (via \`Release Standalone\`, mirrored so the new library code ships as a Docker release)
           PR_BODY
           else
             cat > /tmp/pr-body.md <<PR_BODY
           **Scope:** \`standalone\` (\`${BUMP}\`)
 
-          Merging this PR cuts \`standalone-v${STANDALONE_VERSION}\` automatically — \`Release Standalone\` retags Docker images as \`${STANDALONE_VERSION}\` and creates the GitHub Release. The library is untouched.
+          Merging this PR cuts \`v${STANDALONE_VERSION}\` automatically — \`Release Standalone\` retags Docker images as \`${STANDALONE_VERSION}\` and creates the GitHub Release. The library is untouched.
           PR_BODY
           fi
 

--- a/docs/deployment/npm-publishing.md
+++ b/docs/deployment/npm-publishing.md
@@ -5,9 +5,9 @@ Two independently versioned artifacts, each with its own release workflow:
 | Artifact | Version source | Tag | Workflow |
 | -------- | -------------- | --- | -------- |
 | `@tumaet/apollon` (npm) | `library/package.json` | `@tumaet/apollon@X.Y.Z` | `release-library.yml` |
-| Standalone Docker images | `standalone/{webapp,server}/package.json` | `standalone-vX.Y.Z` | `release-standalone.yml` |
+| Standalone Docker images | `standalone/{webapp,server}/package.json` | `vX.Y.Z` | `release-standalone.yml` |
 
-Standalone tags are prefixed because plain `vX.Y.Z` tags collide with legacy Apollon releases on this repo's history.
+Standalone starts at `4.2.18` (the library version at the time of the release-pipeline switchover). Future `vX.Y.Z` tags advance from there and do not collide with legacy tags.
 
 Both workflows trigger automatically when their version changes on `main`. There is **one** manual step per release: merge the bump PR.
 
@@ -18,7 +18,7 @@ Both workflows trigger automatically when their version changes on `main`. There
    - **`standalone`** bumps only `standalone/{webapp,server}/package.json`; the library is untouched.
 2. On merge:
    - `release-library.yml` fires when `library/package.json` changes: `npm publish --provenance` → tag `@tumaet/apollon@X.Y.Z` → GitHub Release. Skipped if the version is already on npm.
-   - `release-standalone.yml` fires after the push-to-main Docker build succeeds: retag `sha-<commit>` → `X.Y.Z` → cosign-sign → tag `standalone-vX.Y.Z` → GitHub Release. Staging is already running the same digest under the `sha-<commit>` tag from the push-to-main deploy, so no second deploy is needed. Skipped if a release for that version already exists.
+   - `release-standalone.yml` fires after the push-to-main Docker build succeeds: retag `sha-<commit>` → `X.Y.Z` → cosign-sign → tag `vX.Y.Z` → GitHub Release. Staging is already running the same digest under the `sha-<commit>` tag from the push-to-main deploy, so no second deploy is needed. Skipped if a release for that version already exists.
 3. Promote to production: Actions → **Deploy to Production** → `image-tag: X.Y.Z`.
 
 ## Verify a Docker image signature

--- a/package-lock.json
+++ b/package-lock.json
@@ -20452,7 +20452,7 @@
     },
     "standalone/server": {
       "name": "@tumaet/server",
-      "version": "3.0.2",
+      "version": "4.2.18",
       "license": "MIT",
       "dependencies": {
         "@tumaet/apollon": "*",
@@ -20715,7 +20715,7 @@
     },
     "standalone/webapp": {
       "name": "@tumaet/webapp",
-      "version": "3.0.2",
+      "version": "4.2.18",
       "dependencies": {
         "@mui/icons-material": "6.4.2",
         "@mui/material": "6.4.2",

--- a/standalone/server/package.json
+++ b/standalone/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tumaet/server",
-  "version": "3.0.2",
+  "version": "4.2.18",
   "private": true,
   "license": "MIT",
   "dependencies": {

--- a/standalone/webapp/package.json
+++ b/standalone/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tumaet/webapp",
   "private": true,
-  "version": "3.0.2",
+  "version": "4.2.18",
   "type": "module",
   "scripts": {
     "start": "vite",


### PR DESCRIPTION
Reverts the \`standalone-v*\` prefix introduced in #610. Aligns standalone to the library version (\`4.2.18\`) so plain \`vX.Y.Z\` tags advance forward without colliding with any legacy tag.

### Why

The prefix was papering over the actual issue: legacy Apollon tagged every library release as \`vX.Y.Z\` on this repo, so a standalone starting at \`3.0.0\` hit the \`v3.0.0\`/\`v3.0.1\`/... releases that already exist. Jumping standalone to \`4.2.18\` (matching the current library version) means the next standalone bump produces \`v4.2.19\`, which is free. All subsequent \`v4.2.x+\` tags are free too.

### Changes

- \`release-standalone.yml\`: \`gh release view\` / \`create\` back to \`v\${VERSION}\`.
- \`version-bump.yml\`: empty-bump guard walks \`v*\` tags; PR body references \`v\${STANDALONE_VERSION}\`.
- \`standalone/{webapp,server}/package.json\`: \`3.0.2\` → \`4.2.18\`.
- \`docs/deployment/npm-publishing.md\`: tag column + prose updated; one-liner explains the alignment.

### Cleanup after merge

Delete the two orphaned \`standalone-v3.0.1\` / \`standalone-v3.0.2\` releases cut during the end-to-end test.

### Optional follow-up (not in this PR)

Retag the existing legacy library releases \`v4.2.12\` and \`v4.2.18\` as \`@tumaet/apollon@4.2.12\` / \`@tumaet/apollon@4.2.18\` so the library tag namespace is consistent. Destructive; worth a separate decision.