### PR TITLE
feat: add opt-in quiz mode and interactive export support

### DIFF
--- a/library/lib/apollon-editor.tsx
+++ b/library/lib/apollon-editor.tsx
@@ -6,8 +6,9 @@ import {
   mapFromReactFlowNodeToApollonNode,
   mapFromReactFlowEdgeToApollonEdge,
   DeepPartial,
+  filterRenderedElements,
   getSVG,
-  getDiagramBounds,
+  getRenderedDiagramBounds,
 } from "./utils"
 import { UMLDiagramType } from "./types"
 import { createDiagramStore, DiagramStore } from "@/store/diagramStore"
@@ -89,10 +90,17 @@ export class ApollonEditor {
       const assessments = options.model.assessments || {}
       this.diagramStore.getState().setNodesAndEdges(nodes, edges)
       this.diagramStore.getState().setAssessments(assessments)
+      this.diagramStore.getState().setInteractive(options.model.interactive)
     }
 
     if (options?.mode) {
       this.metadataStore.getState().setMode(options.mode)
+    }
+    if (options?.view) {
+      this.metadataStore.getState().setView(options.view)
+    }
+    if (options?.enableQuizMode !== undefined) {
+      this.metadataStore.getState().setEnableQuizMode(options.enableQuizMode)
     }
     if (options?.enablePopups !== undefined) {
       this.popoverStore.getState().setPopupEnabled(options.enablePopups)
@@ -267,7 +275,9 @@ export class ApollonEditor {
       }, 150)
     })
 
