### PR TITLE
chore: bump apollon release to 4.2.22

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tumaet/apollon",
-  "version": "4.2.21",
+  "version": "4.2.22",
   "description": "An embeddable UML modeling editor for React. 13 diagram types, SVG/PNG/PDF/JSON export, optional real-time collaboration via Yjs.",
   "keywords": [
     "apollon",

--- a/standalone/server/package.json
+++ b/standalone/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tumaet/server",
-  "version": "4.2.21",
+  "version": "4.2.22",
   "private": true,
   "license": "MIT",
   "dependencies": {

--- a/standalone/webapp/package.json
+++ b/standalone/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tumaet/webapp",
   "private": true,
-  "version": "4.2.21",
+  "version": "4.2.22",
   "type": "module",
   "scripts": {
     "start": "vite",


### PR DESCRIPTION
### Checklist

- [ ] I linked PR with a related issue
- [ ] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

The previous release version `4.2.21` is already published on npm as `@tumaet/apollon@4.2.21`, so the release pipeline cannot publish that version again.

This PR moves the next release forward to `4.2.22` so the publish step can proceed with a new version.

### Description

This PR bumps the release version from `4.2.21` to `4.2.22` in:
- `library/package.json`
- `standalone/server/package.json`
- `standalone/webapp/package.json`

It also updates `package-lock.json` to keep workspace metadata aligned.

### Steps for Testing

1. Verify the version is `4.2.22` in:
   - `library/package.json`
   - `standalone/server/package.json`
   - `standalone/webapp/package.json`
2. Verify `package-lock.json` reflects the same workspace versions.
3. Confirm the CI workflow fix PR has been merged first, so release tags are created automatically.
4. Merge this PR into `main` and monitor the release workflows for the `4.2.22` release.

### Screenshots

