### PR TITLE
fix(ci): bump npm to 11.5.1 in release-library for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -62,7 +62,7 @@ jobs:
           node-version: 22.14.0
           registry-url: https://registry.npmjs.org/
 
-      - run: npm install -g npm@11.1.0
+      - run: npm install -g npm@11.5.1 # 11.5.1+ required for npm OIDC trusted publishing
 
       - run: npm ci
 


### PR DESCRIPTION
The library publish workflow has been 404'ing on every attempt to publish \`@tumaet/apollon@4.2.19\` despite the npm trusted publisher being correctly configured on npmjs.com.

### Root cause

npm's OIDC trusted publishing support landed in npm CLI **11.5.1** (July 2025). The workflow pinned npm to \`11.1.0\`, which predates that support. Without OIDC support the publish falls back to token auth via \`NODE_AUTH_TOKEN\`, which \`actions/setup-node\` exports as the literal placeholder string \`XXXXX-XXXXX-XXXXX-XXXXX\` when no token is set. npm rejects that placeholder with a misleading \`404 '@tumaet/apollon@4.2.19' is not in this registry\`.

### Fix

Pin \`release-library.yml\` to \`npm@11.5.1\`. No other workflow needs the bump — \`version-bump.yml\` doesn't publish, it only runs \`npm version\` + lockfile regen.

### Verification after merge

\`gh run rerun 24573726906 --failed\` — the existing failed run of \`@tumaet/apollon@4.2.19\` can be rerun (verify-version's \`npm view\` idempotency check still skips if the version did somehow land; otherwise it publishes).