### PR TITLE
ci: audience-appropriate release notes + filter CI noise

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - github-actions
+      - dependabot
+  categories:
+    - title: Features
+      labels:
+        - feat
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - fix
+        - bug
+    - title: Documentation
+      labels:
+        - docs
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -84,5 +84,13 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --target "$GITHUB_SHA" \
+            --verify-tag \
+            --latest=false \
             --generate-notes \
-            --notes "[\`@tumaet/apollon@${VERSION}\`](https://www.npmjs.com/package/@tumaet/apollon/v/${VERSION}) published with \`--provenance\` via npm OIDC trusted publishing."
+            --notes "Install:
+
+          \`\`\`sh
+          npm install @tumaet/apollon@${VERSION}
+          \`\`\`
+
+          Published to npm with [provenance](https://docs.npmjs.com/generating-provenance-statements) via OIDC trusted publishing: [\`@tumaet/apollon@${VERSION}\`](https://www.npmjs.com/package/@tumaet/apollon/v/${VERSION})."

--- a/.github/workflows/release-standalone.yml
+++ b/.github/workflows/release-standalone.yml
@@ -95,5 +95,18 @@ jobs:
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
             --target "$COMMIT_SHA" \
+            --verify-tag \
+            --latest \
             --generate-notes \
-            --notes "\`ghcr.io/ls1intum/apollon/apollon-{webapp,server}:${VERSION}\` — cosign-signed, retagged from \`sha-${COMMIT_SHA}\`."
+            --notes "## Docker images
+
+          - \`ghcr.io/ls1intum/apollon/apollon-webapp:${VERSION}\`
+          - \`ghcr.io/ls1intum/apollon/apollon-server:${VERSION}\`
+
+          Signed with [Sigstore cosign](https://docs.sigstore.dev/cosign/verifying/verify/) (keyless, GitHub OIDC). Verify with:
+
+          \`\`\`sh
+          cosign verify ghcr.io/ls1intum/apollon/apollon-webapp:${VERSION} \\
+            --certificate-identity-regexp='^https://github\\.com/ls1intum/Apollon/\\.github/workflows/release-standalone\\.yml@refs/heads/main\$' \\
+            --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+          \`\`\`"


### PR DESCRIPTION
Public-appearance audit on the v4.2.20 / @tumaet/apollon@4.2.20 releases flagged the current release-note bodies as SRE-ops jargon rather than content a reader would expect.

### Rewrites

- **Standalone** \`v<X.Y.Z>\`: surface the two Docker image tags as a clean list and the cosign verify snippet operators actually copy-paste. No more \`\{webapp,server\}\` shell brace or raw \`sha-<40-char>\` in the body.
- **Library** \`@tumaet/apollon@<X.Y.Z>\`: lead with the install command and the npm provenance link. That's the only content an npm consumer clicking the release link cares about.

### \`.github/release.yml\` (new)

Categorizes commits picked up by \`--generate-notes\` and excludes \`github-actions[bot]\` / \`dependabot\` from the public changelog, so \`chore: release ...\` and \`chore: version packages\` no longer pollute user-facing release notes.

### Other polish

- \`--verify-tag\` on both release workflows: fail fast if the tag's ref is somehow wrong.
- \`--latest=false\` on library, \`--latest\` on standalone: the repo homepage always surfaces the user-facing product as "Latest", never an npm-shaped tag.