### PR TITLE
chore(deploy): require APP_HOSTNAME and document canonical value

### DIFF
--- a/docker/compose.app.yml
+++ b/docker/compose.app.yml
@@ -21,7 +21,7 @@ services:
       - "traefik.docker.network=apollon-network"
       - "traefik.http.routers.http-webapp.entryPoints=http"
       - "traefik.http.routers.http-webapp.middlewares=redirect-to-https"
-      - "traefik.http.routers.http-webapp.rule=Host(`${APP_HOSTNAME}`)"
+      - "traefik.http.routers.http-webapp.rule=Host(`${APP_HOSTNAME:?APP_HOSTNAME must be set}`)"
       - "traefik.http.routers.http-webapp.service=http-webapp"
       - "traefik.http.routers.http-webapp.priority=2"
       - "traefik.http.routers.https-webapp.entryPoints=https"

--- a/docker/compose.proxy.yml
+++ b/docker/compose.proxy.yml
@@ -71,7 +71,7 @@ services:
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.routers.http-maintenance.entryPoints=http"
       - "traefik.http.routers.http-maintenance.middlewares=redirect-to-https"
-      - "traefik.http.routers.http-maintenance.rule=Host(`${APP_HOSTNAME}`)"
+      - "traefik.http.routers.http-maintenance.rule=Host(`${APP_HOSTNAME:?APP_HOSTNAME must be set}`)"
       - "traefik.http.routers.https-maintenance.entryPoints=https"
       - "traefik.http.routers.https-maintenance.rule=Host(`${APP_HOSTNAME}`)"
       - "traefik.http.routers.https-maintenance.tls.certresolver=letsencrypt"

--- a/docs/deployment/github-actions.md
+++ b/docs/deployment/github-actions.md
@@ -24,13 +24,13 @@ See [Releases](npm-publishing.md) for the release-cut procedure.
 
 Set per GitHub Environment. Values are deployment-specific; names are fixed.
 
-| Var | Purpose |
-| --- | --- |
-| `APP_HOSTNAME` | Public hostname the reverse proxy serves. |
-| `ACME_EMAIL` | Registration email for Let's Encrypt. |
-| `VM_HOST` | SSH target the deploy workflow connects to. |
-| `VM_USERNAME` | SSH user on the VM. |
-| `VM_SSH_PRIVATE_KEY` | SSH key (secret). |
+| Var | Purpose | Example |
+| --- | --- | --- |
+| `APP_HOSTNAME` | Single public hostname the reverse proxy serves and that Let's Encrypt issues a certificate for. | `apollon.aet.cit.tum.de` |
+| `ACME_EMAIL` | Registration email for Let's Encrypt. | `admin@tum.de` |
+| `VM_HOST` | SSH target the deploy workflow connects to. May differ from `APP_HOSTNAME`. | `apollon-prod.aet.cit.tum.de` |
+| `VM_USERNAME` | SSH user on the VM. | `github_deployment` |
+| `VM_SSH_PRIVATE_KEY` | SSH key (secret). | — |
 
 ## Run locally in Docker
 


### PR DESCRIPTION
## Summary

Hardening pulled out of the in-flight `apollon.ase.* → apollon.aet.cit.tum.de` DNS migration. Two small, related improvements to the deployment surface — no runtime behaviour change for a correctly-configured environment.

- **Make `APP_HOSTNAME` required.** Previously, an unset `APP_HOSTNAME` interpolated to an empty string and Traefik silently registered a malformed `` Host(``) `` rule that matched nothing. We already use `${ACME_EMAIL:?ACME_EMAIL must be set}` next door; apply the same guard so a misconfigured deploy fails immediately with a readable error.
- **Document the canonical value.** Add an example column to the deployment-vars table so the convention — one canonical public hostname, distinct from the SSH-target `VM_HOST` — is written down. Picks `apollon.aet.cit.tum.de` / `apollon-prod.aet.cit.tum.de` to match the live setup.

## Why now

Hostname migrations are exactly when the silent-empty-`Host()` failure mode bites. Worth catching before someone forgets to copy a variable into a fresh environment.

## Test plan

- [x] `APP_HOSTNAME=apollon.aet.cit.tum.de ACME_EMAIL=… docker compose -f docker/compose.proxy.yml -f docker/compose.app.yml config` — renders cleanly, all 8 `Host()` rules populated.
- [x] Same command without `APP_HOSTNAME` — fails with `required variable APP_HOSTNAME is missing a value: APP_HOSTNAME must be set` (no container starts).
- [ ] On merge: confirm the next prod deploy still picks up `APP_HOSTNAME` from the GitHub Production environment as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)