### PR TITLE
docs(deploy): fix APP_HOSTNAME_ALIASES_RULE example syntax

### DIFF
--- a/docs/deployment/github-actions.md
+++ b/docs/deployment/github-actions.md
@@ -36,7 +36,7 @@ Set per GitHub Environment. Values are deployment-specific; names are fixed.
 
 | Var | Purpose | Example |
 | --- | --- | --- |
-| `APP_HOSTNAME_ALIASES_RULE` | Traefik matcher listing additional hostnames that should permanently 301-redirect to `APP_HOSTNAME`. Each listed hostname also receives its own Let's Encrypt certificate so HTTPS bookmarks redirect cleanly. Leave unset on environments without aliases. | `` Host(`apollon-prod.aet.cit.tum.de`, `apollon.ase.cit.tum.de`, `apollon.ase.in.tum.de`) `` |
+| `APP_HOSTNAME_ALIASES_RULE` | Traefik matcher listing additional hostnames that should permanently 301-redirect to `APP_HOSTNAME`. Each listed hostname also receives its own Let's Encrypt certificate so HTTPS bookmarks redirect cleanly. Combine multiple hosts with `\|\|` — Traefik v3's `Host()` matcher takes a single argument. Leave unset on environments without aliases. | `` Host(`apollon-prod.aet.cit.tum.de`) \|\| Host(`apollon.ase.cit.tum.de`) \|\| Host(`apollon.ase.in.tum.de`) `` |
 
 ## Run locally in Docker
 


### PR DESCRIPTION
## Summary

Follow-up to #648. The example I added for `APP_HOSTNAME_ALIASES_RULE` used the comma-list form ``Host(`a`, `b`, `c`)``, which Traefik v3 accepts at parse time but rejects at runtime:

```
error while adding rule Host: unexpected number of parameters; got 3, expected one of [1]
```

Traefik v3's `Host()` matcher takes a single argument; combine multiple hosts with `||` instead. Update the example accordingly.

The runtime config (Production GitHub variable) has already been corrected; this PR aligns the docs with what actually works.

## Test plan

- [x] Confirmed by Traefik logs on the prod VM that the comma form fails to register the alias router
- [x] Confirmed the `||` form parses cleanly (after applying the same value via `gh variable set`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)