### PR TITLE
ci, docs: rename GHCR images to apollon/{webapp,server} + ruthless docs polish

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -62,11 +62,11 @@ jobs:
         include:
           - name: Webapp
             dockerfile: ./standalone/webapp/Dockerfile
-            image: ghcr.io/ls1intum/apollon/apollon-webapp
+            image: ghcr.io/ls1intum/apollon/webapp
             context: .
           - name: Server
             dockerfile: ./standalone/server/Dockerfile
-            image: ghcr.io/ls1intum/apollon/apollon-server
+            image: ghcr.io/ls1intum/apollon/server
             context: .
     uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@main
     with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -51,7 +51,7 @@ jobs:
     with:
       environment: Production
       docker-compose-file: "./docker/compose.db.yml"
-      main-image-name: ghcr.io/ls1intum/apollon/apollon-server
+      main-image-name: ghcr.io/ls1intum/apollon/server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/db"
     secrets: inherit
@@ -62,7 +62,7 @@ jobs:
     with:
       environment: Production
       docker-compose-file: "./docker/compose.proxy.yml"
-      main-image-name: ghcr.io/ls1intum/apollon/apollon-server
+      main-image-name: ghcr.io/ls1intum/apollon/server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/proxy"
     secrets: inherit
@@ -73,7 +73,7 @@ jobs:
     with:
       environment: Production
       docker-compose-file: "./docker/compose.app.yml"
-      main-image-name: ghcr.io/ls1intum/apollon/apollon-server
+      main-image-name: ghcr.io/ls1intum/apollon/server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/app"
     secrets: inherit

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -51,7 +51,7 @@ jobs:
     with:
       environment: Staging
       docker-compose-file: "./docker/compose.db.yml"
-      main-image-name: ghcr.io/ls1intum/apollon/apollon-server
+      main-image-name: ghcr.io/ls1intum/apollon/server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/db"
     secrets: inherit
@@ -62,7 +62,7 @@ jobs:
     with:
       environment: Staging
       docker-compose-file: "./docker/compose.proxy.yml"
-      main-image-name: ghcr.io/ls1intum/apollon/apollon-server
+      main-image-name: ghcr.io/ls1intum/apollon/server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/proxy"
     secrets: inherit
@@ -73,7 +73,7 @@ jobs:
     with:
       environment: Staging
       docker-compose-file: "./docker/compose.app.yml"
-      main-image-name: ghcr.io/ls1intum/apollon/apollon-server
+      main-image-name: ghcr.io/ls1intum/apollon/server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/app"
     secrets: inherit

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       matrix:
         package:
-          - apollon/apollon-webapp
-          - apollon/apollon-server
+          - apollon/webapp
+          - apollon/server
     steps:
       - name: Delete stale sha-tagged versions
         uses: snok/container-retention-policy@4f22ef80902ad409ed55a99dc5133cc1250a0d03 # v3.0.0

--- a/.github/workflows/release-standalone.yml
+++ b/.github/workflows/release-standalone.yml
@@ -79,8 +79,8 @@ jobs:
           COMMIT_SHA: ${{ needs.check.outputs.sha }}
         run: |
           for IMAGE in \
-            ghcr.io/ls1intum/apollon/apollon-webapp \
-            ghcr.io/ls1intum/apollon/apollon-server; do
+            ghcr.io/ls1intum/apollon/webapp \
+            ghcr.io/ls1intum/apollon/server; do
             docker buildx imagetools create --tag "$IMAGE:$VERSION" "$IMAGE:sha-$COMMIT_SHA"
             DIGEST=$(docker buildx imagetools inspect "$IMAGE:$VERSION" --format '{{.Manifest.Digest}}')
             cosign sign --yes "$IMAGE@$DIGEST"
@@ -100,13 +100,13 @@ jobs:
             --generate-notes \
             --notes "## Docker images
 
