### PR TITLE
ci: replace Caddy with Traefik v3 reverse proxy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,7 +18,7 @@ on:
       deploy-proxy:
         type: boolean
         default: false
-        description: (Re-)deploy Caddy proxy. Usually not necessary.
+        description: (Re-)deploy Traefik reverse proxy. Usually not necessary.
   workflow_call:
     inputs:
       image-tag:
@@ -36,7 +36,7 @@ on:
       deploy-proxy:
         type: boolean
         default: false
-        description: (Re-)deploy Caddy proxy. Usually not necessary.
+        description: (Re-)deploy Traefik reverse proxy. Usually not necessary.
 
 concurrency:
   group: deploy-production

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,7 +18,7 @@ on:
       deploy-proxy:
         type: boolean
         default: false
-        description: (Re-)deploy Caddy proxy. Usually not necessary.
+        description: (Re-)deploy Traefik reverse proxy. Usually not necessary.
   workflow_call:
     inputs:
       image-tag:
@@ -36,7 +36,7 @@ on:
       deploy-proxy:
         type: boolean
         default: false
-        description: (Re-)deploy Caddy proxy. Usually not necessary.
+        description: (Re-)deploy Traefik reverse proxy. Usually not necessary.
 
 concurrency:
   group: deploy-staging

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Override ports via `APOLLON_WEBAPP_PORT`, `APOLLON_SERVER_PORT`, `APOLLON_WS_POR
 | Server        | Express 5, Redis (RedisJSON), WebSocket relay                        |
 | Webapp        | React, TypeScript, Vite, MUI, Tailwind                               |
 | Storage       | Redis with RedisJSON (diagrams expire after 120 days via native TTL) |
-| Reverse proxy | Caddy (production)                                                   |
+| Reverse proxy | Traefik v3 (production)                                              |
 
 ## Requirements
 

--- a/docker/compose.app.yml
+++ b/docker/compose.app.yml
@@ -5,11 +5,28 @@ services:
     expose:
       - "8080"
     networks:
-      - apollon
+      - apollon-network
     cap_drop:
       - ALL
     security_opt:
       - no-new-privileges:true
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=apollon-network"
+      - "traefik.http.routers.http-webapp.entryPoints=http"
+      - "traefik.http.routers.http-webapp.middlewares=redirect-to-https"
+      - "traefik.http.routers.http-webapp.rule=Host(`${APP_HOSTNAME}`)"
+      - "traefik.http.routers.http-webapp.service=http-webapp"
+      - "traefik.http.routers.http-webapp.priority=2"
+      - "traefik.http.routers.https-webapp.entryPoints=https"
+      - "traefik.http.routers.https-webapp.middlewares=secure-headers"
+      - "traefik.http.routers.https-webapp.rule=Host(`${APP_HOSTNAME}`)"
+      - "traefik.http.routers.https-webapp.service=https-webapp"
+      - "traefik.http.routers.https-webapp.tls=true"
+      - "traefik.http.routers.https-webapp.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.https-webapp.priority=3"
+      - "traefik.http.services.http-webapp.loadbalancer.server.port=8080"
+      - "traefik.http.services.https-webapp.loadbalancer.server.port=8080"
     healthcheck:
       test:
         [
@@ -32,6 +49,7 @@ services:
 
   server:
     image: "ghcr.io/ls1intum/apollon/server:${IMAGE_TAG:-latest}"
+    restart: unless-stopped
     expose:
       - "8000"
       - "4444"
@@ -40,9 +58,8 @@ services:
       - PORT=8000
       - WS_PORT=4444
       - REDIS_URL=redis://db:6379
-    restart: unless-stopped
     networks:
-      - apollon
+      - apollon-network
     read_only: true
     tmpfs:
       - /tmp:noexec,nosuid,size=64m
@@ -50,6 +67,38 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=apollon-network"
+      # HTTP API: /api (no stripprefix — server mounts routes under /api internally)
+      - "traefik.http.routers.http-server-api.entryPoints=http"
+      - "traefik.http.routers.http-server-api.middlewares=redirect-to-https"
+      - "traefik.http.routers.http-server-api.rule=Host(`${APP_HOSTNAME}`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.http-server-api.service=http-server-api"
+      - "traefik.http.routers.http-server-api.priority=10"
+      - "traefik.http.routers.https-server-api.entryPoints=https"
+      - "traefik.http.routers.https-server-api.middlewares=secure-headers"
+      - "traefik.http.routers.https-server-api.rule=Host(`${APP_HOSTNAME}`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.https-server-api.service=https-server-api"
+      - "traefik.http.routers.https-server-api.tls=true"
+      - "traefik.http.routers.https-server-api.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.https-server-api.priority=20"
+      - "traefik.http.services.http-server-api.loadbalancer.server.port=8000"
+      - "traefik.http.services.https-server-api.loadbalancer.server.port=8000"
+      # WebSocket relay: /ws → port 4444 (Traefik v3 forwards Upgrade headers automatically)
+      - "traefik.http.routers.http-server-ws.entryPoints=http"
+      - "traefik.http.routers.http-server-ws.middlewares=redirect-to-https"
+      - "traefik.http.routers.http-server-ws.rule=Host(`${APP_HOSTNAME}`) && PathPrefix(`/ws`)"
+      - "traefik.http.routers.http-server-ws.service=http-server-ws"
+      - "traefik.http.routers.http-server-ws.priority=10"
+      - "traefik.http.routers.https-server-ws.entryPoints=https"
+      - "traefik.http.routers.https-server-ws.rule=Host(`${APP_HOSTNAME}`) && PathPrefix(`/ws`)"
+      - "traefik.http.routers.https-server-ws.service=https-server-ws"
+      - "traefik.http.routers.https-server-ws.tls=true"
+      - "traefik.http.routers.https-server-ws.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.https-server-ws.priority=20"
+      - "traefik.http.services.http-server-ws.loadbalancer.server.port=4444"
+      - "traefik.http.services.https-server-ws.loadbalancer.server.port=4444"
     healthcheck:
       test:
         [
@@ -69,6 +118,6 @@ services:
         max-file: "5"
 
 networks:
-  apollon:
-    name: apollon
-    driver: bridge
+  apollon-network:
+    name: apollon-network
+    external: true

--- a/docker/compose.db.yml
+++ b/docker/compose.db.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - dbdata:/data
     networks:
-      - apollon
+      - apollon-network
     command: redis-server --appendonly yes --appendfsync everysec
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
@@ -26,6 +26,6 @@ volumes:
   dbdata:
 
 networks:
-  apollon:
-    name: apollon
-    driver: bridge
+  apollon-network:
+    name: apollon-network
+    external: true

--- a/docker/compose.proxy.yml
+++ b/docker/compose.proxy.yml
@@ -28,7 +28,7 @@ services:
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http"
       - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
-      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:-admin@tum.de}"
+      - "--certificatesresolvers.letsencrypt.acme.email=admin@tum.de"
     labels:
       - "traefik.enable=true"
       - "traefik.http.middlewares.errorpage.errors.status=501,502,503,504"

--- a/docker/compose.proxy.yml
+++ b/docker/compose.proxy.yml
@@ -28,7 +28,7 @@ services:
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http"
       - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
-      - "--certificatesresolvers.letsencrypt.acme.email=admin@tum.de"
+      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:?ACME_EMAIL must be set}"
     labels:
       - "traefik.enable=true"
       - "traefik.http.middlewares.errorpage.errors.status=501,502,503,504"

--- a/docker/compose.proxy.yml
+++ b/docker/compose.proxy.yml
@@ -1,64 +1,129 @@
 services:
-  caddy:
-    image: caddy:2.9-alpine
-    container_name: apollon-caddy
+  reverse-proxy:
+    image: traefik:v3.2
+    container_name: apollon-traefik
     restart: unless-stopped
-    init: true
+    networks:
+      - apollon-network
     ports:
       - "80:80"
       - "443:443"
-      - "443:443/udp"
-    environment:
-      - DOMAIN=${DOMAIN:-localhost}
     volumes:
-      - caddy_data:/data
-      - caddy_config:/config
-    configs:
-      - source: caddyfile
-        target: /etc/caddy/Caddyfile
-    networks:
-      - apollon
-    cap_drop:
-      - ALL
-    cap_add:
-      - NET_BIND_SERVICE
-    security_opt:
-      - no-new-privileges:true
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./letsencrypt:/letsencrypt
+    command:
+      - "--ping=true"
+      - "--ping.entrypoint=http"
+      - "--api.dashboard=false"
+      - "--api.insecure=false"
+      - "--entrypoints.http.address=:80"
+      - "--entrypoints.https.address=:443"
+      - "--entrypoints.http.http.encodequerysemicolons=true"
+      - "--entrypoints.https.http.encodequerysemicolons=true"
+      - "--entryPoints.http.http2.maxConcurrentStreams=50"
+      - "--entryPoints.https.http2.maxConcurrentStreams=50"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=apollon-network"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:-admin@tum.de}"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.middlewares.errorpage.errors.status=501,502,503,504"
+      - "traefik.http.middlewares.errorpage.errors.service=maintenance"
+      - "traefik.http.middlewares.errorpage.errors.query=/index.html"
+      - "traefik.http.middlewares.secure-headers.headers.stsSeconds=63072000"
+      - "traefik.http.middlewares.secure-headers.headers.stsIncludeSubdomains=true"
+      - "traefik.http.middlewares.secure-headers.headers.stsPreload=true"
+      - "traefik.http.middlewares.secure-headers.headers.contentTypeNosniff=true"
+      - "traefik.http.middlewares.secure-headers.headers.referrerPolicy=strict-origin-when-cross-origin"
+      - "traefik.http.middlewares.secure-headers.headers.permissionsPolicy=camera=(), microphone=(), geolocation=()"
     healthcheck:
-      test: ["CMD", "caddy", "version"]
+      test: "wget -qO- http://localhost:80/ping || exit 1"
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
+
+  maintenance:
+    image: nginx:1.27-alpine
+    restart: unless-stopped
+    networks:
+      - apollon-network
+    configs:
+      - source: maintenance-page
+        target: /usr/share/nginx/html/index.html
+      - source: nginx-default-config
+        target: /etc/nginx/conf.d/default.conf
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      - "traefik.http.routers.http-maintenance.entryPoints=http"
+      - "traefik.http.routers.http-maintenance.middlewares=redirect-to-https"
+      - "traefik.http.routers.http-maintenance.rule=Host(`${APP_HOSTNAME}`)"
+      - "traefik.http.routers.https-maintenance.entryPoints=https"
+      - "traefik.http.routers.https-maintenance.rule=Host(`${APP_HOSTNAME}`)"
+      - "traefik.http.routers.https-maintenance.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.https-maintenance.tls=true"
+      - "traefik.http.routers.http-maintenance.priority=1"
+      - "traefik.http.routers.https-maintenance.priority=1"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost/"]
       interval: 30s
-      timeout: 10s
-      retries: 3
-
-configs:
-  caddyfile:
-    content: |
-      {$$DOMAIN} {
-        header {
-          Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
-          Referrer-Policy "strict-origin-when-cross-origin"
-          X-Content-Type-Options "nosniff"
-          Permissions-Policy "camera=(), microphone=(), geolocation=()"
-        }
-
-        @websockets path /ws
-        reverse_proxy @websockets server:4444 {
-          transport http {
-            versions h1.1
-          }
-        }
-
-        @api path /api/*
-        reverse_proxy @api server:8000
-
-        reverse_proxy webapp:8080
-      }
-
-volumes:
-  caddy_data:
-  caddy_config:
+      timeout: 5s
+      retries: 5
+      start_period: 3s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
 
 networks:
-  apollon:
-    name: apollon
+  apollon-network:
+    name: apollon-network
     driver: bridge
+
+configs:
+  nginx-default-config:
+    content: |
+      server {
+        listen 80;
+        server_name _;
+
+        root /usr/share/nginx/html;
+
+        location / {
+            rewrite ^ /index.html break;
+        }
+      }
+
+  maintenance-page:
+    content: |
+      <!DOCTYPE html>
+      <html lang="en">
+      <title>Apollon Maintenance</title>
+      <meta http-equiv="refresh" content="10"/>
+      <style>
+          html, body { padding: 0; margin: 0; width: 100%; height: 100%; }
+          * { box-sizing: border-box; }
+          body { text-align: center; padding: 0; background: #14181d; color: #fff; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; display: flex; justify-content: center; align-items: center; }
+          h1 { font-size: 48px; font-weight: 300; margin: 0.5em 0 0.25em; }
+          article { width: 700px; max-width: 90%; padding: 48px; }
+          p { font-size: 18px; line-height: 1.5; opacity: 0.85; margin: 0.5em 0; }
+          a { color: #fff; font-weight: bold; }
+          a:hover { text-decoration: none; }
+      </style>
+      <article>
+          <h1>We&rsquo;ll be back soon.</h1>
+          <p>Apollon is briefly offline for maintenance. This page refreshes automatically.</p>
+          <p>&mdash; The Apollon team</p>
+      </article>
+      </html>

--- a/docs/deployment/github-actions.md
+++ b/docs/deployment/github-actions.md
@@ -16,7 +16,7 @@ See [Releases](npm-publishing.md) for the release-cut procedure.
 
 | File | Purpose | Lifecycle |
 | ---- | ------- | --------- |
-| `docker/compose.proxy.yml` | Caddy reverse proxy | deployed once; stays up during app deploys |
+| `docker/compose.proxy.yml` | Traefik reverse proxy + maintenance page | deployed once; stays up during app deploys |
 | `docker/compose.db.yml` | Redis | deployed once; stays up during app deploys |
 | `docker/compose.app.yml` | Server + webapp | deployed by CI on every merge + release |
 

--- a/docs/deployment/github-actions.md
+++ b/docs/deployment/github-actions.md
@@ -22,30 +22,15 @@ See [Releases](npm-publishing.md) for the release-cut procedure.
 
 ## Required environment variables
 
-Set per GitHub Environment (Production / Staging). None of these are code-specific — third-party deployers replace the values, not the names.
+Set per GitHub Environment. Values are deployment-specific; names are fixed.
 
 | Var | Purpose |
 | --- | --- |
-| `APP_HOSTNAME` | Public hostname the reverse proxy serves (Traefik `Host()` matcher, Let's Encrypt SAN). |
+| `APP_HOSTNAME` | Public hostname the reverse proxy serves. |
 | `ACME_EMAIL` | Registration email for Let's Encrypt. |
 | `VM_HOST` | SSH target the deploy workflow connects to. |
 | `VM_USERNAME` | SSH user on the VM. |
-| `VM_SSH_PRIVATE_KEY` | SSH key (secret, not variable). |
-
-## Hostname cutover procedure
-
-When moving the public hostname to a new VM (e.g., migrating from one host to another while the old one still holds the name):
-
-1. **Pre-cutover** — deploy to the new VM using a temporary `APP_HOSTNAME` (e.g., a VM-specific subdomain that resolves to the new box). Verify end-to-end including `/api` and `/ws`.
-2. **Lower DNS TTL** on the target hostname to 60–300 s, a day or more in advance, so propagation is fast.
-3. **Cutover window** (~2 min downtime):
-   1. Stop the old VM's proxy stack so it releases the hostname.
-   2. Flip the DNS record to the new VM's IP.
-   3. Change `APP_HOSTNAME` in the GitHub Environment to the target hostname.
-   4. Run **Deploy to Production** (or Staging) with `deploy-proxy: true`. Traefik requests a Let's Encrypt cert via HTTP-01 on the first request after the flip (~10 s).
-4. **After settling** — remove the temporary hostname from DNS or keep it as a redirect. `VM_HOST` can continue pointing at the VM-specific name for SSH; it is independent of `APP_HOSTNAME`.
-
-Let's Encrypt rate limits (50 certs/week per registered domain, 5 duplicate certs/week) make this safe to repeat a handful of times; don't loop it.
+| `VM_SSH_PRIVATE_KEY` | SSH key (secret). |
 
 ## Run locally in Docker
 

--- a/docs/deployment/github-actions.md
+++ b/docs/deployment/github-actions.md
@@ -20,6 +20,33 @@ See [Releases](npm-publishing.md) for the release-cut procedure.
 | `docker/compose.db.yml` | Redis | deployed once; stays up during app deploys |
 | `docker/compose.app.yml` | Server + webapp | deployed by CI on every merge + release |
 
+## Required environment variables
+
+Set per GitHub Environment (Production / Staging). None of these are code-specific — third-party deployers replace the values, not the names.
+
+| Var | Purpose |
+| --- | --- |
+| `APP_HOSTNAME` | Public hostname the reverse proxy serves (Traefik `Host()` matcher, Let's Encrypt SAN). |
+| `ACME_EMAIL` | Registration email for Let's Encrypt. |
+| `VM_HOST` | SSH target the deploy workflow connects to. |
+| `VM_USERNAME` | SSH user on the VM. |
+| `VM_SSH_PRIVATE_KEY` | SSH key (secret, not variable). |
+
+## Hostname cutover procedure
+
+When moving the public hostname to a new VM (e.g., migrating from one host to another while the old one still holds the name):
+
+1. **Pre-cutover** — deploy to the new VM using a temporary `APP_HOSTNAME` (e.g., a VM-specific subdomain that resolves to the new box). Verify end-to-end including `/api` and `/ws`.
+2. **Lower DNS TTL** on the target hostname to 60–300 s, a day or more in advance, so propagation is fast.
+3. **Cutover window** (~2 min downtime):
+   1. Stop the old VM's proxy stack so it releases the hostname.
+   2. Flip the DNS record to the new VM's IP.
+   3. Change `APP_HOSTNAME` in the GitHub Environment to the target hostname.
+   4. Run **Deploy to Production** (or Staging) with `deploy-proxy: true`. Traefik requests a Let's Encrypt cert via HTTP-01 on the first request after the flip (~10 s).
+4. **After settling** — remove the temporary hostname from DNS or keep it as a redirect. `VM_HOST` can continue pointing at the VM-specific name for SSH; it is independent of `APP_HOSTNAME`.
+
+Let's Encrypt rate limits (50 certs/week per registered domain, 5 duplicate certs/week) make this safe to repeat a handful of times; don't loop it.
+
 ## Run locally in Docker
 
 ```sh

