### PR TITLE
ci: enrich OCI image labels for GHCR package pages

### DIFF
--- a/standalone/server/Dockerfile
+++ b/standalone/server/Dockerfile
@@ -18,7 +18,12 @@ FROM node:22.14.0-slim AS runtime
 WORKDIR /app
 
 LABEL org.opencontainers.image.source="https://github.com/ls1intum/Apollon" \
-      org.opencontainers.image.title="apollon-server"
+      org.opencontainers.image.url="https://github.com/ls1intum/Apollon" \
+      org.opencontainers.image.documentation="https://github.com/ls1intum/Apollon#readme" \
+      org.opencontainers.image.title="apollon-server" \
+      org.opencontainers.image.description="Apollon standalone server — Express + Redis + WebSocket relay powering the Apollon UML editor." \
+      org.opencontainers.image.vendor="TUM Applied Education Technologies" \
+      org.opencontainers.image.licenses="MIT"
 
 # Install tini for proper PID 1 signal handling
 RUN apt-get update && apt-get install -y --no-install-recommends tini && rm -rf /var/lib/apt/lists/*

--- a/standalone/webapp/Dockerfile
+++ b/standalone/webapp/Dockerfile
@@ -16,7 +16,12 @@ RUN npm run build:lib && npm run build:webapp
 FROM nginx:1.27-alpine AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/ls1intum/Apollon" \
-      org.opencontainers.image.title="apollon-webapp"
+      org.opencontainers.image.url="https://github.com/ls1intum/Apollon" \
+      org.opencontainers.image.documentation="https://github.com/ls1intum/Apollon#readme" \
+      org.opencontainers.image.title="apollon-webapp" \
+      org.opencontainers.image.description="Apollon standalone webapp — the browser frontend of the Apollon UML modeling editor." \
+      org.opencontainers.image.vendor="TUM Applied Education Technologies" \
+      org.opencontainers.image.licenses="MIT"
 
 RUN rm /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
Adds `description`, `url`, `documentation`, `vendor`, and `licenses` to the standard `org.opencontainers.image.*` labels on both Dockerfiles. GHCR uses these to populate the package page (description, links, license badge); before this PR the pages render sparse.

Takes effect on the next release — existing 4.2.20 images keep the old label set; GHCR will pick up the new ones on 4.2.21+.

## Follow-ups (not in this PR)

- Delete the legacy GHCR packages `ls1intum/apollon` (last pushed 2022-04-24) and `ls1intum/apollon_standalone` (last pushed 2026-04-02, from the pre-merge standalone repo). Destructive, needs confirmation.
- Consider adding manifest annotations (not just image-config labels) via `docker/metadata-action`'s `annotations-levels` if the LABEL fallback doesn't render — currently relying on GHCR's fallback behavior.