### PR TITLE
ci: create release tags automatically

### DIFF
--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -22,12 +22,15 @@ jobs:
     outputs:
       version: ${{ steps.v.outputs.version }}
       publish: ${{ steps.v.outputs.publish }}
+      release: ${{ steps.v.outputs.release }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.sha }}
 
       - id: v
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(node -p "require('./library/package.json').version")
           if [[ "$VERSION" == *-* || "$VERSION" == *+* ]]; then
@@ -40,12 +43,18 @@ jobs:
           else
             echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
+          TAG="@tumaet/apollon@${VERSION}"
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
   publish:
     name: Publish and release
     needs: [check]
-    if: needs.check.outputs.publish == 'true'
+    if: needs.check.outputs.publish == 'true' || needs.check.outputs.release == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm-publish
@@ -73,9 +82,27 @@ jobs:
         working-directory: library
 
       - run: npm publish --access public --tag latest --provenance
+        if: needs.check.outputs.publish == 'true'
         working-directory: library
 
+      - name: Ensure release tag exists
+        if: needs.check.outputs.release == 'true'
+        env:
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          TAG="@tumaet/apollon@${VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists on origin"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG" "$GITHUB_SHA"
+          git push origin "refs/tags/$TAG"
+
       - name: Create GitHub Release
+        if: needs.check.outputs.release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.check.outputs.version }}

--- a/.github/workflows/release-standalone.yml
+++ b/.github/workflows/release-standalone.yml
@@ -86,6 +86,22 @@ jobs:
             cosign sign --yes "$IMAGE@$DIGEST"
           done
 
+      - name: Ensure release tag exists
+        env:
+          VERSION: ${{ needs.check.outputs.version }}
+          COMMIT_SHA: ${{ needs.check.outputs.sha }}
+        run: |
+          TAG="v${VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists on origin"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG" "$COMMIT_SHA"
+          git push origin "refs/tags/$TAG"
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Checklist

- [ ] I linked PR with a related issue
- [ ] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

The release workflows currently call `gh release create ... --verify-tag` for both the library and standalone releases, but they do not create the required git tags beforehand.

That means a release can partially succeed and then fail at GitHub Release creation when the expected tag is missing:
- library expects `@tumaet/apollon@<version>`
- standalone expects `v<version>`

This PR fixes that release-flow gap by making CI create the required tag automatically before running the verified GitHub release step.

### Description

This PR updates the release workflows so they no longer depend on a manually created tag.

Changes:
- `release-library.yml`
  - detects whether the GitHub release still needs to be created
  - creates `@tumaet/apollon@<version>` if it does not already exist
  - keeps `--verify-tag` in place for `gh release create`
  - handles the rerun case where npm publish already succeeded but the GitHub release/tag is still missing
- `release-standalone.yml`
  - creates `v<version>` if it does not already exist
  - keeps `--verify-tag` in place for `gh release create`

### Steps for Testing

1. Review `.github/workflows/release-library.yml` and confirm the workflow now ensures `@tumaet/apollon@<version>` exists before `gh release create --verify-tag`.
2. Review `.github/workflows/release-standalone.yml` and confirm the workflow now ensures `v<version>` exists before `gh release create --verify-tag`.
3. Confirm both workflows are idempotent when the tag already exists on `origin`.
4. Merge this PR before the next release bump PR and verify the next release no longer requires manual tag creation.

