### PR TITLE
fix(docker): healthchecks use 127.0.0.1 to avoid IPv6 resolution trap

### DIFF
--- a/docker/compose.app.yml
+++ b/docker/compose.app.yml
@@ -35,7 +35,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:8080/",
+          "http://127.0.0.1:8080/",
         ]
       interval: 30s
       timeout: 3s
@@ -105,7 +105,7 @@ services:
           "CMD",
           "node",
           "-e",
-          "fetch('http://localhost:8000/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))",
+          "fetch('http://127.0.0.1:8000/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))",
         ]
       interval: 30s
       timeout: 5s

--- a/docker/compose.proxy.yml
+++ b/docker/compose.proxy.yml
@@ -41,7 +41,7 @@ services:
       - "traefik.http.middlewares.secure-headers.headers.referrerPolicy=strict-origin-when-cross-origin"
       - "traefik.http.middlewares.secure-headers.headers.permissionsPolicy=camera=(), microphone=(), geolocation=()"
     healthcheck:
-      test: "wget -qO- http://localhost:80/ping || exit 1"
+      test: "wget -qO- http://127.0.0.1:80/ping || exit 1"
       interval: 5s
       timeout: 3s
       retries: 5
@@ -75,7 +75,7 @@ services:
       - "traefik.http.routers.http-maintenance.priority=1"
       - "traefik.http.routers.https-maintenance.priority=1"
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost/"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1/"]
       interval: 30s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

BusyBox \`wget\` (Alpine images: nginx, traefik) resolves \`localhost\` to \`::1\` first and doesn't fall back. Nginx (webapp + maintenance) and Traefik only bind IPv4 — so every healthcheck returned \`Connection refused\`, Docker marked containers unhealthy, and Traefik's docker provider filtered them as "unhealthy or starting". Result on staging: only the server router was registered, \`/\` and \`/api\` returned Traefik's default 404, webapp + maintenance were invisible to Traefik.

Pinning \`127.0.0.1\` bypasses the IPv6 lookup.

## Observed live

\`\`\`
== proxy-maintenance-1 ==
unhealthy
  1 wget: can't connect to remote host: Connection refused
== app-webapp-1 ==
unhealthy
  1 Connecting to localhost:8080 ([::1]:8080)  wget: can't connect to remote host: Connection refused
\`\`\`

Traefik DEBUG log: \`Filtering unhealthy or starting container container=maintenance-... container=webapp-...\`

After this fix, all containers become healthy within seconds, Traefik discovers them, and the HTTPS routers register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)