--- a/standalone/server/src/middlewares/cors.ts
+++ b/standalone/server/src/middlewares/cors.ts
@@ -4,8 +4,8 @@ export function configureCors() {
   const corsOrigin = process.env.CORS_ORIGIN
 
   return cors({
-    // When served behind a reverse proxy (Caddy), API and webapp share the same
-    // origin so CORS is a no-op. Allow all origins if CORS_ORIGIN is not set.
+    // Behind the production reverse proxy, API and webapp share the same origin so
+    // CORS is a no-op. Allow all origins if CORS_ORIGIN is not set.
     origin: corsOrigin ? [corsOrigin] : true,
     methods: ["GET", "POST", "PUT"],
     allowedHeaders: ["Content-Type"],


### PR DESCRIPTION
## Summary

- Replaces the Caddy reverse proxy with Traefik v3.2, aligning Apollon with the ls1intum Hephaestus deployment model.
- Introduces an nginx-based maintenance fallback that takes over whenever the app compose is down.
- WebSocket routing (`/ws`) is preserved; Traefik v3 forwards `Upgrade`/`Connection` headers automatically, so the previous h1.1-transport workaround is no longer needed.
- `/api` is forwarded **without** stripprefix because the server already mounts routes under `/api` internally.

## Changes

**`docker/compose.proxy.yml`** — full rewrite:
- `traefik:v3.2` behind an external `apollon-network` bridge
- ACME Let's Encrypt HTTP-01 challenge, cert storage at `./letsencrypt`
- `secure-headers` middleware mirrors the previous Caddy HSTS + Referrer-Policy + X-Content-Type-Options + Permissions-Policy set
- `maintenance` service (nginx:1.27-alpine) with `priority=1` Host catch-all; serves an Apollon-branded "We'll be back soon" page when webapp is not registered

**`docker/compose.app.yml`** — Traefik labels added:
- webapp: catch-all Host rule, priority 2 (http redirect) / 3 (https)
- server `/api`: priority 10/20 → port 8000, no stripprefix
- server `/ws`: priority 10/20 → port 4444 (WebSocket relay)
- network renamed to external `apollon-network`

**`docker/compose.db.yml`** — now joins external `apollon-network`.

**Caddy references scrubbed** in:
- `README.md` (tech stack table)
- `standalone/server/src/middlewares/cors.ts` (comment)
- `docs/deployment/github-actions.md` (compose files table)
- `.github/workflows/deploy-prod.yml` and `deploy-staging.yml` (input descriptions)

## Required env vars on the deploy host

- `APP_HOSTNAME` — used in all Host rules (e.g. `apollon.ase.cit.tum.de`)
- `ACME_EMAIL` — defaults to `admin@tum.de`
- `IMAGE_TAG` — already in use

## Test plan

- [ ] Verified `docker compose -f compose.proxy.yml -f compose.db.yml -f compose.app.yml config` resolves cleanly with `APP_HOSTNAME` set.
- [ ] Verified prettier passes on all edited files.
- [ ] WebSocket path: webapp connects to `wss://\${host}/ws`; server's `ws` library listens on `0.0.0.0:4444` without a path filter, so `PathPrefix(`/ws`)` → `server:4444` proxies the Upgrade request without stripping.
- [ ] `/api` path: server mounts `app.use("/api", diagramRouter)` — no stripprefix confirmed.
- [ ] Deploy-proxy once to staging: verify cert issuance, webapp + /api + /ws round-trip, HSTS header on HTTPS.
- [ ] Tear down `compose.app.yml` and verify maintenance page is served on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)