### PR TITLE
fix: use case line breaks

### DIFF
--- a/library/lib/components/svgs/nodes/useCaseDiagram/UseCaseNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/useCaseDiagram/UseCaseNodeSVG.tsx
@@ -51,9 +51,10 @@ export const UseCaseNodeSVG: React.FC<Props> = ({
   const scaledHeight = height * (SIDEBAR_PREVIEW_SCALE ?? 1)
 
   const { fillColor, strokeColor, textColor } = getCustomColorsFromData(data)
+  const textHorizontalPadding = 32
 
   const wrappedLines = useMemo(() => {
-    return wrapText(name, width - 20)
+    return wrapText(name, width - textHorizontalPadding)
   }, [name, width])
 
   return (

--- a/library/lib/components/svgs/nodes/useCaseDiagram/UseCaseNodeSVG.tsx
+++ b/library/lib/components/svgs/nodes/useCaseDiagram/UseCaseNodeSVG.tsx
@@ -6,9 +6,33 @@ import AssessmentIcon from "../../AssessmentIcon"
 import { SVGComponentProps } from "@/types/SVG"
 import { DefaultNodeProps } from "@/types"
 import { getCustomColorsFromData } from "@/utils/layoutUtils"
+import { useMemo } from "react"
 
 interface Props extends SVGComponentProps {
   data: DefaultNodeProps
+}
+
+const wrapText = (text: string, maxWidth: number): string[] => {
+  const words = text.split(" ")
+  const lines: string[] = []
+  let currentLine = ""
+
+  words.forEach((word) => {
+    const testLine = currentLine ? `${currentLine} ${word}` : word
+    const lineWidth = testLine.length * 7 // Approximation for font size 12px
+    if (lineWidth < maxWidth) {
+      currentLine = testLine
+    } else {
+      if (currentLine) lines.push(currentLine)
+      currentLine = word
+    }
+  })
+
+  if (currentLine) {
+    lines.push(currentLine)
+  }
+
+  return lines
 }
 
 export const UseCaseNodeSVG: React.FC<Props> = ({
@@ -27,6 +51,10 @@ export const UseCaseNodeSVG: React.FC<Props> = ({
   const scaledHeight = height * (SIDEBAR_PREVIEW_SCALE ?? 1)
 
   const { fillColor, strokeColor, textColor } = getCustomColorsFromData(data)
+
+  const wrappedLines = useMemo(() => {
+    return wrapText(name, width - 20)
+  }, [name, width])
 
   return (
     <svg
@@ -56,7 +84,18 @@ export const UseCaseNodeSVG: React.FC<Props> = ({
           dominantBaseline="middle"
           fill={textColor}
         >
-          {name}
+          {wrappedLines.map((line, index) => {
+            const lineHeight = 16
+            const totalLines = wrappedLines.length
+            const startY = (totalLines - 1) * -8
+            const dy = index === 0 ? startY : lineHeight
+
+            return (
+              <tspan key={index} x={width / 2} dy={dy}>
+                {line}
+              </tspan>
+            )
+          })}
         </CustomText>
       </g>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
     },
     "library": {
       "name": "@tumaet/apollon",
-      "version": "4.2.21",
+      "version": "4.2.22",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.1",
@@ -21895,7 +21895,7 @@
     },
     "standalone/server": {
       "name": "@tumaet/server",
-      "version": "4.2.21",
+      "version": "4.2.22",
       "license": "MIT",
       "dependencies": {
         "@tumaet/apollon": "*",
@@ -22142,7 +22142,7 @@
     },
     "standalone/webapp": {
       "name": "@tumaet/webapp",
-      "version": "4.2.21",
+      "version": "4.2.22",
       "dependencies": {
         "@mui/icons-material": "6.4.2",
         "@mui/material": "6.4.2",


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

- [x] I linked PR with a related issue
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
The text in UseCase Diagram's usecase node doesnt have a line break causing the text to overflow in x.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This PR completes #213

### Description

<!-- Describe your changes in detail -->

### Steps for Testing

<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a UseCase diagram
2. Add use-case element
3. Rename the usecase

### Screenshots

https://github.com/user-attachments/assets/ac64b93f-32a0-4658-be43-551bb031c648


<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
