### PR TITLE
feat(proxy): redirect alias hostnames to canonical APP_HOSTNAME

### DIFF
--- a/docker/compose.proxy.yml
+++ b/docker/compose.proxy.yml
@@ -78,6 +78,28 @@ services:
       - "traefik.http.routers.https-maintenance.tls=true"
       - "traefik.http.routers.http-maintenance.priority=1"
       - "traefik.http.routers.https-maintenance.priority=1"
+      # Legacy / alternate hostnames are 301'd to ${APP_HOSTNAME} so the
+      # browser address bar, analytics, and same-origin assumptions
+      # (CORS, cookies, CSP) all settle on a single canonical host.
+      # The capture-group $${1} survives Compose interpolation as ${1}
+      # for Traefik's regexp engine.
+      - "traefik.http.middlewares.redirect-to-canonical.redirectregex.regex=^https?://[^/]+/(.*)"
+      - "traefik.http.middlewares.redirect-to-canonical.redirectregex.replacement=https://${APP_HOSTNAME}/$${1}"
+      - "traefik.http.middlewares.redirect-to-canonical.redirectregex.permanent=true"
+      # APP_HOSTNAME_ALIASES_RULE must be a Traefik matcher, e.g.
+      #   Host(`a.example.com`, `b.example.com`)
+      # When unset, the HostRegexp default never matches and — because it
+      # exposes no concrete domains — does not trigger ACME provisioning.
+      - "traefik.http.routers.http-aliases.entryPoints=http"
+      - "traefik.http.routers.http-aliases.rule=${APP_HOSTNAME_ALIASES_RULE:-HostRegexp(`^aliases-disabled$`)}"
+      - "traefik.http.routers.http-aliases.middlewares=redirect-to-canonical"
+      - "traefik.http.routers.http-aliases.priority=1"
+      - "traefik.http.routers.https-aliases.entryPoints=https"
+      - "traefik.http.routers.https-aliases.rule=${APP_HOSTNAME_ALIASES_RULE:-HostRegexp(`^aliases-disabled$`)}"
+      - "traefik.http.routers.https-aliases.middlewares=redirect-to-canonical"
+      - "traefik.http.routers.https-aliases.tls=true"
+      - "traefik.http.routers.https-aliases.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.https-aliases.priority=1"
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1/"]
       interval: 30s


### PR DESCRIPTION
## Summary

The new prod VM (`apollon-prod.aet.cit.tum.de`) is becoming the single landing point for four hostnames as DNS migrates over:

| Hostname | Role |
| --- | --- |
| `apollon.aet.cit.tum.de` | **canonical** (new, public-facing) |
| `apollon-prod.aet.cit.tum.de` | VM hostname |
| `apollon.ase.cit.tum.de` | legacy |
| `apollon.ase.in.tum.de` | legacy |

This PR makes Traefik 301-redirect every non-canonical hostname to the canonical one (preserving path + query), while still terminating TLS on each alias so users with HTTPS bookmarks to legacy URLs don't hit a name-mismatch warning before the redirect.

Why redirect instead of multi-host serving:
- Single canonical URL in browser bar / analytics / share links
- Same-origin invariants (CORS, cookies, CSP) collapse onto one host
- One source of truth — easy to operate

## Changes

- `docker/compose.proxy.yml`: new `redirect-to-canonical` middleware (regexredirect → `https://${APP_HOSTNAME}/$1`, permanent 301) plus HTTP and HTTPS alias routers gated by a new `APP_HOSTNAME_ALIASES_RULE` env var.
- The HTTPS alias router requests its own LE cert via the existing `letsencrypt` resolver.
- When `APP_HOSTNAME_ALIASES_RULE` is unset (e.g. Staging) the rule falls back to a `HostRegexp` that never matches and exposes no concrete domain, so Traefik won't try to provision certs for prod hostnames on the Staging VM.

## Required deploy steps (Production)

After merge:

1. **Update GitHub Production environment variables** (Settings → Environments → Production):
   - Change `APP_HOSTNAME` from `apollon-prod.aet.cit.tum.de` → `apollon.aet.cit.tum.de`
   - Add `APP_HOSTNAME_ALIASES_RULE` = `` Host(`apollon-prod.aet.cit.tum.de`, `apollon.ase.cit.tum.de`, `apollon.ase.in.tum.de`) ``
2. **Run `Deploy to Production`** with `deploy-proxy=true` *and* `deploy-app=true` (the app routers also bind to `${APP_HOSTNAME}`, so they need a refresh).
3. Confirm the three aliases each return `301 Location: https://apollon.aet.cit.tum.de/...` over both HTTP and HTTPS, and that LE issued certs for each.

DNS for all four hostnames already resolves to the new VM (verified via `getent hosts`).

## Test plan

- [ ] `docker compose --env-file=.env -f docker/compose.proxy.yml config` renders the alias rule correctly with both prod values and an empty default
- [ ] After deploy: `curl -sI http://apollon.ase.cit.tum.de/foo?x=1` → `301` to `https://apollon.aet.cit.tum.de/foo?x=1`
- [ ] After deploy: `curl -sI https://apollon-prod.aet.cit.tum.de/` → `301`, valid TLS
- [ ] After deploy: `curl -sI https://apollon.aet.cit.tum.de/` → `200` (no redirect loop on canonical)
- [ ] Staging deploy with `APP_HOSTNAME_ALIASES_RULE` unset shows no ACME errors in Traefik logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)