### PR TITLE
fix(traefik): bump to v3.6.13 for Docker API compatibility

### DIFF
--- a/docker/compose.proxy.yml
+++ b/docker/compose.proxy.yml
@@ -1,6 +1,6 @@
 services:
   reverse-proxy:
-    image: traefik:v3.2
+    image: traefik:v3.6.13
     container_name: apollon-traefik
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## Summary

Traefik v3.2's bundled Docker client negotiates API version 1.24, which Docker daemon 29.x rejects (minimum API 1.40). The provider loops with `"client version 1.24 is too old. Minimum supported API version is 1.40"` and never discovers labeled containers — so no routes register and the proxy serves only the self-signed `TRAEFIK DEFAULT CERT`.

Observed live on staging after merging #619:

\`\`\`
ERR Failed to retrieve information of the docker client and server host
    error="Error response from daemon: client version 1.24 is too old..."
    providerName=docker
\`\`\`

v3.6.13 (latest stable) uses a newer Docker client and negotiates correctly.

## Test plan

- [ ] Deploy proxy to staging, confirm Traefik logs show routers being registered (no more `client version 1.24 is too old`)
- [ ] `curl -I https://apollon-staging.aet.cit.tum.de/` returns a Let's Encrypt cert
- [ ] `/api/health` and `/ws` resolve to server
- [ ] Same for production once cut over

🤖 Generated with [Claude Code](https://claude.com/claude-code)