-    const bounds = getDiagramBounds(reactFlowInstance, container)
+    filterRenderedElements(container, options)
+
+    const bounds = getRenderedDiagramBounds(reactFlowInstance, container)
 
     const margin = 60
     const clip = {
@@ -358,6 +368,26 @@ export class ApollonEditor {
     this.metadataStore.getState().updateDiagramTitle(name)
   }
 
+  public toggleInteractiveElementsMode(forceEnabled?: boolean): void {
+    const currentView = this.metadataStore.getState().view
+    const shouldEnable =
+      forceEnabled ?? currentView !== Apollon.ApollonView.Highlight
+
+    this.metadataStore
+      .getState()
+      .setView(
+        shouldEnable
+          ? Apollon.ApollonView.Highlight
+          : Apollon.ApollonView.Modelling
+      )
+  }
+
+  public getInteractiveForSerialization():
+    | Apollon.InteractiveElements
+    | undefined {
+    return this.diagramStore.getState().getInteractiveForSerialization()
+  }
+
   public getDiagramMetadata() {
     const { diagramTitle, diagramType } = this.metadataStore.getState()
     return { diagramTitle, diagramType }
@@ -366,6 +396,7 @@ export class ApollonEditor {
   get model(): Apollon.UMLModel {
     const { nodes, edges, diagramId } = this.diagramStore.getState()
     const { diagramTitle, diagramType } = this.metadataStore.getState()
+    const interactive = this.getInteractiveForSerialization()
     return {
       id: diagramId,
       version: "4.0.0",
@@ -374,21 +405,35 @@ export class ApollonEditor {
       nodes: nodes.map((node) => mapFromReactFlowNodeToApollonNode(node)),
       edges: edges.map((edge) => mapFromReactFlowEdgeToApollonEdge(edge)),
       assessments: this.diagramStore.getState().assessments,
+      ...(interactive && { interactive }),
     }
   }
 
   set model(model: Apollon.UMLModel) {
-    const { nodes, edges, assessments } = model
+    const { nodes, edges, assessments, interactive } = model
 
     this.diagramStore.getState().setNodesAndEdges(nodes, edges)
     this.diagramStore.getState().setAssessments(assessments)
+    this.diagramStore.getState().setInteractive(interactive)
     this.metadataStore
       .getState()
       .updateMetaData(model.title, parseDiagramType(model.type))
   }
 
   public getSelectedElements(): string[] {
-    return this.assessmentSelectionStore.getState().selectedElementIds
+    const { mode, readonly } = this.metadataStore.getState()
+    if (mode === Apollon.ApollonMode.Assessment && readonly) {
+      return this.assessmentSelectionStore.getState().selectedElementIds
+    }
+    return this.diagramStore.getState().selectedElementIds
+  }
+
+  get view(): Apollon.ApollonView {
+    return this.metadataStore.getState().view
+  }
+
+  set view(view: Apollon.ApollonView) {
+    this.metadataStore.getState().setView(view)
   }
 
   public addOrUpdateAssessment(assessment: Apollon.Assessment): void {

--- a/library/lib/apollon-editor.tsx
+++ b/library/lib/apollon-editor.tsx
@@ -111,9 +111,7 @@ export class ApollonEditor {
         ? [Apollon.ApollonView.Modelling, Apollon.ApollonView.Highlight]
         : undefined
     if (availableViews) {
-      this.metadataStore
-        .getState()
-        .setAvailableViews(availableViews)
+      this.metadataStore.getState().setAvailableViews(availableViews)
     }
     if (options?.enablePopups !== undefined) {
       this.popoverStore.getState().setPopupEnabled(options.enablePopups)

--- a/library/lib/apollon-editor.tsx
+++ b/library/lib/apollon-editor.tsx
@@ -99,8 +99,21 @@ export class ApollonEditor {
     if (options?.view) {
       this.metadataStore.getState().setView(options.view)
     }
-    if (options?.enableQuizMode !== undefined) {
-      this.metadataStore.getState().setEnableQuizMode(options.enableQuizMode)
+    const availableViews = options?.availableViews
+      ? Array.from(
+          new Set([
+            Apollon.ApollonView.Modelling,
+            ...options.availableViews,
+            ...(options.view ? [options.view] : []),
+          ])
+        )
+      : options?.view === Apollon.ApollonView.Highlight
+        ? [Apollon.ApollonView.Modelling, Apollon.ApollonView.Highlight]
+        : undefined
+    if (availableViews) {
+      this.metadataStore
+        .getState()
+        .setAvailableViews(availableViews)
     }
     if (options?.enablePopups !== undefined) {
       this.popoverStore.getState().setPopupEnabled(options.enablePopups)

--- a/library/lib/components/Sidebar.tsx
+++ b/library/lib/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import { DividerLine } from "./ui/DividerLine"
 import { useMetadataStore } from "@/store/context"
 import { useShallow } from "zustand/shallow"
 import { DraggableGhost } from "./DraggableGhost"
+import { ApollonView } from "@/typings"
 
 /* ========================================================================
    Sidebar Component
@@ -17,7 +18,14 @@ import { DraggableGhost } from "./DraggableGhost"
    ======================================================================== */
 
 export const Sidebar = () => {
-  const diagramType = useMetadataStore(useShallow((state) => state.diagramType))
+  const { diagramType, view, setView, enableQuizMode } = useMetadataStore(
+    useShallow((state) => ({
+      diagramType: state.diagramType,
+      view: state.view,
+      setView: state.setView,
+      enableQuizMode: state.enableQuizMode,
+    }))
+  )
   const labelPreviewTypes = new Set([
     "sfcTransitionBranch",
     "petriNetPlace",
@@ -44,62 +52,136 @@ export const Sidebar = () => {
         flexShrink: 0,
       }}
     >
-      {dropElementConfigs[diagramType].map((config, index) => {
-        const extraPreviewHeight = labelPreviewTypes.has(config.type)
-          ? LAYOUT.DEFAULT_ATTRIBUTE_HEIGHT
-          : 0
-        const previewScale = DROPS.SIDEBAR_PREVIEW_SCALE
-        const previewWidth = config.width * previewScale
-        const previewHeight =
-          (config.height + extraPreviewHeight) * previewScale
-
-        return (
-          <React.Fragment key={`${config.type}_${config.defaultData?.name}`}>
-            <DraggableGhost dropElementConfig={config}>
-              <div
-                className="prevent-select"
-                style={{
-                  width: previewWidth,
-                  height: previewHeight,
-                  zIndex: ZINDEX.DRAGGABLE_GHOST,
-                  marginTop: config.marginTop,
-                }}
-              >
-                {React.createElement(config.svg, {
-                  width: config.width,
-                  height: config.height,
-                  ...config.defaultData,
-                  data: config.defaultData,
-                  SIDEBAR_PREVIEW_SCALE: previewScale,
-                  id: `sidebarElement_${index}`,
-                })}
-              </div>
-            </DraggableGhost>
-          </React.Fragment>
-        )
-      })}
-
-      <DividerLine style={{ margin: "3px 0" }} />
-      <DraggableGhost dropElementConfig={ColorDescriptionConfig}>
+      {enableQuizMode && (
         <div
-          className="prevent-select"
           style={{
-            width: ColorDescriptionConfig.width * DROPS.SIDEBAR_PREVIEW_SCALE,
-            height: ColorDescriptionConfig.height * DROPS.SIDEBAR_PREVIEW_SCALE,
-            zIndex: ZINDEX.DRAGGABLE_GHOST,
-            marginTop: ColorDescriptionConfig.marginTop,
+            width: "100%",
+            display: "flex",
+            flexDirection: "column",
+            gap: "8px",
           }}
         >
-          {React.createElement(ColorDescriptionConfig.svg, {
-            width: ColorDescriptionConfig.width,
-            height: ColorDescriptionConfig.height,
-            ...ColorDescriptionConfig.defaultData,
-            data: ColorDescriptionConfig.defaultData,
-            SIDEBAR_PREVIEW_SCALE: DROPS.SIDEBAR_PREVIEW_SCALE,
-            id: "sidebarElement_ColorDescription",
-          })}
+          <button
+            type="button"
+            onClick={() => setView(ApollonView.Modelling)}
+            style={{
+              borderRadius: "8px",
+              border: "1px solid var(--apollon-primary-contrast, #000000)",
+              background:
+                view === ApollonView.Modelling
+                  ? "var(--apollon-primary, #3e8acc)"
+                  : "transparent",
+              color:
+                view === ApollonView.Modelling
+                  ? "var(--apollon-background, #ffffff)"
+                  : "var(--apollon-primary-contrast, #000000)",
+              padding: "8px 10px",
+              cursor: "pointer",
+              fontWeight: 600,
+            }}
+          >
+            Model
+          </button>
+          <button
+            type="button"
+            onClick={() => setView(ApollonView.Highlight)}
+            style={{
+              borderRadius: "8px",
+              border: "1px solid var(--apollon-primary-contrast, #000000)",
+              background:
+                view === ApollonView.Highlight
+                  ? "var(--apollon-primary, #3e8acc)"
+                  : "transparent",
+              color:
+                view === ApollonView.Highlight
+                  ? "var(--apollon-background, #ffffff)"
+                  : "var(--apollon-primary-contrast, #000000)",
+              padding: "8px 10px",
+              cursor: "pointer",
+              fontWeight: 600,
+            }}
+          >
+            Quiz Elements
+          </button>
         </div>
-      </DraggableGhost>
+      )}
+
+      {enableQuizMode && view === ApollonView.Highlight && (
+        <div
+          style={{
+            width: "100%",
+            fontSize: "12px",
+            lineHeight: 1.4,
+            color: "var(--apollon-primary-contrast, #000000)",
+          }}
+        >
+          Click nodes or relationships to mark the quiz-relevant elements.
+        </div>
+      )}
+
+      {(!enableQuizMode || view === ApollonView.Modelling) &&
+        dropElementConfigs[diagramType].map((config, index) => {
+          const extraPreviewHeight = labelPreviewTypes.has(config.type)
+            ? LAYOUT.DEFAULT_ATTRIBUTE_HEIGHT
+            : 0
+          const previewScale = DROPS.SIDEBAR_PREVIEW_SCALE
+          const previewWidth = config.width * previewScale
+          const previewHeight =
+            (config.height + extraPreviewHeight) * previewScale
+
+          return (
+            <React.Fragment key={`${config.type}_${config.defaultData?.name}`}>
+              <DraggableGhost dropElementConfig={config}>
+                <div
+                  className="prevent-select"
+                  style={{
+                    width: previewWidth,
+                    height: previewHeight,
+                    zIndex: ZINDEX.DRAGGABLE_GHOST,
+                    marginTop: config.marginTop,
+                  }}
+                >
+                  {React.createElement(config.svg, {
+                    width: config.width,
+                    height: config.height,
+                    ...config.defaultData,
+                    data: config.defaultData,
+                    SIDEBAR_PREVIEW_SCALE: previewScale,
+                    id: `sidebarElement_${index}`,
+                  })}
+                </div>
+              </DraggableGhost>
+            </React.Fragment>
+          )
+        })}
+
+      {(!enableQuizMode || view === ApollonView.Modelling) && (
+        <>
+          <DividerLine style={{ margin: "3px 0" }} />
+          <DraggableGhost dropElementConfig={ColorDescriptionConfig}>
+            <div
+              className="prevent-select"
+              style={{
+                width:
+                  ColorDescriptionConfig.width * DROPS.SIDEBAR_PREVIEW_SCALE,
+                height:
+                  ColorDescriptionConfig.height * DROPS.SIDEBAR_PREVIEW_SCALE,
+                zIndex: ZINDEX.DRAGGABLE_GHOST,
+                marginTop: ColorDescriptionConfig.marginTop,
+              }}
+            >
+              {React.createElement(ColorDescriptionConfig.svg, {
+                width: ColorDescriptionConfig.width,
+                height: ColorDescriptionConfig.height,
+                ...ColorDescriptionConfig.defaultData,
+                data: ColorDescriptionConfig.defaultData,
+                SIDEBAR_PREVIEW_SCALE: DROPS.SIDEBAR_PREVIEW_SCALE,
+                id: "sidebarElement_ColorDescription",
+              })}
+            </div>
+          </DraggableGhost>
+        </>
+      )}
     </aside>
   )
 }

--- a/library/lib/components/Sidebar.tsx
+++ b/library/lib/components/Sidebar.tsx
@@ -18,14 +18,17 @@ import { ApollonView } from "@/typings"
    ======================================================================== */
 
 export const Sidebar = () => {
-  const { diagramType, view, setView, enableQuizMode } = useMetadataStore(
+  const { diagramType, view, setView, availableViews } = useMetadataStore(
     useShallow((state) => ({
       diagramType: state.diagramType,
       view: state.view,
       setView: state.setView,
-      enableQuizMode: state.enableQuizMode,
+      availableViews: state.availableViews,
     }))
   )
+  const showInteractiveSelectionView =
+    availableViews.includes(ApollonView.Highlight) ||
+    view === ApollonView.Highlight
   const labelPreviewTypes = new Set([
     "sfcTransitionBranch",
     "petriNetPlace",
@@ -52,7 +55,7 @@ export const Sidebar = () => {
         flexShrink: 0,
       }}
     >
-      {enableQuizMode && (
+      {showInteractiveSelectionView && (
         <div
           style={{
             width: "100%",
@@ -101,12 +104,12 @@ export const Sidebar = () => {
               fontWeight: 600,
             }}
           >
-            Quiz Elements
+            Select Elements
           </button>
         </div>
       )}
 
-      {enableQuizMode && view === ApollonView.Highlight && (
+      {view === ApollonView.Highlight && (
         <div
           style={{
             width: "100%",
@@ -115,11 +118,11 @@ export const Sidebar = () => {
             color: "var(--apollon-primary-contrast, #000000)",
           }}
         >
-          Click nodes or relationships to mark the quiz-relevant elements.
+          Click nodes or relationships to toggle whether they are interactive.
         </div>
       )}
 
-      {(!enableQuizMode || view === ApollonView.Modelling) &&
+      {view === ApollonView.Modelling &&
         dropElementConfigs[diagramType].map((config, index) => {
           const extraPreviewHeight = labelPreviewTypes.has(config.type)
             ? LAYOUT.DEFAULT_ATTRIBUTE_HEIGHT
@@ -155,7 +158,7 @@ export const Sidebar = () => {
           )
         })}
 
-      {(!enableQuizMode || view === ApollonView.Modelling) && (
+      {view === ApollonView.Modelling && (
         <>
           <DividerLine style={{ margin: "3px 0" }} />
           <DraggableGhost dropElementConfig={ColorDescriptionConfig}>

--- a/library/lib/components/wrapper/AssessmentSelectableWrapper.tsx
+++ b/library/lib/components/wrapper/AssessmentSelectableWrapper.tsx
@@ -16,12 +16,11 @@ interface AssessmentSelectableWrapperProps {
 export const AssessmentSelectableWrapper: React.FC<
   AssessmentSelectableWrapperProps
 > = ({ elementId, children, asElement = "div" }) => {
-  const { mode, readonly, view, enableQuizMode } = useMetadataStore(
+  const { mode, readonly, view } = useMetadataStore(
     useShallow((state) => ({
       mode: state.mode,
       readonly: state.readonly,
       view: state.view,
-      enableQuizMode: state.enableQuizMode,
     }))
   )
   const { isElementInteractive, toggleInteractiveElement } = useDiagramStore(
@@ -40,7 +39,6 @@ export const AssessmentSelectableWrapper: React.FC<
   } = useAssessmentSelection(elementId)
 
   const showInteractiveInteraction =
-    enableQuizMode &&
     mode === ApollonMode.Modelling &&
     view === ApollonView.Highlight &&
     !readonly

--- a/library/lib/components/wrapper/AssessmentSelectableWrapper.tsx
+++ b/library/lib/components/wrapper/AssessmentSelectableWrapper.tsx
@@ -1,5 +1,8 @@
 import React from "react"
 import { useAssessmentSelection } from "@/hooks/useAssessmentSelection"
+import { useDiagramStore, useMetadataStore } from "@/store"
+import { ApollonMode, ApollonView } from "@/typings"
+import { useShallow } from "zustand/shallow"
 
 interface AssessmentSelectableWrapperProps {
   elementId: string
@@ -13,6 +16,20 @@ interface AssessmentSelectableWrapperProps {
 export const AssessmentSelectableWrapper: React.FC<
   AssessmentSelectableWrapperProps
 > = ({ elementId, children, asElement = "div" }) => {
+  const { mode, readonly, view, enableQuizMode } = useMetadataStore(
+    useShallow((state) => ({
+      mode: state.mode,
+      readonly: state.readonly,
+      view: state.view,
+      enableQuizMode: state.enableQuizMode,
+    }))
+  )
+  const { isElementInteractive, toggleInteractiveElement } = useDiagramStore(
+    useShallow((state) => ({
+      isElementInteractive: state.isElementInteractive,
+      toggleInteractiveElement: state.toggleInteractiveElement,
+    }))
+  )
   const {
     isSelected,
     isHighlighted,
@@ -21,6 +38,53 @@ export const AssessmentSelectableWrapper: React.FC<
     handleElementMouseEnter,
     handleElementMouseLeave,
   } = useAssessmentSelection(elementId)
+
+  const showInteractiveInteraction =
+    enableQuizMode &&
+    mode === ApollonMode.Modelling &&
+    view === ApollonView.Highlight &&
+    !readonly
+  const isInteractiveSelected = isElementInteractive(elementId)
+
+  if (showInteractiveInteraction) {
+    const handleInteractiveClick = (event: React.PointerEvent) => {
+      event.preventDefault()
+      event.stopPropagation()
+      toggleInteractiveElement(elementId)
+    }
+
+    if (asElement == "g") {
+      return (
+        <g
+          style={{
+            cursor: "pointer",
+            ...(isInteractiveSelected && {
+              filter: "drop-shadow(0 0 4px rgba(25, 118, 210, 0.75))",
+            }),
+          }}
+          onPointerDown={handleInteractiveClick}
+        >
+          {children}
+        </g>
+      )
+    }
+
+    return (
+      <div
+        style={{
+          cursor: "pointer",
+          ...(isInteractiveSelected && {
+            outline: "2px solid #1976d2",
+            outlineOffset: "2px",
+            backgroundColor: "rgba(25, 118, 210, 0.12)",
+          }),
+        }}
+        onPointerDown={handleInteractiveClick}
+      >
+        {children}
+      </div>
+    )
+  }
 
   if (!showAssessmentInteraction) {
     return <>{children}</>

--- a/library/lib/hooks/useDiagramModifiable.ts
+++ b/library/lib/hooks/useDiagramModifiable.ts
@@ -1,19 +1,23 @@
 import { useMetadataStore } from "@/store"
-import { ApollonMode } from "@/typings"
+import { ApollonMode, ApollonView } from "@/typings"
 import { useMemo } from "react"
 import { useShallow } from "zustand/shallow"
 
 export const useDiagramModifiable = () => {
-  const { readonlyDiagram, diagramMode } = useMetadataStore(
+  const { readonlyDiagram, diagramMode, diagramView } = useMetadataStore(
     useShallow((state) => ({
       readonlyDiagram: state.readonly,
       diagramMode: state.mode,
+      diagramView: state.view,
     }))
   )
 
   const isDiagramUpdatable = useMemo(
-    () => diagramMode === ApollonMode.Modelling && !readonlyDiagram,
-    [diagramMode, readonlyDiagram]
+    () =>
+      diagramMode === ApollonMode.Modelling &&
+      diagramView === ApollonView.Modelling &&
+      !readonlyDiagram,
+    [diagramMode, diagramView, readonlyDiagram]
   )
 
   return isDiagramUpdatable

--- a/library/lib/store/diagramStore.ts
+++ b/library/lib/store/diagramStore.ts
@@ -221,8 +221,7 @@ export const createDiagramStore = (
           set(
             {
               interactiveElements: prunedInteractive?.elements ?? {},
-              interactiveRelationships:
-                prunedInteractive?.relationships ?? {},
+              interactiveRelationships: prunedInteractive?.relationships ?? {},
             },
             undefined,
             "setInteractive"
@@ -273,8 +272,7 @@ export const createDiagramStore = (
             {
               nodes,
               interactiveElements: prunedInteractive?.elements ?? {},
-              interactiveRelationships:
-                prunedInteractive?.relationships ?? {},
+              interactiveRelationships: prunedInteractive?.relationships ?? {},
             },
             undefined,
             "setNodes"
@@ -304,8 +302,7 @@ export const createDiagramStore = (
             {
               edges,
               interactiveElements: prunedInteractive?.elements ?? {},
-              interactiveRelationships:
-                prunedInteractive?.relationships ?? {},
+              interactiveRelationships: prunedInteractive?.relationships ?? {},
             },
             undefined,
             "setEdges"
@@ -332,8 +329,7 @@ export const createDiagramStore = (
               nodes,
               edges,
               interactiveElements: prunedInteractive?.elements ?? {},
-              interactiveRelationships:
-                prunedInteractive?.relationships ?? {},
+              interactiveRelationships: prunedInteractive?.relationships ?? {},
             },
             undefined,
             "setNodesAndEdges"
@@ -440,8 +436,7 @@ export const createDiagramStore = (
             {
               nodes: nextNodes,
               interactiveElements: prunedInteractive?.elements ?? {},
-              interactiveRelationships:
-                prunedInteractive?.relationships ?? {},
+              interactiveRelationships: prunedInteractive?.relationships ?? {},
             },
             undefined,
             "onNodesChange"
@@ -533,8 +528,7 @@ export const createDiagramStore = (
             {
               edges: nextEdges,
               interactiveElements: prunedInteractive?.elements ?? {},
-              interactiveRelationships:
-                prunedInteractive?.relationships ?? {},
+              interactiveRelationships: prunedInteractive?.relationships ?? {},
             },
             undefined,
             "onEdgesChange"
@@ -595,8 +589,7 @@ export const createDiagramStore = (
             {
               nodes: preserveSelectedNodesAfterYdoc,
               interactiveElements: prunedInteractive?.elements ?? {},
-              interactiveRelationships:
-                prunedInteractive?.relationships ?? {},
+              interactiveRelationships: prunedInteractive?.relationships ?? {},
             },
             undefined,
             "updateNodesFromYjs"
@@ -649,8 +642,7 @@ export const createDiagramStore = (
             {
               edges: preserveSelectedEdgesAfterYdoc,
               interactiveElements: prunedInteractive?.elements ?? {},
-              interactiveRelationships:
-                prunedInteractive?.relationships ?? {},
+              interactiveRelationships: prunedInteractive?.relationships ?? {},
             },
             undefined,
             "updateEdgesFromYjs"

--- a/library/lib/store/diagramStore.ts
+++ b/library/lib/store/diagramStore.ts
@@ -13,7 +13,11 @@ import * as Y from "yjs"
 import { sortNodesTopologically } from "@/utils"
 import { getNodesMap, getEdgesMap, getAssessments } from "@/sync/ydoc"
 import { deepEqual } from "@/utils/storeUtils"
-import { Assessment } from "@/typings"
+import { Assessment, InteractiveElements } from "@/typings"
+import {
+  pruneInteractiveElements,
+  toggleInteractiveRecord,
+} from "@/utils/interactiveUtils"
 
 export type DiagramStoreData = {
   nodes: Node[]
@@ -26,6 +30,8 @@ type InitialDiagramState = {
   selectedElementIds: string[]
   diagramId: string
   assessments: Record<string, Assessment>
+  interactiveElements: Record<string, boolean>
+  interactiveRelationships: Record<string, boolean>
   canUndo: boolean
   canRedo: boolean
   undoManager: Y.UndoManager | null
@@ -37,6 +43,8 @@ const initialDiagramState: InitialDiagramState = {
   selectedElementIds: [],
   diagramId: Math.random().toString(36).substring(2, 15),
   assessments: {},
+  interactiveElements: {},
+  interactiveRelationships: {},
   canUndo: false,
   canRedo: false,
   undoManager: null,
@@ -48,6 +56,8 @@ export type DiagramStore = {
   selectedElementIds: string[]
   diagramId: string
   assessments: Record<string, Assessment>
+  interactiveElements: Record<string, boolean>
+  interactiveRelationships: Record<string, boolean>
   canUndo: boolean
   canRedo: boolean
   undoManager: Y.UndoManager | null
@@ -77,6 +87,10 @@ export type DiagramStore = {
   redo: () => void
   initializeUndoManager: () => void
   updateUndoRedoState: () => void
+  toggleInteractiveElement: (elementId: string) => void
+  getInteractiveForSerialization: () => InteractiveElements | undefined
+  setInteractive: (interactive: InteractiveElements | undefined) => void
+  isElementInteractive: (elementId: string) => boolean
 }
 
 export const createDiagramStore = (
@@ -161,6 +175,67 @@ export const createDiagramStore = (
           set({ selectedElementIds }, undefined, "setSelectedElementsId")
         },
 
+        toggleInteractiveElement: (elementId) => {
+          const isNode = get().nodes.some((node) => node.id === elementId)
+          const isEdge = get().edges.some((edge) => edge.id === elementId)
+
+          if (!isNode && !isEdge) {
+            return
+          }
+
+          set(
+            (state) => ({
+              interactiveElements: isNode
+                ? toggleInteractiveRecord(state.interactiveElements, elementId)
+                : state.interactiveElements,
+              interactiveRelationships: isEdge
+                ? toggleInteractiveRecord(
+                    state.interactiveRelationships,
+                    elementId
+                  )
+                : state.interactiveRelationships,
+            }),
+            undefined,
+            "toggleInteractiveElement"
+          )
+        },
+
+        getInteractiveForSerialization: () => {
+          return pruneInteractiveElements(
+            {
+              elements: get().interactiveElements,
+              relationships: get().interactiveRelationships,
+            },
+            get().nodes,
+            get().edges
+          )
+        },
+
+        setInteractive: (interactive) => {
+          const prunedInteractive = pruneInteractiveElements(
+            interactive,
+            get().nodes,
+            get().edges
+          )
+
+          set(
+            {
+              interactiveElements: prunedInteractive?.elements ?? {},
+              interactiveRelationships:
+                prunedInteractive?.relationships ?? {},
+            },
+            undefined,
+            "setInteractive"
+          )
+        },
+
+        isElementInteractive: (elementId) => {
+          return !!(
+            get().interactiveElements[elementId] ||
+            get().interactiveRelationships[elementId]
+          )
+        },
+
         addNode: (node) => {
           ydoc.transact(() => {
             getNodesMap(ydoc).set(node.id, node)
@@ -186,7 +261,24 @@ export const createDiagramStore = (
             getNodesMap(ydoc).clear()
             nodes.forEach((node) => getNodesMap(ydoc).set(node.id, node))
           }, "store")
-          set({ nodes }, undefined, "setNodes")
+          const prunedInteractive = pruneInteractiveElements(
+            {
+              elements: get().interactiveElements,
+              relationships: get().interactiveRelationships,
+            },
+            nodes,
+            get().edges
+          )
+          set(
+            {
+              nodes,
+              interactiveElements: prunedInteractive?.elements ?? {},
+              interactiveRelationships:
+                prunedInteractive?.relationships ?? {},
+            },
+            undefined,
+            "setNodes"
+          )
         },
 
         setEdges: (payload) => {
@@ -200,7 +292,24 @@ export const createDiagramStore = (
             getEdgesMap(ydoc).clear()
             edges.forEach((edge) => getEdgesMap(ydoc).set(edge.id, edge))
           }, "store")
-          set({ edges }, undefined, "setEdges")
+          const prunedInteractive = pruneInteractiveElements(
+            {
+              elements: get().interactiveElements,
+              relationships: get().interactiveRelationships,
+            },
+            get().nodes,
+            edges
+          )
+          set(
+            {
+              edges,
+              interactiveElements: prunedInteractive?.elements ?? {},
+              interactiveRelationships:
+                prunedInteractive?.relationships ?? {},
+            },
+            undefined,
+            "setEdges"
+          )
         },
 
         setNodesAndEdges: (nodes, edges) => {
@@ -210,7 +319,25 @@ export const createDiagramStore = (
             nodes.forEach((node) => getNodesMap(ydoc).set(node.id, node))
             edges.forEach((edge) => getEdgesMap(ydoc).set(edge.id, edge))
           }, "store")
-          set({ nodes, edges }, undefined, "setNodesAndEdges")
+          const prunedInteractive = pruneInteractiveElements(
+            {
+              elements: get().interactiveElements,
+              relationships: get().interactiveRelationships,
+            },
+            nodes,
+            edges
+          )
+          set(
+            {
+              nodes,
+              edges,
+              interactiveElements: prunedInteractive?.elements ?? {},
+              interactiveRelationships:
+                prunedInteractive?.relationships ?? {},
+            },
+            undefined,
+            "setNodesAndEdges"
+          )
         },
 
         onNodesChange: (changes) => {
@@ -300,7 +427,25 @@ export const createDiagramStore = (
               }
             }
           }, "store")
-          set({ nodes: nextNodes }, undefined, "onNodesChange")
+          const prunedInteractive = pruneInteractiveElements(
+            {
+              elements: get().interactiveElements,
+              relationships: get().interactiveRelationships,
+            },
+            nextNodes,
+            get().edges
+          )
+
+          set(
+            {
+              nodes: nextNodes,
+              interactiveElements: prunedInteractive?.elements ?? {},
+              interactiveRelationships:
+                prunedInteractive?.relationships ?? {},
+            },
+            undefined,
+            "onNodesChange"
+          )
         },
 
         onEdgesChange: (changes) => {
@@ -375,7 +520,25 @@ export const createDiagramStore = (
               }
             }
           }, "store")
-          set({ edges: nextEdges }, undefined, "onEdgesChange")
+          const prunedInteractive = pruneInteractiveElements(
+            {
+              elements: get().interactiveElements,
+              relationships: get().interactiveRelationships,
+            },
+            get().nodes,
+            nextEdges
+          )
+
+          set(
+            {
+              edges: nextEdges,
+              interactiveElements: prunedInteractive?.elements ?? {},
+              interactiveRelationships:
+                prunedInteractive?.relationships ?? {},
+            },
+            undefined,
+            "onEdgesChange"
+          )
         },
 
         reset: () => {
@@ -419,9 +582,21 @@ export const createDiagramStore = (
             )
           }
 
+          const prunedInteractive = pruneInteractiveElements(
+            {
+              elements: get().interactiveElements,
+              relationships: get().interactiveRelationships,
+            },
+            preserveSelectedNodesAfterYdoc,
+            get().edges
+          )
+
           set(
             {
               nodes: preserveSelectedNodesAfterYdoc,
+              interactiveElements: prunedInteractive?.elements ?? {},
+              interactiveRelationships:
+                prunedInteractive?.relationships ?? {},
             },
             undefined,
             "updateNodesFromYjs"
@@ -461,8 +636,22 @@ export const createDiagramStore = (
             )
           }
 
+          const prunedInteractive = pruneInteractiveElements(
+            {
+              elements: get().interactiveElements,
+              relationships: get().interactiveRelationships,
+            },
+            get().nodes,
+            preserveSelectedEdgesAfterYdoc
+          )
+
           set(
-            { edges: preserveSelectedEdgesAfterYdoc },
+            {
+              edges: preserveSelectedEdgesAfterYdoc,
+              interactiveElements: prunedInteractive?.elements ?? {},
+              interactiveRelationships:
+                prunedInteractive?.relationships ?? {},
+            },
             undefined,
             "updateEdgesFromYjs"
           )

--- a/library/lib/store/metadataStore.ts
+++ b/library/lib/store/metadataStore.ts
@@ -113,11 +113,7 @@ export const createMetadataStore = (
         },
 
         setAvailableViews: (availableViews) => {
-          set(
-            { availableViews },
-            undefined,
-            "setAvailableViews"
-          )
+          set({ availableViews }, undefined, "setAvailableViews")
         },
 
         setReadonly: (readonly) => {

--- a/library/lib/store/metadataStore.ts
+++ b/library/lib/store/metadataStore.ts
@@ -11,14 +11,14 @@ export type MetadataStore = {
   diagramType: UMLDiagramType
   mode: ApollonMode
   view: ApollonView
-  enableQuizMode: boolean
+  availableViews: ApollonView[]
   readonly: boolean
   debug: boolean
   scrollLock: boolean
   scrollEnabled: boolean
   setMode: (mode: ApollonMode) => void
   setView: (view: ApollonView) => void
-  setEnableQuizMode: (enableQuizMode: boolean) => void
+  setAvailableViews: (availableViews: ApollonView[]) => void
   setReadonly: (readonly: boolean) => void
   setScrollLock: (scrollLock: boolean) => void
   setScrollEnabled: (scrollEnabled: boolean) => void
@@ -35,7 +35,7 @@ type InitialMetadataState = {
   diagramType: UMLDiagramType
   mode: ApollonMode
   view: ApollonView
-  enableQuizMode: boolean
+  availableViews: ApollonView[]
   readonly: boolean
   debug: boolean
   scrollLock: boolean
@@ -46,7 +46,7 @@ const initialMetadataState: InitialMetadataState = {
   diagramType: UMLDiagramType.ClassDiagram,
   mode: ApollonMode.Modelling,
   view: ApollonView.Modelling,
-  enableQuizMode: false,
+  availableViews: [ApollonView.Modelling],
   readonly: false,
   debug: false,
   scrollLock: false,
@@ -112,8 +112,12 @@ export const createMetadataStore = (
           set({ view }, undefined, "setView")
         },
 
-        setEnableQuizMode: (enableQuizMode) => {
-          set({ enableQuizMode }, undefined, "setEnableQuizMode")
+        setAvailableViews: (availableViews) => {
+          set(
+            { availableViews },
+            undefined,
+            "setAvailableViews"
+          )
         },
 
         setReadonly: (readonly) => {

--- a/library/lib/store/metadataStore.ts
+++ b/library/lib/store/metadataStore.ts
@@ -4,17 +4,21 @@ import { parseDiagramType } from "@/utils"
 import * as Y from "yjs"
 import { getDiagramMetadata } from "@/sync/ydoc"
 import { UMLDiagramType } from "@/types"
-import { ApollonMode } from "@/typings"
+import { ApollonMode, ApollonView } from "@/typings"
 
 export type MetadataStore = {
   diagramTitle: string
   diagramType: UMLDiagramType
   mode: ApollonMode
+  view: ApollonView
+  enableQuizMode: boolean
   readonly: boolean
   debug: boolean
   scrollLock: boolean
   scrollEnabled: boolean
   setMode: (mode: ApollonMode) => void
+  setView: (view: ApollonView) => void
+  setEnableQuizMode: (enableQuizMode: boolean) => void
   setReadonly: (readonly: boolean) => void
   setScrollLock: (scrollLock: boolean) => void
   setScrollEnabled: (scrollEnabled: boolean) => void
@@ -30,6 +34,8 @@ type InitialMetadataState = {
   diagramTitle: string
   diagramType: UMLDiagramType
   mode: ApollonMode
+  view: ApollonView
+  enableQuizMode: boolean
   readonly: boolean
   debug: boolean
   scrollLock: boolean
@@ -39,6 +45,8 @@ const initialMetadataState: InitialMetadataState = {
   diagramTitle: "Untitled Diagram",
   diagramType: UMLDiagramType.ClassDiagram,
   mode: ApollonMode.Modelling,
+  view: ApollonView.Modelling,
+  enableQuizMode: false,
   readonly: false,
   debug: false,
   scrollLock: false,
@@ -98,6 +106,14 @@ export const createMetadataStore = (
 
         setMode: (mode) => {
           set({ mode }, undefined, "setMode")
+        },
+
+        setView: (view) => {
+          set({ view }, undefined, "setView")
+        },
+
+        setEnableQuizMode: (enableQuizMode) => {
+          set({ enableQuizMode }, undefined, "setEnableQuizMode")
         },
 
         setReadonly: (readonly) => {

--- a/library/lib/typings.ts
+++ b/library/lib/typings.ts
@@ -83,6 +83,7 @@ export type ApollonOptions = {
   type?: UMLDiagramType
   mode?: ApollonMode
   view?: ApollonView
+  availableViews?: ApollonView[]
   readonly?: boolean
   enablePopups?: boolean
   model?: UMLModel
@@ -94,7 +95,6 @@ export type ApollonOptions = {
   debug?: boolean
   collaborationEnabled?: boolean
   scrollLock?: boolean
-  enableQuizMode?: boolean
 }
 
 export type FeedbackCorrectionStatus = {

--- a/library/lib/typings.ts
+++ b/library/lib/typings.ts
@@ -55,6 +55,11 @@ export type ApollonEdge = {
   }
 }
 
+export type InteractiveElements = {
+  elements: Record<string, boolean>
+  relationships: Record<string, boolean>
+}
+
 export type UMLModel = {
   version: `4.${number}.${number}`
   id: string
@@ -63,6 +68,7 @@ export type UMLModel = {
   nodes: ApollonNode[]
   edges: ApollonEdge[]
   assessments: { [id: string]: Assessment }
+  interactive?: InteractiveElements
 }
 
 export enum ApollonView {
@@ -76,6 +82,7 @@ export type SvgExportMode = "web" | "compat"
 export type ApollonOptions = {
   type?: UMLDiagramType
   mode?: ApollonMode
+  view?: ApollonView
   readonly?: boolean
   enablePopups?: boolean
   model?: UMLModel
@@ -87,6 +94,7 @@ export type ApollonOptions = {
   debug?: boolean
   collaborationEnabled?: boolean
   scrollLock?: boolean
+  enableQuizMode?: boolean
 }
 
 export type FeedbackCorrectionStatus = {

--- a/library/lib/utils/exportUtils.ts
+++ b/library/lib/utils/exportUtils.ts
@@ -18,10 +18,53 @@ const svgFontStyles = `
 
 type SvgExportMode = "web" | "compat"
 
+type ExportFilterOptions = {
+  include?: string[]
+  exclude?: string[]
+  svgMode?: SvgExportMode
+}
+
+function shouldRenderElement(
+  elementId: string | null,
+  options?: ExportFilterOptions
+): boolean {
+  if (!elementId) {
+    return true
+  }
+
+  if (options?.include && options.include.length > 0) {
+    return options.include.includes(elementId)
+  }
+
+  if (options?.exclude && options.exclude.length > 0) {
+    return !options.exclude.includes(elementId)
+  }
+
+  return true
+}
+
+export function filterRenderedElements(
+  container: HTMLElement,
+  options?: ExportFilterOptions
+): void {
+  if (!options?.include?.length && !options?.exclude?.length) {
+    return
+  }
+
+  container
+    .querySelectorAll(".react-flow__node, .react-flow__edge")
+    .forEach((element) => {
+      const elementId = element.getAttribute("data-id") || element.id || null
+      if (!shouldRenderElement(elementId, options)) {
+        element.remove()
+      }
+    })
+}
+
 export const getSVG = (
   container: HTMLElement,
   clip: Rect,
-  options?: { svgMode?: SvgExportMode }
+  options?: ExportFilterOptions
 ): string => {
   const emptySVG = "<svg></svg>"
 
@@ -449,6 +492,127 @@ function getBoundingBox(edges: Edge[], nodes: Node[]) {
   }
 }
 
+function getNodeBoundsFromDOM(
+  container: HTMLElement,
+  reactFlow?: ReactFlowInstance<Node, Edge>
+): Rect | undefined {
+  const nodeElements = container.querySelectorAll(".react-flow__node")
+
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  let foundNode = false
+
+  nodeElements.forEach((nodeEl) => {
+    const styleStr = nodeEl.getAttribute("style") ?? ""
+    const styles = extractStyles(styleStr)
+    const svgElement = nodeEl.querySelector("svg")
+    const renderedSvgRect = svgElement?.getBoundingClientRect()
+    if (svgElement) {
+      const viewBox = svgElement.getAttribute("viewBox")
+      if (viewBox) {
+        const viewBoxParts = viewBox.split(/[\s,]+/).map(Number)
+        if (viewBoxParts.length >= 4) {
+          const [vbX, vbY, vbW, vbH] = viewBoxParts
+          const svgWidth =
+            renderedSvgRect?.width ??
+            parseFloat(svgElement.getAttribute("width") ?? `${vbW}`)
+          const svgHeight =
+            renderedSvgRect?.height ??
+            parseFloat(svgElement.getAttribute("height") ?? `${vbH}`)
+
+          if (
+            Number.isFinite(svgWidth) &&
+            Number.isFinite(svgHeight) &&
+            vbW !== 0 &&
+            vbH !== 0
+          ) {
+            try {
+              const bbox = (svgElement as SVGGraphicsElement).getBBox()
+              if (
+                Number.isFinite(bbox.x) &&
+                Number.isFinite(bbox.y) &&
+                Number.isFinite(bbox.width) &&
+                Number.isFinite(bbox.height) &&
+                (bbox.width > 0 || bbox.height > 0)
+              ) {
+                const scaleX = svgWidth / vbW
+                const scaleY = svgHeight / vbH
+                const bboxX = styles.transform.x + (bbox.x - vbX) * scaleX
+                const bboxY = styles.transform.y + (bbox.y - vbY) * scaleY
+                const bboxMaxX =
+                  styles.transform.x + (bbox.x + bbox.width - vbX) * scaleX
+                const bboxMaxY =
+                  styles.transform.y + (bbox.y + bbox.height - vbY) * scaleY
+
+                foundNode = true
+                minX = Math.min(minX, bboxX)
+                minY = Math.min(minY, bboxY)
+                maxX = Math.max(maxX, bboxMaxX)
+                maxY = Math.max(maxY, bboxMaxY)
+                return
+              }
+            } catch {
+              // Fall back to screen-rect or wrapper-based bounds when getBBox()
+              // is unavailable in the current renderer.
+            }
+          }
+        }
+      }
+    }
+
+    if (renderedSvgRect && reactFlow) {
+      const topLeft = reactFlow.screenToFlowPosition({
+        x: renderedSvgRect.left,
+        y: renderedSvgRect.top,
+      })
+      const bottomRight = reactFlow.screenToFlowPosition({
+        x: renderedSvgRect.right,
+        y: renderedSvgRect.bottom,
+      })
+
+      if (
+        Number.isFinite(topLeft.x) &&
+        Number.isFinite(topLeft.y) &&
+        Number.isFinite(bottomRight.x) &&
+        Number.isFinite(bottomRight.y)
+      ) {
+        foundNode = true
+        minX = Math.min(minX, topLeft.x)
+        minY = Math.min(minY, topLeft.y)
+        maxX = Math.max(maxX, bottomRight.x)
+        maxY = Math.max(maxY, bottomRight.y)
+        return
+      }
+    }
+
+    const width = renderedSvgRect?.width ?? parseFloat(styles.width ?? "")
+    const height = renderedSvgRect?.height ?? parseFloat(styles.height ?? "")
+
+    if (!Number.isFinite(width) || !Number.isFinite(height)) {
+      return
+    }
+
+    foundNode = true
+    minX = Math.min(minX, styles.transform.x)
+    minY = Math.min(minY, styles.transform.y)
+    maxX = Math.max(maxX, styles.transform.x + width)
+    maxY = Math.max(maxY, styles.transform.y + height)
+  })
+
+  if (!foundNode) {
+    return undefined
+  }
+
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  }
+}
+
 /**
  * Calculate bounding box from actual rendered edge paths in the DOM.
  * This accounts for:
@@ -866,6 +1030,36 @@ export function getDiagramBounds(
   return bounds
 }
 
+export function getRenderedDiagramBounds(
+  reactFlow: ReactFlowInstance<Node, Edge>,
+  container: HTMLElement
+): Rect {
+  let bounds = getNodeBoundsFromDOM(container, reactFlow)
+
+  const edgeBounds = getEdgeBoundsFromDOM(container)
+  if (bounds && edgeBounds) {
+    bounds = mergeBounds(bounds, edgeBounds)
+  } else if (!bounds && edgeBounds) {
+    bounds = edgeBounds
+  }
+
+  const overflowBounds = getNodeOverflowBoundsFromDOM(container)
+  if (bounds && overflowBounds) {
+    bounds = mergeBounds(bounds, overflowBounds)
+  } else if (!bounds && overflowBounds) {
+    bounds = overflowBounds
+  }
+
+  const textBounds = getTextBoundsFromDOM(container, reactFlow)
+  if (bounds && textBounds) {
+    bounds = mergeBounds(bounds, textBounds)
+  } else if (!bounds && textBounds) {
+    bounds = textBounds
+  }
+
+  return bounds ?? { x: 0, y: 0, width: 0, height: 0 }
+}
+
 function extractStyles(styleString: string) {
   const transformMatch = styleString.match(
     /transform:\s*translate\((-?\d+\.?\d*)px,\s*(-?\d+\.?\d*)px\)/
@@ -1211,6 +1405,8 @@ function removeMarkerElements(svg: Element): void {
  * @internal — Exported for unit testing only. Not part of the public API.
  */
 export const __testing = {
+  filterRenderedElements,
+  getRenderedDiagramBounds,
   extractPathPoints,
   extractStyles,
   resolveCSSVariable,
@@ -1220,5 +1416,6 @@ export const __testing = {
   removeMarkerElements,
   replaceTextDecorationWithManualUnderline,
   mergeBounds,
+  getNodeBoundsFromDOM,
   getNodeOverflowBoundsFromDOM,
 } as const

--- a/library/lib/utils/interactiveUtils.ts
+++ b/library/lib/utils/interactiveUtils.ts
@@ -1,0 +1,75 @@
+import { ApollonEdge, ApollonNode, InteractiveElements } from "@/typings"
+
+function filterInteractiveRecord(
+  record: Record<string, boolean> | undefined,
+  allowedIds: Set<string>
+): Record<string, boolean> {
+  if (!record) {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(record).filter(
+      ([id, included]) => included && allowedIds.has(id)
+    )
+  )
+}
+
+export function pruneInteractiveElements(
+  interactive: InteractiveElements | undefined,
+  nodes: Array<Pick<ApollonNode, "id">>,
+  edges: Array<Pick<ApollonEdge, "id">>
+): InteractiveElements | undefined {
+  if (!interactive) {
+    return undefined
+  }
+
+  const nodeIds = new Set(nodes.map((node) => node.id))
+  const edgeIds = new Set(edges.map((edge) => edge.id))
+
+  const elements = filterInteractiveRecord(interactive.elements, nodeIds)
+  const relationships = filterInteractiveRecord(
+    interactive.relationships,
+    edgeIds
+  )
+
+  if (
+    Object.keys(elements).length === 0 &&
+    Object.keys(relationships).length === 0
+  ) {
+    return undefined
+  }
+
+  return {
+    elements,
+    relationships,
+  }
+}
+
+export function toggleInteractiveRecord(
+  record: Record<string, boolean>,
+  id: string
+): Record<string, boolean> {
+  const nextRecord = { ...record }
+
+  if (nextRecord[id]) {
+    delete nextRecord[id]
+  } else {
+    nextRecord[id] = true
+  }
+
+  return nextRecord
+}
+
+export function hasInteractiveSelections(
+  interactive: InteractiveElements | undefined
+): boolean {
+  if (!interactive) {
+    return false
+  }
+
+  return (
+    Object.values(interactive.elements ?? {}).some(Boolean) ||
+    Object.values(interactive.relationships ?? {}).some(Boolean)
+  )
+}

--- a/library/lib/utils/versionConverter.ts
+++ b/library/lib/utils/versionConverter.ts
@@ -814,6 +814,23 @@ export function convertV3ToV4(v3Data: V3DiagramFormat | V3UMLModel): UMLModel {
     nodes,
     edges,
     assessments,
+    interactive:
+      model.interactive &&
+      (Object.values(model.interactive.elements ?? {}).some(Boolean) ||
+        Object.values(model.interactive.relationships ?? {}).some(Boolean))
+        ? {
+            elements: Object.fromEntries(
+              Object.entries(model.interactive.elements ?? {}).filter(
+                ([, included]) => included
+              )
+            ),
+            relationships: Object.fromEntries(
+              Object.entries(model.interactive.relationships ?? {}).filter(
+                ([, included]) => included
+              )
+            ),
+          }
+        : undefined,
   }
 }
 

--- a/standalone/webapp/src/pages/ApollonPlayground.tsx
+++ b/standalone/webapp/src/pages/ApollonPlayground.tsx
@@ -51,6 +51,7 @@ export const ApollonPlayground: React.FC = () => {
     readonly: false,
     debug: false,
     scrollLock: false,
+    enableQuizMode: false,
   })
 
   useEffect(() => {
@@ -193,6 +194,20 @@ export const ApollonPlayground: React.FC = () => {
             }}
           />
           <label className="font-semibold">Scroll Lock</label>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={apollonOptions.enableQuizMode}
+            onChange={(event) => {
+              setApollonOptions((prev) => ({
+                ...prev!,
+                enableQuizMode: event.target.checked,
+              }))
+            }}
+          />
+          <label className="font-semibold">Enable Quiz Mode</label>
         </div>
 
         {apollonOptions.mode === ApollonMode.Assessment &&

--- a/standalone/webapp/src/pages/ApollonPlayground.tsx
+++ b/standalone/webapp/src/pages/ApollonPlayground.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react"
 import {
   ApollonEditor,
   ApollonMode,
+  ApollonView,
   Locale,
   UMLDiagramType,
   ApollonOptions,
@@ -47,11 +48,11 @@ export const ApollonPlayground: React.FC = () => {
 
   const [apollonOptions, setApollonOptions] = useState<ApollonOptions>({
     mode: ApollonMode.Modelling,
+    availableViews: [ApollonView.Modelling],
     locale: Locale.en,
     readonly: false,
     debug: false,
     scrollLock: false,
-    enableQuizMode: false,
   })
 
   useEffect(() => {
@@ -199,15 +200,20 @@ export const ApollonPlayground: React.FC = () => {
         <div className="flex items-center gap-2">
           <input
             type="checkbox"
-            checked={apollonOptions.enableQuizMode}
+            checked={
+              apollonOptions.availableViews?.includes(ApollonView.Highlight) ??
+              false
+            }
             onChange={(event) => {
               setApollonOptions((prev) => ({
                 ...prev!,
-                enableQuizMode: event.target.checked,
+                availableViews: event.target.checked
+                  ? [ApollonView.Modelling, ApollonView.Highlight]
+                  : [ApollonView.Modelling],
               }))
             }}
           />
-          <label className="font-semibold">Enable Quiz Mode</label>
+          <label className="font-semibold">Enable Highlight View</label>
         </div>
 
         {apollonOptions.mode === ApollonMode.Assessment &&


### PR DESCRIPTION

<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

- [ ] I linked PR with a related issue
- [ ] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

This PR addresses the quiz-element export workflow needed by Artemis drag-and-drop quiz generation and makes quiz interactions explicitly opt-in.

### Description

This PR introduces an opt-in Quiz Mode flow in Apollon while keeping default behavior unchanged for existing consumers.

Main changes:
- Added an enableQuizMode option (default false) so quiz-related UI and interactions are only active when explicitly enabled.
- Added view handling for Modelling and Highlight states, used to switch between normal modelling and quiz-element selection.
- Updated sidebar behavior so quiz controls are hidden unless quiz mode is enabled.
- Added interactive element/relationship tracking in diagram state and model serialization (interactive field in model).
- Added utility functions to toggle and prune interactive selections.
- Integrated export filtering for include/exclude use cases and switched export bounds calculation to rendered DOM-based bounds merging (nodes, edges, overflow, text).
- Added Playground control (Enable Quiz Mode checkbox) to test the feature without exposing quiz controls by default in normal usage.

Compatibility:
- Existing integrations remain unaffected unless enableQuizMode is set to true.
- Default editor behavior remains normal modelling mode with no quiz-specific controls.

### Steps for Testing

1. Build and test:
1. Run npm run build:lib
2. Run npm run build:webapp
3. Run npm run test --workspace=@tumaet/apollon

2. Playground behavior:
1. Run npm run dev and open /playground
2. Verify Enable Quiz Mode is unchecked by default
3. Verify sidebar renders normal modelling tools only
4. Enable Quiz Mode and verify Model / Quiz Elements controls appear
5. Switch to Quiz Elements and click nodes/edges to mark them
6. Switch back to Model and verify normal modelling tools are shown again

3. Serialization and export behavior:
1. Select quiz elements in Quiz Elements view
2. Export JSON and verify interactive data is present for selected elements/relationships
3. Verify export still works when no interactive selections are made
4. Verify include/exclude-based export uses filtered rendered bounds

### Screenshots