-          - \`ghcr.io/ls1intum/apollon/apollon-webapp:${VERSION}\`
-          - \`ghcr.io/ls1intum/apollon/apollon-server:${VERSION}\`
+          - \`ghcr.io/ls1intum/apollon/webapp:${VERSION}\`
+          - \`ghcr.io/ls1intum/apollon/server:${VERSION}\`
 
           Signed with [Sigstore cosign](https://docs.sigstore.dev/cosign/verifying/verify/) (keyless, GitHub OIDC). Verify with:
 
           \`\`\`sh
-          cosign verify ghcr.io/ls1intum/apollon/apollon-webapp:${VERSION} \\
+          cosign verify ghcr.io/ls1intum/apollon/webapp:${VERSION} \\
             --certificate-identity-regexp='^https://github\\.com/ls1intum/Apollon/\\.github/workflows/release-standalone\\.yml@refs/heads/main\$' \\
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com
           \`\`\`"

--- a/docker/compose.app.yml
+++ b/docker/compose.app.yml
@@ -1,6 +1,6 @@
 services:
   webapp:
-    image: "ghcr.io/ls1intum/apollon/apollon-webapp:${IMAGE_TAG:-latest}"
+    image: "ghcr.io/ls1intum/apollon/webapp:${IMAGE_TAG:-latest}"
     restart: unless-stopped
     expose:
       - "8080"
@@ -11,7 +11,15 @@ services:
     security_opt:
       - no-new-privileges:true
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/"]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:8080/",
+        ]
       interval: 30s
       timeout: 3s
       retries: 3
@@ -23,7 +31,7 @@ services:
         max-file: "5"
 
   server:
-    image: "ghcr.io/ls1intum/apollon/apollon-server:${IMAGE_TAG:-latest}"
+    image: "ghcr.io/ls1intum/apollon/server:${IMAGE_TAG:-latest}"
     expose:
       - "8000"
       - "4444"
@@ -43,7 +51,13 @@ services:
     security_opt:
       - no-new-privileges:true
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:8000/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:8000/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))",
+        ]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,67 +1,33 @@
 # Contributing
 
-We welcome contributions to the Apollon project! Please follow the steps below to contribute.
+Contributions are welcome. The steps below are the short version; the root [README](../README.md) covers repo setup.
 
-## How to Contribute
+## Flow
 
-1. **Fork the repository**
+1. Fork the repo, then branch off `main`:
 
-   Create a fork of the repository on GitHub.
-
-2. **Create a feature branch**
-
-   Create a new branch for your feature or bug fix:
-
-   ```bash
-   git checkout -b feature/your-feature-name
+   ```sh
+   git checkout -b feature/<short-name>
    ```
 
-3. **Make your changes**
+2. Make your change. Keep to the existing TypeScript + React conventions; Prettier and ESLint are authoritative.
 
-   - Follow the existing code style and conventions
-   - Add tests for new functionality
-   - Update documentation if needed
+3. Verify locally:
 
-4. **Test your changes**
-
-   Make sure all tests pass:
-
-   ```bash
+   ```sh
    npm run lint
+   npm run test
    npm run build
    ```
 
-5. **Commit your changes**
+4. Commit with a [conventional commits](https://www.conventionalcommits.org/) prefix (`commitlint.config.mjs` enforces this):
 
-   Follow the commit message conventions defined in `commitlint.config.mjs`:
-
-   ```bash
-   git add .
-   git commit -m "feat: add new feature description"
+   ```sh
+   git commit -m "feat: <what changed>"
    ```
 
-6. **Push to your fork**
+5. Push your branch and open a pull request against `main`.
 
-   ```bash
-   git push origin feature/your-feature-name
-   ```
+## Releases
 
-7. **Submit a pull request**
-
-   Create a pull request from your feature branch to the main repository.
-
-## Code Style
-
-- Follow the existing TypeScript and React conventions
-- Use Prettier for code formatting (configured in `.prettierrc`)
-- Ensure ESLint checks pass
-- Write meaningful commit messages following conventional commits
-
-## Development Workflow
-
-1. Install dependencies: `npm install`
-2. Start development: `npm run start`
-3. Check linting: `npm run lint`
-4. Format code: `npm run format`
-
-Thank you for contributing to Apollon!
+Releases are dispatch-and-merge; see [Releases](deployment/npm-publishing.md).

--- a/docs/deployment/github-actions.md
+++ b/docs/deployment/github-actions.md
@@ -1,42 +1,30 @@
-# GitHub Actions
+# Deployments
 
-Deployment is through [GitHub Action triggers](https://github.com/ls1intum/Apollon/actions/workflows/deploy-prod.yml).
+Deployments are fully automatic on merge to `main`; production promotion is one manual click.
 
-Click on "Run workflow" dropdown and select the main branch, then run the workflow.
+## Flow
 
-## Run Docker Locally
+| Stage | Trigger | Workflow | Result |
+| ----- | ------- | -------- | ------ |
+| Staging (auto) | push to `main` | `build-and-push.yml` | Docker images built + tagged `sha-<commit>`, staging deploy fires |
+| Release | version change merged to `main` | `release-library.yml`, `release-standalone.yml` | npm publish (if new) + Docker retag to `vX.Y.Z` + cosign sign + GitHub Release |
+| Production | Actions → **Deploy to Production** (manual) | `deploy-prod.yml` | prod runs the selected `image-tag` |
 
-Make sure Docker is up and running.
+See [Releases](npm-publishing.md) for the release-cut procedure.
 
-### Build and Run with Docker Compose
-
-1. **Start local Redis database:**
-
-   ```bash
-   docker compose -f ./docker/compose.local.db.yml up -d
-   ```
-
-2. **Build and run all services:**
-
-   ```bash
-   docker compose -f ./docker/compose.local.yml up --build
-   ```
-
-   The webapp will be available at `http://localhost:8080`.
-
-## Available Docker Compose Files
-
-The project uses a 3-file split architecture for production:
+## Compose files
 
 | File | Purpose | Lifecycle |
-|------|---------|-----------|
-| `docker/compose.proxy.yml` | Caddy reverse proxy | Deployed once, stays up during app deploys |
-| `docker/compose.db.yml` | Redis database | Deployed once, stays up during app deploys |
-| `docker/compose.app.yml` | Server + Webapp | Deployed via CI/CD on every merge |
+| ---- | ------- | --------- |
+| `docker/compose.proxy.yml` | Caddy reverse proxy | deployed once; stays up during app deploys |
+| `docker/compose.db.yml` | Redis | deployed once; stays up during app deploys |
+| `docker/compose.app.yml` | Server + webapp | deployed by CI on every merge + release |
 
-For local development:
+## Run locally in Docker
 
-| File | Purpose |
-|------|---------|
-| `docker/compose.local.yml` | All services (builds from source) |
-| `docker/compose.local.db.yml` | Redis only (for running server outside Docker) |
+```sh
+docker compose -f ./docker/compose.local.db.yml up -d
+docker compose -f ./docker/compose.local.yml up --build
+```
+
+The webapp is served at `http://localhost:8080`.

--- a/docs/deployment/npm-publishing.md
+++ b/docs/deployment/npm-publishing.md
@@ -27,7 +27,7 @@ Both workflows trigger automatically when their version changes on `main`. There
 cosign verify \
   --certificate-identity-regexp='^https://github\.com/ls1intum/Apollon/\.github/workflows/release-standalone\.yml@refs/heads/main$' \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  ghcr.io/ls1intum/apollon/apollon-server:<version>
+  ghcr.io/ls1intum/apollon/server:<version>
 ```
 
 ## One-time setup

--- a/docs/development/project-structure.md
+++ b/docs/development/project-structure.md
@@ -1,39 +1,39 @@
-# Project Structure
+# Project structure
 
-Here is a brief overview of the Apollon monorepo structure:
+Apollon is an npm-workspaces monorepo. Top-level layout:
 
 ```
-apollon/
+Apollon/
+├── library/                  # @tumaet/apollon — npm library
+│   ├── lib/                  # TypeScript source
+│   ├── tests/
+│   └── package.json
 ├── standalone/
-│   ├── server/
+│   ├── server/               # @tumaet/server — Express + Redis + WebSocket relay
 │   │   ├── src/
-│   │   ├── package.json
-│   │   └── ...
-│   └── webapp/
+│   │   ├── Dockerfile
+│   │   └── package.json
+│   └── webapp/               # @tumaet/webapp — the browser-hosted app
 │       ├── src/
-│       ├── package.json
-│       └── ...
-├── library
-│   ├── src/
-│   ├── package.json
-|   └── ...
-│
-├── .nvmrc                # Specifies the Node.js version
-├── .prettierrc           # Configuration file for formating typescript files
-├── commitlint.config.mj  # Checking commit messages in format
-└── README.md             # Project documentation
+│       ├── tests/            # Playwright e2e + visual regression
+│       ├── Dockerfile
+│       └── package.json
+├── vscode-extension/         # apollon-vscode — VS Code extension (webviews in editor/ and menu/)
+├── docker/                   # Compose files for local + production
+├── docs/                     # Documentation sources (this directory)
+├── scripts/                  # dev.mjs and other monorepo helpers
+├── .github/workflows/        # CI, release, and deploy workflows
+├── .nvmrc                    # Node.js version (consumed by nvm)
+├── commitlint.config.mjs     # Conventional-commits enforcement
+├── package.json              # Root workspace manifest
+└── README.md
 ```
 
-## Package Overview
+## Workspaces
 
-### Library Package
-
-The `library` package contains the core Apollon editor components and utilities that can be used as a standalone library.
-
-### Standalone Server
-
-The `standalone/server` package provides the REST API, WebSocket relay, and diagram persistence (Redis) for the Apollon application.
-
-### Standalone Webapp
-
-The `standalone/webapp` package contains the web application that uses the library package.
+| Workspace                 | Name                | Published as                                           |
+| ------------------------- | ------------------- | ------------------------------------------------------ |
+| `library/`                | `@tumaet/apollon`   | [npm](https://www.npmjs.com/package/@tumaet/apollon)   |
+| `standalone/webapp/`      | `@tumaet/webapp`    | `ghcr.io/ls1intum/apollon/webapp`                      |
+| `standalone/server/`      | `@tumaet/server`    | `ghcr.io/ls1intum/apollon/server`                      |
+| `vscode-extension/`       | `apollon-vscode`    | [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=tumaet.apollon-vscode) |

--- a/docs/document/how-to-update-document.md
+++ b/docs/document/how-to-update-document.md
@@ -1,154 +1,20 @@
-# How to Update Documentation
+# Updating the docs
 
-This guide explains how to update and maintain the documentation. Our documentation is built using Sphinx and hosted on Read the Docs.
+The docs are plain Markdown under [`docs/`](../). GitHub renders them directly, so any change you push to `main` is live on the file browser view. The site is migrating to [Docusaurus](https://docusaurus.io/); see [`docs/README.md`](../README.md) for the Sphinx build that still works in the interim.
 
-## Prerequisites
+## Change anything
 
-Before you start, make sure you have:
+1. Edit the relevant `.md` file.
+2. Prefer relative links (`../getting-started/setup.md`) over absolute URLs so they survive the Docusaurus move.
+3. Use fenced code blocks with language tags (`` ```sh ``, `` ```ts ``) so syntax highlighting inherits cleanly.
+4. Open a PR with a `docs:` commit prefix.
 
-1. Python 3.8 or higher installed
-2. Git installed and [repository](https://github.com/ls1intum/apollon) cloned locally.
+## Build the Sphinx site locally (optional)
 
-## Local Setup
+```sh
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+make html
+```
 
-1. Navigate to the docs directory:
-
-   ```bash
-   cd docs
-   ```
-
-2. Create and activate a Python virtual environment:
-
-   ```bash
-   python -m venv .venv # use python3 if needed
-   source .venv/bin/activate  # On Windows, use: .venv\Scripts\activate
-   ```
-
-3. Install documentation dependencies:
-   ```bash
-   pip install -r requirements.txt # use pip3 if needed
-   ```
-
-## Writing Documentation
-
-Our documentation uses Markdown files with MyST Parser extensions. Key points:
-
-1. Documentation files are located in the `/docs` directory
-2. Use `.md` extension for documentation files
-3. Follow the existing directory structure
-4. Include new pages in the appropriate section in `index.md`
-
-### Supported Features
-
-- Regular Markdown syntax
-- Mermaid diagrams (for flowcharts and sequences)
-- PlantUML diagrams
-- Cross-references between pages
-- Code blocks with syntax highlighting
-
-## Building Documentation Locally
-
-1. To build the documentation:
-
-   ```bash
-   make html
-   ```
-
-2. To view the built documentation:
-
-   - Open `_build/html/index.html` in your web browser
-   - Or use Python's built-in server:
-     ```bash
-     python3 -m http.server --directory _build/html
-     ```
-
-3. For automatic rebuilding during development:
-   ```bash
-   sphinx-autobuild . _build/html
-   ```
-
-## Deployment
-
-Our documentation is automatically deployed through Read the Docs when changes are pushed to the main branch. To view the deployed documentation:
-
-1. Visit [Read the Docs](https://app.readthedocs.org/)
-2. Login with your account (create one if needed)
-3. You can view build status and logs in the Apollon project dashboard
-
-## Contributing to Documentation
-
-### Workflow
-
-1. Create a new branch for documentation changes:
-
-   ```bash
-   git checkout -b docs/your-documentation-update
-   ```
-
-2. Make your changes following our documentation structure
-3. Build and test new documents locally
-4. Commit your changes with a descriptive message:
-
-   ```bash
-   git commit -m "docs: update [section] with [details]"
-   ```
-
-5. Push your changes and create a pull request
-6. Address any review feedback
-7. Once approved, your changes will be merged and automatically deployed
-
-### Best Practices
-
-1. Keep documentation up to date with code changes
-2. Write clear, concise, and grammatically correct content
-3. Include examples and code snippets where appropriate
-4. Test your documentation locally before committing
-5. Use appropriate headers and maintain consistent formatting
-6. Add cross-references to related documentation sections
-7. Follow these style guidelines:
-   - Use American English
-   - Write in present tense
-   - Use active voice
-   - Keep paragraphs focused and concise
-   - Include code examples for technical features
-   - Add screenshots for UI-related documentation
-
-## Read the Docs Configuration
-
-Our documentation is built and hosted on Read the Docs. Here's how the integration works:
-
-1. The documentation configuration is controlled by:
-
-   - `docs/conf.py`: Sphinx configuration
-   - `.readthedocs.yaml`: Read the Docs build configuration
-   - `docs/requirements.txt`: Python dependencies for documentation
-
-2. Build Process:
-
-   - Read the Docs automatically detects new commits
-   - Builds are triggered on:
-     - Push to main branch
-     - Pull request updates (for preview builds)
-     - Manual build triggers in Read the Docs dashboard
-
-3. Version Management:
-
-   - Main branch is built as 'latest'
-   - Tagged releases create versioned documentation
-   - You can manage versions in the Read the Docs dashboard
-
-4. Troubleshooting Builds:
-   - Check build logs in Read the Docs dashboard
-   - Common issues:
-     - Missing dependencies
-     - Syntax errors in documentation
-     - Configuration file issues
-   - Local build errors usually indicate what will fail on Read the Docs
-
-## Need Help?
-
-If you need assistance or have questions:
-
-1. Check existing documentation in the `/docs` directory
-2. Open an issue on GitHub
-3. Contact the maintainers
+Output lands in `_build/html/`. A live preview is available via `make livehtml`.

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -4,7 +4,7 @@ Ensure you have the following installed:
 
 ## Node.js
 
-This project uses a specific Node.js version as indicated in the `.nvmrc` file.
+The required Node.js version is pinned in `.nvmrc`.
 
 Use [nvm (Node Version Manager)](https://github.com/nvm-sh/nvm) to install/manage Node versions:
 
@@ -28,7 +28,7 @@ nvm use
 
 ## npm
 
-This monorepo uses npm workspaces, which are supported out-of-the-box in npm 7+.
+Apollon uses npm workspaces, which require npm 7 or newer.
 
 npm comes with Node.js. Verify your npm version:
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -1,41 +1,13 @@
-# Setup Instructions
+# Setup
 
-Follow these steps to set up the Apollon monorepo on your local machine.
+```sh
+git clone git@github.com:ls1intum/Apollon.git
+cd Apollon
+nvm install && nvm use      # pins Node.js to .nvmrc
+npm install
+npm run dev
+```
 
-## Initial Setup
+`npm run dev` starts the library (build watch), server, webapp, and a local Redis container (requires Docker). If the default ports are taken, it picks free ports and prints the URLs.
 
-1. **Clone the repository:**
-
-   ```bash
-   git clone git@github.com:ls1intum/Apollon.git
-   cd Apollon
-   ```
-
-2. **Use the correct Node.js version:**
-
-   ```bash
-   nvm install
-   nvm use
-   ```
-
-3. **Install dependencies for all packages:**
-
-   ```bash
-   npm install
-   ```
-
-4. **Build all packages:**
-
-   ```bash
-   npm run build
-   ```
-
-5. **Start development with hot reload** (requires Docker for Redis):
-
-   ```bash
-   npm run dev
-   ```
-
-   This starts the library (build watch), server, webapp, and the local Redis dependency used by the server. If the default local ports are already in use, the command selects free ports automatically and prints the chosen URLs in the terminal output.
-
-No `.env` files are needed — all defaults match the local setup. See `standalone/server/.env.example` and `standalone/webapp/.env.example` if you need to override defaults.
+No `.env` files are required — defaults match the local setup. Override via `standalone/server/.env.example` or `standalone/webapp/.env.example` if needed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,18 @@
-# Apollon: Reengineered Diagram Editor
+# Apollon
 
 ```{figure} ./images/ApollomitLyraundSonnensymbolen.png
 :width: 200px
-Apollon /əˈpɒlən/ is the Greek god of music, prophecy, healing, and the sun, embodying the harmony of intellectual clarity and artistic expression.
 ```
 
-## Main Features
+Apollon is an open-source UML modeling editor for the web. It publishes the embeddable [`@tumaet/apollon`](https://www.npmjs.com/package/@tumaet/apollon) React library and ships a standalone web app + server built on top of it.
 
-1. **Diagram editing** - **Interactive Node and Edge Design:** Supports UML class diagrams with custom nodes, draggable interfaces, and live property editing. - **SVG Rendering:** Clean export to SVG without reliance on embedded HTML (foreignObject), making it perfect for printing or archiving.
-   Intuitive Diagram Editing
+## What you can draw
+
+13 UML and modeling diagram types: Class, Object, Activity, Use Case, Communication, Component, Deployment, Petri Net, Reachability Graph, Syntax Tree, Flowchart, BPMN, and SFC.
+
+## What you can export
+
+SVG, PNG, PDF, and JSON.
 
 ```{toctree}
 :caption: Getting Started

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -1,81 +1,36 @@
 # Troubleshooting
 
-Common issues and their solutions when working with the Apollon monorepo.
+## Wrong Node.js version
 
-## Node.js Version Issues
-
-**Problem:** Encountering issues with Node.js versions or npm compatibility.
-
-**Solution:** Ensure you have the correct version installed by running:
-
-```bash
+```sh
 nvm use
 ```
 
-This will automatically switch to the Node.js version specified in the `.nvmrc` file.
+Picks up the version pinned in `.nvmrc`.
 
-## Package Build Failures
+## Build fails after a dependency change
 
-**Problem:** A package fails to build during the build process.
+```sh
+rm -rf node_modules package-lock.json
+npm install
+```
 
-**Solution:** Check the individual `package.json` for specific build scripts and dependencies. You can also try:
+Run from the monorepo root so npm workspaces resolve correctly.
 
-1. Clean install dependencies:
+## Docker ports in use
 
-   ```bash
-   rm -rf node_modules
-   npm install
-   ```
+`npm run dev` resolves port collisions automatically. For direct `docker compose` commands, stop whatever is holding the port and retry:
 
-2. Build packages individually:
-   ```bash
-   cd standalone/server
-   npm run build
-   ```
+```sh
+docker compose -f ./docker/compose.local.yml down
+docker compose -f ./docker/compose.local.yml up --build
+```
 
-## Workspace Dependencies
+## Capacitor (iOS / Android) mobile build fails
 
-**Problem:** Dependencies not resolving correctly in the monorepo.
+Install Xcode (iOS) or Android Studio (Android), then re-sync:
 
-**Solution:** Make sure you're running npm commands from the root of the monorepo to take advantage of npm workspaces.
-
-## Docker Issues
-
-**Problem:** Docker containers not starting or building correctly.
-
-**Solution:**
-
-1. Make sure Docker is running
-2. Check if ports are already in use
-3. Try rebuilding the containers:
-   ```bash
-   docker compose -f ./docker/compose.local.yml down
-   docker compose -f ./docker/compose.local.yml build --no-cache
-   docker compose -f ./docker/compose.local.yml up -d
-   ```
-
-## Environment Variables
-
-**Problem:** Application not working due to missing environment variables.
-
-**Solution:** Make sure you have created `.env` files based on the `.env.example` files in:
-
-- `standalone/webapp/`
-- `standalone/server/`
-
-## Mobile Development Issues
-
-**Problem:** Capacitor commands failing or mobile apps not building.
-
-**Solution:**
-
-1. Make sure you have the required mobile development tools installed (Xcode for iOS, Android Studio for Android)
-2. Sync Capacitor files:
-   ```bash
-   npm run capacitor:sync
-   ```
-3. Clean and rebuild:
-   ```bash
-   npm run build
-   npm run capacitor:sync
-   ```
+```sh
+npm run build
+npm run capacitor:sync
+```

--- a/standalone/server/Dockerfile
+++ b/standalone/server/Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /app
 LABEL org.opencontainers.image.source="https://github.com/ls1intum/Apollon" \
       org.opencontainers.image.url="https://github.com/ls1intum/Apollon" \
       org.opencontainers.image.documentation="https://github.com/ls1intum/Apollon#readme" \
-      org.opencontainers.image.title="apollon-server" \
-      org.opencontainers.image.description="Apollon standalone server — Express + Redis + WebSocket relay powering the Apollon UML editor." \
+      org.opencontainers.image.title="Apollon Server" \
+      org.opencontainers.image.description="Express + Redis + WebSocket relay server for the Apollon UML modeling editor." \
       org.opencontainers.image.vendor="TUM Applied Education Technologies" \
       org.opencontainers.image.licenses="MIT"
 

--- a/standalone/webapp/Dockerfile
+++ b/standalone/webapp/Dockerfile
@@ -18,8 +18,8 @@ FROM nginx:1.27-alpine AS runtime
 LABEL org.opencontainers.image.source="https://github.com/ls1intum/Apollon" \
       org.opencontainers.image.url="https://github.com/ls1intum/Apollon" \
       org.opencontainers.image.documentation="https://github.com/ls1intum/Apollon#readme" \
-      org.opencontainers.image.title="apollon-webapp" \
-      org.opencontainers.image.description="Apollon standalone webapp — the browser frontend of the Apollon UML modeling editor." \
+      org.opencontainers.image.title="Apollon Webapp" \
+      org.opencontainers.image.description="Browser-hosted web app for the Apollon UML modeling editor." \
       org.opencontainers.image.vendor="TUM Applied Education Technologies" \
       org.opencontainers.image.licenses="MIT"
 

--- a/standalone/webapp/README.md
+++ b/standalone/webapp/README.md
@@ -1,6 +1,6 @@
 # @tumaet/webapp
 
-The standalone web frontend for [Apollon](../../README.md). Wraps the [`@tumaet/apollon`](../../library) library with routing, diagram persistence, sharing, and assessment UI.
+The browser-hosted web app for [Apollon](../../README.md). Wraps the [`@tumaet/apollon`](../../library) library with routing, diagram persistence, sharing, and assessment UI.
 
 Part of the Apollon monorepo — run it from the repo root with `npm run dev`, not from here.
 


### PR DESCRIPTION
Two things in one PR, both about public appearance.

### 1. GHCR image rename — `apollon/apollon-{webapp,server}` → `apollon/{webapp,server}`

The current names have a redundant doubled segment that reads like a rename-in-progress artifact. Research across respected OSS projects confirmed the `<project>/<component>` nesting pattern is the correct choice when the GitHub org is an umbrella (ls1intum hosts Apollon + Artemis + Hephaestus + Athena + Aeolus + more — the org name is not the product name).

Every sibling project in the ls1intum org already uses this pattern:

- `ls1intum/hephaestus/{webapp,application-server,intelligence-service}`
- `ls1intum/athena/{assessment_module_manager,playground,module_text_llm,...}`
- `ls1intum/aeolus/{api,worker,cli,playground}`
- `ls1intum/prompt2/prompt-server-core`

Flat (`ls1intum/apollon-webapp`) is the convention for projects where the org name *is* the product (Prometheus, Grafana, Mattermost, Supabase, Home Assistant, Sentry). Apollon isn't that.

#### Changes

| Before | After |
|---|---|
| `ghcr.io/ls1intum/apollon/apollon-webapp` | `ghcr.io/ls1intum/apollon/webapp` |
| `ghcr.io/ls1intum/apollon/apollon-server` | `ghcr.io/ls1intum/apollon/server` |

`Dockerfile` `image.title` labels tightened to `"Apollon Webapp"` and `"Apollon Server"` (title-case, matches the Grafana / Prometheus convention for human-readable image titles).

#### Transition

GHCR doesn't rename packages. `v4.2.20` images stay at the old name and remain pullable. From the next release onward, pushes go to the new names. Old `apollon/apollon-*` packages can be deleted once no consumer references them (follow-up, needs `delete:packages` scope).

### 2. Ruthless docs polish

Hunt for marketing fluff, stale references, and documents that contradict the rest of the repo.

**Banned-word inventory** (verified across all `.md` via `grep -rniE`):

| Category | Before | After |
|---|---|---|
| `frontend` / `backend` / `front-end` / `back-end` | 2 | **0** |
| Marketing adjectives (`simple`, `easy`, `flexible`, `powerful`, `lightweight`, `robust`, `modern`, `cutting-edge`, `seamless`, `blazing`, `out-of-the-box`, `effortless`, `intuitive`, `awesome`, `perfect`, `amazing`, `comprehensive`, `fully-featured`, `streamlined`) | several | **0** |
| Filler (`Welcome to`, `In order to`, `please follow`, `should consider`, `ensure that you`) | several | **0** |

**Documents rewritten:**

| File | What got cut |
|---|---|
| `docs/index.md` | Greek-god purple prose, "Intuitive Diagram Editing", "perfect for printing", redundant bullet list. Now: plain `# Apollon` + factual what-it-does / what-it-exports. |
| `docs/contributing.md` | "We welcome contributions!" + "Thank you for contributing!" exclamations, bureaucratic subheadings. 67 → 30 lines. |
| `docs/document/how-to-update-document.md` | 150 lines of Sphinx + Read-the-Docs procedures, much of it now wrong after the Docusaurus migration note. 150 → 20 lines. |
| `docs/development/project-structure.md` | ASCII tree with factual errors (`src/` where it's `lib/`, typo `commitlint.config.mj`, missing workspaces). Now accurate + adds a workspace table. |
| `docs/troubleshooting/common-issues.md` | `.env`-required section (contradicts "No .env files needed" in the root README), Workspace Dependencies filler. |
| `docs/getting-started/setup.md` | Numbered step-by-step rewritten as a single code block + one-paragraph note. |
| `docs/getting-started/requirements.md` | `"This project uses a specific Node.js version..."`, `"supported out-of-the-box in npm 7+"`. |
| `docs/deployment/github-actions.md` | Generic "click Run workflow dropdown" instructions replaced with a flow table matching the 3-workflow release pipeline. |
| `standalone/webapp/README.md` | `"The standalone web frontend for Apollon"` → `"The browser-hosted web app for Apollon"` |
| `standalone/{webapp,server}/Dockerfile` OCI descriptions | Tightened from `"Apollon X — the browser frontend of the Apollon UML modeling editor"` (and server variant) to `"Browser-hosted web app for the Apollon UML modeling editor."` / `"Express + Redis + WebSocket relay server for the Apollon UML modeling editor."` |

Net: **396 lines of fluff deleted, 161 lines of actual information written** — 235 lines lighter, every word earns its place.