### PR TITLE
Fix/assessment popover in assessment mod

### DIFF
--- a/library/lib/components/toolbars/edgeToolBar/CustomEdgeToolBar.tsx
+++ b/library/lib/components/toolbars/edgeToolBar/CustomEdgeToolBar.tsx
@@ -106,9 +106,11 @@ export const CustomEdgeToolbar: React.FC<CustomEdgeToolbarProps> = ({
       .filter(({ x, y }) => Number.isFinite(x) && Number.isFinite(y))
 
     const nextPosition =
-      getToolbarCandidates(position).find((candidate) =>
-        draggers.every((dragger) => !overlapsDragger(candidate, dragger))
-      ) ?? defaultPosition
+      draggers.length === 0
+        ? defaultPosition
+        : (getToolbarCandidates(position).find((candidate) =>
+            draggers.every((dragger) => !overlapsDragger(candidate, dragger))
+          ) ?? defaultPosition)
 
     setToolbarPosition((currentPosition) =>
       currentPosition.x === nextPosition.x &&

--- a/library/lib/components/toolbars/edgeToolBar/CustomEdgeToolBar.tsx
+++ b/library/lib/components/toolbars/edgeToolBar/CustomEdgeToolBar.tsx
@@ -4,7 +4,62 @@ import { IPoint } from "@/edges"
 import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
 import { useIsOnlyThisElementSelected } from "@/hooks/useIsOnlyThisElementSelected"
 import { Box } from "@mui/material"
-import { useMemo } from "react"
+import { useLayoutEffect, useMemo, useState } from "react"
+
+const TOOLBAR_WIDTH = 32
+const TOOLBAR_HEIGHT = 56
+const TOOLBAR_GAP = 20
+const DRAGGER_CLEARANCE = 14
+
+const getDefaultToolbarPosition = (position: IPoint) => ({
+  x: position.x + 4,
+  y: position.y - 8,
+})
+
+const overlapsDragger = (toolbarPosition: IPoint, dragger: IPoint) => {
+  return (
+    dragger.x >= toolbarPosition.x - DRAGGER_CLEARANCE &&
+    dragger.x <= toolbarPosition.x + TOOLBAR_WIDTH + DRAGGER_CLEARANCE &&
+    dragger.y >= toolbarPosition.y - DRAGGER_CLEARANCE &&
+    dragger.y <= toolbarPosition.y + TOOLBAR_HEIGHT + DRAGGER_CLEARANCE
+  )
+}
+
+const getToolbarCandidates = (position: IPoint) => [
+  {
+    x: position.x + TOOLBAR_GAP,
+    y: position.y - TOOLBAR_HEIGHT / 2,
+  },
+  {
+    x: position.x - TOOLBAR_WIDTH - TOOLBAR_GAP,
+    y: position.y - TOOLBAR_HEIGHT / 2,
+  },
+  {
+    x: position.x - TOOLBAR_WIDTH / 2,
+    y: position.y - TOOLBAR_HEIGHT - TOOLBAR_GAP,
+  },
+  {
+    x: position.x - TOOLBAR_WIDTH / 2,
+    y: position.y + TOOLBAR_GAP,
+  },
+  {
+    x: position.x + TOOLBAR_GAP,
+    y: position.y - TOOLBAR_HEIGHT - TOOLBAR_GAP,
+  },
+  {
+    x: position.x - TOOLBAR_WIDTH - TOOLBAR_GAP,
+    y: position.y - TOOLBAR_HEIGHT - TOOLBAR_GAP,
+  },
+  {
+    x: position.x + TOOLBAR_GAP,
+    y: position.y + TOOLBAR_GAP,
+  },
+  {
+    x: position.x - TOOLBAR_WIDTH - TOOLBAR_GAP,
+    y: position.y + TOOLBAR_GAP,
+  },
+  getDefaultToolbarPosition(position),
+]
 
 interface CustomEdgeToolbarProps {
   edgeId: string
@@ -28,20 +83,48 @@ export const CustomEdgeToolbar: React.FC<CustomEdgeToolbarProps> = ({
     return selected && isDiagramModifiable
   }, [selected, isDiagramModifiable])
 
-  const toolbarPosition = useMemo(() => {
-    return {
-      x: position.x - 16,
-      y: position.y - 28,
+  const [toolbarPosition, setToolbarPosition] = useState<IPoint>(() =>
+    getDefaultToolbarPosition(position)
+  )
+
+  useLayoutEffect(() => {
+    const defaultPosition = getDefaultToolbarPosition(position)
+
+    if (!showToolbar || !anchorRef.current) {
+      setToolbarPosition(defaultPosition)
+      return
     }
-  }, [position.x, position.y, edgeId])
+
+    const edgeGroup = anchorRef.current.parentElement
+    const draggers = Array.from(
+      edgeGroup?.querySelectorAll<SVGCircleElement>(".edge-circle") ?? []
+    )
+      .map((circle) => ({
+        x: Number(circle.getAttribute("cx")),
+        y: Number(circle.getAttribute("cy")),
+      }))
+      .filter(({ x, y }) => Number.isFinite(x) && Number.isFinite(y))
+
+    const nextPosition =
+      getToolbarCandidates(position).find((candidate) =>
+        draggers.every((dragger) => !overlapsDragger(candidate, dragger))
+      ) ?? defaultPosition
+
+    setToolbarPosition((currentPosition) =>
+      currentPosition.x === nextPosition.x &&
+      currentPosition.y === nextPosition.y
+        ? currentPosition
+        : nextPosition
+    )
+  }, [anchorRef, position.x, position.y, showToolbar, edgeId])
 
   return (
     <foreignObject
       ref={anchorRef}
-      width={32}
-      height={56}
-      x={toolbarPosition.x + 20}
-      y={toolbarPosition.y + 20}
+      width={TOOLBAR_WIDTH}
+      height={TOOLBAR_HEIGHT}
+      x={toolbarPosition.x}
+      y={toolbarPosition.y}
     >
       {showToolbar && (
         <Box

--- a/library/lib/edges/EdgeProps.ts
+++ b/library/lib/edges/EdgeProps.ts
@@ -1,5 +1,6 @@
 import { Edge, EdgeProps } from "@xyflow/react"
 import { IPoint } from "./Connection"
+import { EdgeMode } from "./edgeMode"
 
 // Define message structure with direction
 export interface MessageData {
@@ -13,7 +14,8 @@ export type CustomEdgeProps = {
   sourceMultiplicity: string | null
   targetRole: string | null
   targetMultiplicity: string | null
-  points: IPoint[]
+  points?: IPoint[]
+  edgeMode?: EdgeMode
   label?: string | null
   messages?: MessageData[] // For communication diagram edges with direction-aware messages
   strokeColor?: string

--- a/library/lib/edges/edgeMode.ts
+++ b/library/lib/edges/edgeMode.ts
@@ -1,0 +1,38 @@
+import { IPoint } from "./Connection"
+
+export type EdgeMode = "AUTO" | "MANUAL"
+
+export interface EdgeRoutingData {
+  edgeMode?: EdgeMode
+  points?: IPoint[]
+  [key: string]: unknown
+}
+
+export function resolveEdgeMode(data?: EdgeRoutingData | null): EdgeMode {
+  if (data?.edgeMode === "AUTO" || data?.edgeMode === "MANUAL") {
+    return data.edgeMode
+  }
+
+  return Array.isArray(data?.points) && data.points.length > 2
+    ? "MANUAL"
+    : "AUTO"
+}
+
+export function toAutoEdgeData(data?: EdgeRoutingData | null): EdgeRoutingData {
+  return {
+    ...(data ?? {}),
+    edgeMode: "AUTO",
+    points: undefined,
+  }
+}
+
+export function toManualEdgeData(
+  points: IPoint[],
+  data?: EdgeRoutingData | null
+): EdgeRoutingData {
+  return {
+    ...(data ?? {}),
+    edgeMode: "MANUAL",
+    points,
+  }
+}

--- a/library/lib/edges/edgeTypes/ClassDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/ClassDiagramEdge.tsx
@@ -182,8 +182,8 @@ export const ClassDiagramEdge = ({
           sourceY={sourceY}
           targetX={targetX}
           targetY={targetY}
-          sourcePosition={sourcePosition}
-          targetPosition={targetPosition}
+          sourcePosition={edgeData.sourcePosition}
+          targetPosition={edgeData.targetPosition}
           textColor={textColor}
         />
 

--- a/library/lib/hooks/useConnect.ts
+++ b/library/lib/hooks/useConnect.ts
@@ -6,18 +6,34 @@ import {
   OnConnectStart,
   OnConnectStartParams,
   OnEdgesDelete,
+  ConnectionLineType,
 } from "@xyflow/react"
 import { useCallback, useRef } from "react"
-import { findClosestHandle, generateUUID, getDefaultEdgeType } from "@/utils"
+import {
+  findClosestHandle,
+  findStraightConnectionHandles,
+  getConnectionLineType,
+  generateUUID,
+  getDefaultEdgeType,
+} from "@/utils"
 import { DiagramNodeTypeRecord } from "@/nodes"
 import { useDiagramStore, useMetadataStore } from "@/store/context"
 import { useShallow } from "zustand/shallow"
 
+type ConnectionHandles = {
+  sourceHandle?: string | null
+  targetHandle?: string | null
+}
+
 export const useConnect = () => {
   const startEdge = useRef<Edge | null>(null)
   const connectionStartParams = useRef<OnConnectStartParams | null>(null)
-  const { screenToFlowPosition, getIntersectingNodes, getInternalNode } =
-    useReactFlow()
+  const {
+    screenToFlowPosition,
+    getIntersectingNodes,
+    getInternalNode,
+    getNode,
+  } = useReactFlow()
   const { setEdges, addEdge, edges } = useDiagramStore(
     useShallow((state) => ({
       setEdges: state.setEdges,
@@ -29,15 +45,127 @@ export const useConnect = () => {
   const diagramType = useMetadataStore(useShallow((state) => state.diagramType))
 
   const defaultEdgeType = getDefaultEdgeType(diagramType)
+  const shouldOptimizeStraightHandles =
+    getConnectionLineType(diagramType) === ConnectionLineType.Step
 
   const isFourHandleNode = useCallback(
     (nodeType?: string) =>
+      nodeType === DiagramNodeTypeRecord.bpmnStartEvent ||
+      nodeType === DiagramNodeTypeRecord.bpmnIntermediateEvent ||
+      nodeType === DiagramNodeTypeRecord.bpmnEndEvent ||
+      nodeType === DiagramNodeTypeRecord.bpmnGateway ||
       nodeType === DiagramNodeTypeRecord.componentInterface ||
+      nodeType === DiagramNodeTypeRecord.flowchartInputOutput ||
       nodeType === DiagramNodeTypeRecord.petriNetPlace ||
       nodeType === DiagramNodeTypeRecord.petriNetTransition ||
       nodeType === DiagramNodeTypeRecord.sfcTransitionBranch,
     []
   )
+
+  const getNodeRect = useCallback(
+    (nodeId: string) => {
+      const node = getNode(nodeId)
+      const internalNodeData = getInternalNode(nodeId)
+
+      if (
+        !node ||
+        !internalNodeData ||
+        node.width == null ||
+        node.height == null
+      ) {
+        return null
+      }
+
+      return {
+        node,
+        rect: {
+          x: internalNodeData.internals.positionAbsolute.x,
+          y: internalNodeData.internals.positionAbsolute.y,
+          width: node.width,
+          height: node.height,
+        },
+      }
+    },
+    [getInternalNode, getNode]
+  )
+
+  const getStraightConnectionHandles = useCallback(
+    ({
+      sourceNodeId,
+      targetNodeId,
+      sourceHandle,
+      targetHandle,
+      targetPoint,
+      allowSourceHandleAdjustment,
+    }: {
+      sourceNodeId: string
+      targetNodeId: string
+      sourceHandle?: string | null
+      targetHandle?: string | null
+      targetPoint?: { x: number; y: number }
+      allowSourceHandleAdjustment?: boolean
+    }) => {
+      if (!shouldOptimizeStraightHandles) {
+        return null
+      }
+
+      const sourceNodeInfo = getNodeRect(sourceNodeId)
+      const targetNodeInfo = getNodeRect(targetNodeId)
+
+      if (!sourceNodeInfo || !targetNodeInfo) {
+        return null
+      }
+
+      return findStraightConnectionHandles({
+        sourceRect: sourceNodeInfo.rect,
+        targetRect: targetNodeInfo.rect,
+        sourceHandle,
+        targetHandle,
+        targetPoint,
+        useFourSourceHandles: isFourHandleNode(sourceNodeInfo.node.type),
+        useFourTargetHandles: isFourHandleNode(targetNodeInfo.node.type),
+        allowSourceHandleAdjustment,
+      })
+    },
+    [getNodeRect, isFourHandleNode, shouldOptimizeStraightHandles]
+  )
+
+  const getPreferredConnectionHandles = useCallback(
+    ({
+      sourceNodeId,
+      targetNodeId,
+      sourceHandle,
+      targetHandle,
+      targetPoint,
+      allowSourceHandleAdjustment,
+    }: {
+      sourceNodeId: string
+      targetNodeId: string
+      sourceHandle?: string | null
+      targetHandle?: string | null
+      targetPoint?: { x: number; y: number }
+      allowSourceHandleAdjustment?: boolean
+    }): ConnectionHandles => {
+      const fallbackConnection = { sourceHandle, targetHandle }
+      const straightConnection = getStraightConnectionHandles({
+        sourceNodeId,
+        targetNodeId,
+        sourceHandle,
+        targetHandle,
+        targetPoint,
+        allowSourceHandleAdjustment,
+      })
+
+      return {
+        sourceHandle:
+          straightConnection?.sourceHandle ?? fallbackConnection.sourceHandle,
+        targetHandle:
+          straightConnection?.targetHandle ?? fallbackConnection.targetHandle,
+      }
+    },
+    [getStraightConnectionHandles]
+  )
+
   const getDropPosition = useCallback(
     (event: MouseEvent | TouchEvent) => {
       const { clientX, clientY } =
@@ -85,8 +213,18 @@ export const useConnect = () => {
 
   const onConnect = useCallback(
     (connection: Connection) => {
+      const preferredHandles = getPreferredConnectionHandles({
+        sourceNodeId: connection.source,
+        targetNodeId: connection.target,
+        sourceHandle: connection.sourceHandle,
+        targetHandle: connection.targetHandle,
+        allowSourceHandleAdjustment: true,
+      })
+
       const newEdge: Edge = {
         ...connection,
+        sourceHandle: preferredHandles.sourceHandle,
+        targetHandle: preferredHandles.targetHandle,
         id: generateUUID(),
         type: defaultEdgeType,
         selected: false,
@@ -94,7 +232,7 @@ export const useConnect = () => {
 
       addEdge(newEdge)
     },
-    [addEdge, defaultEdgeType]
+    [addEdge, defaultEdgeType, getPreferredConnectionHandles]
   )
 
   const onConnectEnd: OnConnectEnd = useCallback(
@@ -124,7 +262,7 @@ export const useConnect = () => {
         )
           return
 
-        const targetHandle = findClosestHandle({
+        const closestTargetHandle = findClosestHandle({
           point: dropPosition,
           rect: {
             x: internalNodeData.internals.positionAbsolute.x,
@@ -135,7 +273,9 @@ export const useConnect = () => {
           useFourHandles: isFourHandleNode(nodeOnTop.type),
         })
 
-        if (!targetHandle) return
+        if (!closestTargetHandle) return
+
+        const targetHandle = closestTargetHandle
 
         if (startEdge.current) {
           const updatedEdge = edges.find(
@@ -143,13 +283,34 @@ export const useConnect = () => {
           )
 
           if (!updatedEdge) return
+          const preferredHandles =
+            connectionStartParams.current?.handleType === "source"
+              ? getPreferredConnectionHandles({
+                  sourceNodeId: updatedEdge.source,
+                  targetNodeId: nodeOnTop.id,
+                  sourceHandle: updatedEdge.sourceHandle,
+                  targetHandle,
+                  targetPoint: dropPosition,
+                })
+              : getPreferredConnectionHandles({
+                  sourceNodeId: nodeOnTop.id,
+                  targetNodeId: updatedEdge.target,
+                  sourceHandle: targetHandle,
+                  targetHandle: updatedEdge.targetHandle,
+                  targetPoint: dropPosition,
+                })
+
           const newEdge =
             connectionStartParams.current?.handleType === "source"
-              ? { ...updatedEdge, target: nodeOnTop.id, targetHandle }
+              ? {
+                  ...updatedEdge,
+                  target: nodeOnTop.id,
+                  targetHandle: preferredHandles.targetHandle,
+                }
               : {
                   ...updatedEdge,
                   source: nodeOnTop.id,
-                  sourceHandle: targetHandle,
+                  sourceHandle: preferredHandles.sourceHandle,
                 }
 
           // Disallow loop from a handle to the same handle on the same node.
@@ -168,11 +329,19 @@ export const useConnect = () => {
         } else {
           const sourceNodeId = connectionState.fromNode!.id
           const sourceHandleId = connectionState.fromHandle?.id
+          const preferredHandles = getPreferredConnectionHandles({
+            sourceNodeId,
+            targetNodeId: nodeOnTop.id,
+            sourceHandle: sourceHandleId,
+            targetHandle,
+            targetPoint: dropPosition,
+            allowSourceHandleAdjustment: true,
+          })
 
           // Disallow loop from a handle to itself, but allow loops to other handles.
           if (
             sourceNodeId === nodeOnTop.id &&
-            sourceHandleId === targetHandle
+            preferredHandles.sourceHandle === preferredHandles.targetHandle
           ) {
             startEdge.current = null
             connectionStartParams.current = null
@@ -185,8 +354,8 @@ export const useConnect = () => {
               source: sourceNodeId,
               target: nodeOnTop.id,
               type: defaultEdgeType,
-              sourceHandle: sourceHandleId,
-              targetHandle,
+              sourceHandle: preferredHandles.sourceHandle,
+              targetHandle: preferredHandles.targetHandle,
             })
           )
         }
@@ -200,6 +369,7 @@ export const useConnect = () => {
       getDropPosition,
       getInternalNode,
       getIntersectingNodes,
+      getPreferredConnectionHandles,
       isFourHandleNode,
       setEdges,
     ]

--- a/library/lib/hooks/useConnect.ts
+++ b/library/lib/hooks/useConnect.ts
@@ -16,6 +16,7 @@ import {
   generateUUID,
   getDefaultEdgeType,
 } from "@/utils"
+import { toAutoEdgeData } from "@/edges/edgeMode"
 import { DiagramNodeTypeRecord } from "@/nodes"
 import { useDiagramStore, useMetadataStore } from "@/store/context"
 import { useShallow } from "zustand/shallow"
@@ -228,6 +229,7 @@ export const useConnect = () => {
         id: generateUUID(),
         type: defaultEdgeType,
         selected: false,
+        data: toAutoEdgeData(),
       }
 
       addEdge(newEdge)
@@ -356,6 +358,7 @@ export const useConnect = () => {
               type: defaultEdgeType,
               sourceHandle: preferredHandles.sourceHandle,
               targetHandle: preferredHandles.targetHandle,
+              data: toAutoEdgeData(),
             })
           )
         }

--- a/library/lib/hooks/useElementInteractions.ts
+++ b/library/lib/hooks/useElementInteractions.ts
@@ -1,4 +1,6 @@
 import { usePopoverStore } from "@/store/context"
+import { useMetadataStore } from "@/store"
+import { ApollonMode } from "@/typings"
 import {
   NodeMouseHandler,
   OnBeforeDelete,
@@ -11,25 +13,33 @@ import { useDiagramModifiable } from "./useDiagramModifiable"
 
 export const useElementInteractions = () => {
   const isDiagramModifiable = useDiagramModifiable()
+  const { mode, readonly } = useMetadataStore(
+    useShallow((state) => ({
+      mode: state.mode,
+      readonly: state.readonly,
+    }))
+  )
   const { setPopOverElementId } = usePopoverStore(
     useShallow((state) => ({
       setPopOverElementId: state.setPopOverElementId,
     }))
   )
+  const canOpenAssessmentPopover = mode === ApollonMode.Assessment && !readonly
+  const canOpenPopover = isDiagramModifiable || canOpenAssessmentPopover
 
   const onBeforeDelete: OnBeforeDelete = () => {
     return new Promise((resolve) => resolve(isDiagramModifiable))
   }
 
   const onNodeDoubleClick: NodeMouseHandler<Node> = (_event, node) => {
-    if (!isDiagramModifiable) {
+    if (!canOpenPopover) {
       return
     }
     setPopOverElementId(node.id)
   }
 
   const onEdgeDoubleClick: EdgeMouseHandler<Edge> = (_event, edge) => {
-    if (!isDiagramModifiable) {
+    if (!canOpenPopover) {
       return
     }
     setPopOverElementId(edge.id)

--- a/library/lib/hooks/useReconnect.ts
+++ b/library/lib/hooks/useReconnect.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react"
 import { useDiagramStore } from "@/store"
 import { Edge, Connection } from "@xyflow/react"
+import { toAutoEdgeData } from "@/edges/edgeMode"
 
 export const useReconnect = () => {
   const setEdges = useDiagramStore((state) => state.setEdges)
@@ -12,10 +13,7 @@ export const useReconnect = () => {
         target: newConnection.target,
         sourceHandle: newConnection.sourceHandle || oldEdge.sourceHandle,
         targetHandle: newConnection.targetHandle || oldEdge.targetHandle,
-        data: {
-          ...oldEdge.data,
-          points: [],
-        },
+        data: toAutoEdgeData(oldEdge.data),
       }
 
       setEdges((edges) =>

--- a/library/lib/hooks/useStepPathEdge.ts
+++ b/library/lib/hooks/useStepPathEdge.ts
@@ -21,7 +21,12 @@ import {
   removeDuplicatePoints,
   parseSvgPath,
   calculateInnerMidpoints,
+  alignCustomPathEndpointSegments,
+  calculateStraightPathBreakpoints,
+  createStraightPathDetour,
   getMarkerSegmentPath,
+  orthogonalizePoints,
+  getStraightPathOrientation,
 } from "@/utils/edgeUtils"
 import { useEdgeState, useEdgeReconnection } from "../edges/GenericEdge"
 import { useDiagramModifiable } from "./useDiagramModifiable"
@@ -239,7 +244,7 @@ export const useStepPathEdge = ({
     },
   })
 
-  // Reset custom points when nodes move
+  // Keep custom routes when connected nodes move.
   useEffect(() => {
     const currentSourcePos = {
       x: sourceNode.position.x,
@@ -271,40 +276,43 @@ export const useStepPathEdge = ({
       }
 
       if (customPoints.length > 0) {
+        let newPoints = customPoints
+
         if (sourceChanged && targetChanged) {
           const deltaX = currentSourcePos.x - prevSourcePos.x
           const deltaY = currentSourcePos.y - prevSourcePos.y
-          const newPoints = customPoints.map((point) =>
-            screenToFlowPosition({
-              x: point.x + deltaX,
-              y: point.y + deltaY,
-            })
-          )
 
-          setCustomPoints(newPoints)
-          setEdges((edges) =>
-            edges.map((edge) =>
-              edge.id === id
-                ? {
-                    ...edge,
-                    data: { ...edge.data, points: newPoints },
-                  }
-                : edge
-            )
-          )
-        } else {
-          setCustomPoints([])
-          setEdges((edges) =>
-            edges.map((edge) =>
-              edge.id === id
-                ? {
-                    ...edge,
-                    data: { ...edge.data, points: undefined },
-                  }
-                : edge
-            )
-          )
+          newPoints = customPoints.map((point) => ({
+            x: point.x + deltaX,
+            y: point.y + deltaY,
+          }))
         }
+
+        newPoints = alignCustomPathEndpointSegments(
+          newPoints,
+          {
+            x: adjustedSourceCoordinates.sourceX,
+            y: adjustedSourceCoordinates.sourceY,
+          },
+          {
+            x: adjustedTargetCoordinates.targetX,
+            y: adjustedTargetCoordinates.targetY,
+          },
+          sourcePosition,
+          targetPosition
+        )
+
+        setCustomPoints(newPoints)
+        setEdges((edges) =>
+          edges.map((edge) =>
+            edge.id === id
+              ? {
+                  ...edge,
+                  data: { ...edge.data, points: newPoints },
+                }
+              : edge
+          )
+        )
       }
     }
   }, [
@@ -315,6 +323,12 @@ export const useStepPathEdge = ({
     targetNode.position.y,
     targetNode.parentId,
     customPoints,
+    adjustedSourceCoordinates.sourceX,
+    adjustedSourceCoordinates.sourceY,
+    adjustedTargetCoordinates.targetX,
+    adjustedTargetCoordinates.targetY,
+    sourcePosition,
+    targetPosition,
     id,
     setEdges,
     setCustomPoints,
@@ -360,7 +374,23 @@ export const useStepPathEdge = ({
       }
     }
 
-    return points
+    if (points.length > 2) {
+      return alignCustomPathEndpointSegments(
+        points,
+        {
+          x: adjustedSourceCoordinates.sourceX,
+          y: adjustedSourceCoordinates.sourceY,
+        },
+        {
+          x: adjustedTargetCoordinates.targetX,
+          y: adjustedTargetCoordinates.targetY,
+        },
+        sourcePosition,
+        targetPosition
+      )
+    }
+
+    return orthogonalizePoints(points)
   }, [
     customPoints,
     computedPoints,
@@ -370,6 +400,8 @@ export const useStepPathEdge = ({
     adjustedSourceCoordinates.sourceY,
     adjustedTargetCoordinates.targetX,
     adjustedTargetCoordinates.targetY,
+    sourcePosition,
+    targetPosition,
   ])
 
   const currentPath = useMemo(() => {
@@ -386,8 +418,11 @@ export const useStepPathEdge = ({
   }, [currentPath, markerSegmentPath])
 
   const midpoints = useMemo(() => {
-    if (!allowMidpointDragging || activePoints.length < 3) return []
-    return calculateInnerMidpoints(activePoints)
+    if (!allowMidpointDragging) return []
+    const innerMidpoints = calculateInnerMidpoints(activePoints)
+    return innerMidpoints.length > 0
+      ? innerMidpoints
+      : calculateStraightPathBreakpoints(activePoints)
   }, [activePoints, allowMidpointDragging])
 
   useEffect(() => {
@@ -436,12 +471,24 @@ export const useStepPathEdge = ({
 
       // Store initial state
       const currentMidpoint = midpoints[index]
+      if (!currentMidpoint) return
+
+      const straightPathOrientation = getStraightPathOrientation(activePoints)
+      const isStraightPathBreakpoint = straightPathOrientation !== null
+      const straightPathBasePoints = [...activePoints]
+      const initialPointerPosition = screenToFlowPosition({
+        x: event.clientX,
+        y: event.clientY,
+      })
+      let hasDragged = false
+
       draggingIndexRef.current = index
       dragOffsetRef.current = {
-        x: event.clientX - currentMidpoint.x,
-        y: event.clientY - currentMidpoint.y,
+        x: initialPointerPosition.x - currentMidpoint.x,
+        y: initialPointerPosition.y - currentMidpoint.y,
       }
       dragPointsRef.current = [...activePoints]
+      finalPointsRef.current = [...activePoints]
 
       // Get DOM elements for direct manipulation (like React Flow does for nodes)
       const circleEl = event.target as SVGCircleElement
@@ -452,28 +499,66 @@ export const useStepPathEdge = ({
       const overlayPath = container?.querySelector(
         ".edge-overlay"
       ) as SVGPathElement | null
+      const midpointElements = Array.from(
+        container?.querySelectorAll(".edge-circle") ?? []
+      ) as SVGCircleElement[]
+
+      if (isStraightPathBreakpoint) {
+        midpointElements.forEach((element) => {
+          if (element !== circleEl) {
+            element.style.display = "none"
+          }
+        })
+      }
 
       const handlePointerMove = (e: PointerEvent) => {
         if (draggingIndexRef.current === null) return
 
         const idx = draggingIndexRef.current
-        const newX = e.clientX - dragOffsetRef.current.x
-        const newY = e.clientY - dragOffsetRef.current.y
+        const pointerPosition = screenToFlowPosition({
+          x: e.clientX,
+          y: e.clientY,
+        })
+        const newX = pointerPosition.x - dragOffsetRef.current.x
+        const newY = pointerPosition.y - dragOffsetRef.current.y
 
-        // Determine if this segment is horizontal or vertical
-        const pts = dragPointsRef.current
-        const isVertical = Math.abs(pts[idx + 1].x - pts[idx + 2].x) < 1
+        let newPoints: IPoint[]
+        if (isStraightPathBreakpoint) {
+          newPoints = createStraightPathDetour(
+            straightPathBasePoints,
+            currentMidpoint,
+            { x: newX, y: newY },
+            undefined,
+            midpoints,
+            idx
+          )
 
-        // Update the two points that define this segment
-        const newPoints = [...pts]
-        if (isVertical) {
-          newPoints[idx + 1] = { x: newX, y: pts[idx + 1].y }
-          newPoints[idx + 2] = { x: newX, y: pts[idx + 2].y }
+          const handlePoint =
+            straightPathOrientation === "vertical"
+              ? { x: newX, y: currentMidpoint.y }
+              : { x: currentMidpoint.x, y: newY }
+
+          circleEl.setAttribute("cx", String(handlePoint.x))
+          circleEl.setAttribute("cy", String(handlePoint.y))
         } else {
-          newPoints[idx + 1] = { x: pts[idx + 1].x, y: newY }
-          newPoints[idx + 2] = { x: pts[idx + 2].x, y: newY }
+          // Determine if this segment is horizontal or vertical
+          const pts = dragPointsRef.current
+          const isVertical = Math.abs(pts[idx + 1].x - pts[idx + 2].x) < 1
+
+          // Update the two points that define this segment
+          newPoints = [...pts]
+          if (isVertical) {
+            newPoints[idx + 1] = { x: newX, y: pts[idx + 1].y }
+            newPoints[idx + 2] = { x: newX, y: pts[idx + 2].y }
+          } else {
+            newPoints[idx + 1] = { x: pts[idx + 1].x, y: newY }
+            newPoints[idx + 2] = { x: pts[idx + 2].x, y: newY }
+          }
+          dragPointsRef.current = newPoints
         }
-        dragPointsRef.current = newPoints
+
+        newPoints = orthogonalizePoints(newPoints)
+        hasDragged = true
         finalPointsRef.current = newPoints
 
         // Direct DOM updates for instant feedback
@@ -484,24 +569,58 @@ export const useStepPathEdge = ({
           `${pathD} ${getMarkerSegmentPath(newPoints, offset, targetPosition)}`
         )
 
-        // Update circle position
-        const mids = calculateInnerMidpoints(newPoints)
-        if (mids[idx]) {
-          circleEl.setAttribute("cx", String(mids[idx].x))
-          circleEl.setAttribute("cy", String(mids[idx].y))
+        if (!isStraightPathBreakpoint) {
+          const mids = calculateInnerMidpoints(newPoints)
+          midpointElements.forEach((element, elementIndex) => {
+            const midpoint = mids[elementIndex]
+            if (midpoint) {
+              element.setAttribute("cx", String(midpoint.x))
+              element.setAttribute("cy", String(midpoint.y))
+            }
+          })
         }
       }
 
       const handlePointerUp = () => {
+        const nextPoints = finalPointsRef.current
+        const collapsedToStraight =
+          hasDragged &&
+          nextPoints.length === 2 &&
+          getStraightPathOrientation(nextPoints) !== null
+        const shouldPersist =
+          hasDragged &&
+          nextPoints.length > 2 &&
+          getStraightPathOrientation(nextPoints) === null
+
         // Sync to React state only on release
-        setCustomPoints(finalPointsRef.current)
-        setEdges((eds) =>
-          eds.map((e) =>
-            e.id === id
-              ? { ...e, data: { ...e.data, points: finalPointsRef.current } }
-              : e
+        if (shouldPersist) {
+          setCustomPoints(nextPoints)
+          setEdges((eds) =>
+            eds.map((e) =>
+              e.id === id
+                ? { ...e, data: { ...e.data, points: nextPoints } }
+                : e
+            )
           )
-        )
+        } else if (collapsedToStraight) {
+          setCustomPoints([])
+          setEdges((eds) =>
+            eds.map((e) =>
+              e.id === id
+                ? { ...e, data: { ...e.data, points: undefined } }
+                : e
+            )
+          )
+        } else {
+          midpointElements.forEach((element, elementIndex) => {
+            const midpoint = midpoints[elementIndex]
+            element.style.display = ""
+            if (midpoint) {
+              element.setAttribute("cx", String(midpoint.x))
+              element.setAttribute("cy", String(midpoint.y))
+            }
+          })
+        }
         draggingIndexRef.current = null
         document.removeEventListener("pointermove", handlePointerMove)
         document.removeEventListener("pointerup", handlePointerUp)
@@ -519,6 +638,7 @@ export const useStepPathEdge = ({
       setCustomPoints,
       offset,
       targetPosition,
+      screenToFlowPosition,
     ]
   )
 

--- a/library/lib/hooks/useStepPathEdge.ts
+++ b/library/lib/hooks/useStepPathEdge.ts
@@ -606,9 +606,7 @@ export const useStepPathEdge = ({
           setCustomPoints([])
           setEdges((eds) =>
             eds.map((e) =>
-              e.id === id
-                ? { ...e, data: { ...e.data, points: undefined } }
-                : e
+              e.id === id ? { ...e, data: { ...e.data, points: undefined } } : e
             )
           )
         } else {

--- a/library/lib/hooks/useStepPathEdge.ts
+++ b/library/lib/hooks/useStepPathEdge.ts
@@ -1,13 +1,17 @@
 import { useCallback, useMemo, useEffect, useRef, useState } from "react"
-import { getSmoothStepPath, useReactFlow } from "@xyflow/react"
+import {
+  getSmoothStepPath,
+  Position,
+  useReactFlow,
+  type Rect,
+} from "@xyflow/react"
 import { log } from "../logger"
-import { EDGES } from "@/constants"
+import { EDGES, MARKER_BASE_SIZE, MARKER_CONFIGS } from "@/constants"
 import {
   adjustSourceCoordinates,
   adjustTargetCoordinates,
   getPositionOnCanvas,
 } from "@/utils"
-import { Position } from "@xyflow/react"
 import {
   IPoint,
   pointsToSvgPath,
@@ -28,7 +32,15 @@ import {
   orthogonalizePoints,
   getStraightPathOrientation,
 } from "@/utils/edgeUtils"
+import { extractMarkerId } from "@/utils/pathParsing"
+import { computeAutoEdgeRoute } from "@/utils/edgeRouting"
 import { useEdgeState, useEdgeReconnection } from "../edges/GenericEdge"
+import {
+  EdgeMode,
+  resolveEdgeMode,
+  toAutoEdgeData,
+  toManualEdgeData,
+} from "../edges/edgeMode"
 import { useDiagramModifiable } from "./useDiagramModifiable"
 import { useHandleFinder } from "./useHandleFinder"
 
@@ -45,7 +57,7 @@ interface UseStepPathEdgeProps {
   targetPosition: Position
   sourceHandleId?: string | null
   targetHandleId?: string | null
-  data?: { points?: IPoint[] }
+  data?: { points?: IPoint[]; edgeMode?: EdgeMode }
   allowMidpointDragging?: boolean
   enableReconnection?: boolean
   enableStraightPath?: boolean
@@ -57,6 +69,9 @@ export interface StepPathEdgeData {
   isMiddlePathHorizontal: boolean
   sourcePoint: IPoint
   targetPoint: IPoint
+  sourcePosition: Position
+  targetPosition: Position
+  edgeMode: EdgeMode
 }
 
 export const useStepPathEdge = ({
@@ -77,6 +92,22 @@ export const useStepPathEdge = ({
   enableReconnection = true,
   enableStraightPath = false,
 }: UseStepPathEdgeProps) => {
+  const resolveMarkerSideInset = useCallback(
+    (markerUrl?: string): number => {
+      const markerId = extractMarkerId(markerUrl)
+      if (!markerId) {
+        return MARKER_BASE_SIZE
+      }
+
+      if (!(markerId in MARKER_CONFIGS)) {
+        return MARKER_BASE_SIZE
+      }
+
+      const markerConfig = MARKER_CONFIGS[markerId as keyof typeof MARKER_CONFIGS]
+      return markerConfig.size * markerConfig.widthFactor
+    },
+    []
+  )
   const draggingIndexRef = useRef<number | null>(null)
   const dragOffsetRef = useRef<IPoint>({ x: 0, y: 0 })
   const pathRef = useRef<SVGPathElement | null>(null)
@@ -100,6 +131,7 @@ export const useStepPathEdge = ({
     tempReconnectPoints,
     setTempReconnectPoints,
   } = useEdgeState(data?.points)
+  const resolvedEdgeMode = useMemo(() => resolveEdgeMode(data), [data])
   const {
     isReconnectingRef,
     reconnectingEndRef,
@@ -122,6 +154,18 @@ export const useStepPathEdge = ({
     offset = 0,
   } = getEdgeMarkerStyles(type)
   const padding = markerPadding ?? EDGES.MARKER_PADDING
+  const autoTargetEndpointPadding = Math.max(
+    0,
+    padding - EDGES.MARKER_PADDING
+  )
+  const sourceSideInset = useMemo(
+    () => resolveMarkerSideInset(markerStart),
+    [markerStart, resolveMarkerSideInset]
+  )
+  const targetSideInset = useMemo(
+    () => resolveMarkerSideInset(markerEnd),
+    [markerEnd, resolveMarkerSideInset]
+  )
   const sourceNode = getNode(source)!
   const targetNode = getNode(target)!
   const allNodes = getNodes()
@@ -142,26 +186,96 @@ export const useStepPathEdge = ({
   const roundedTargetX = Math.round(targetX)
   const roundedTargetY = Math.round(targetY)
 
-  const adjustedTargetCoordinates = adjustTargetCoordinates(
+  const manualAdjustedTargetCoordinates = adjustTargetCoordinates(
     roundedTargetX,
     roundedTargetY,
     targetPosition,
     padding
   )
-  const adjustedSourceCoordinates = adjustSourceCoordinates(
+  const manualAdjustedSourceCoordinates = adjustSourceCoordinates(
     roundedSourceX,
     roundedSourceY,
     sourcePosition,
     EDGES.SOURCE_CONNECTION_POINT_PADDING
   )
+  const sourceRect = useMemo<Rect>(
+    () => ({
+      x: sourceAbsolutePosition.x,
+      y: sourceAbsolutePosition.y,
+      width: sourceNode.width ?? 100,
+      height: sourceNode.height ?? 160,
+    }),
+    [sourceAbsolutePosition, sourceNode.width, sourceNode.height]
+  )
+  const targetRect = useMemo<Rect>(
+    () => ({
+      x: targetAbsolutePosition.x,
+      y: targetAbsolutePosition.y,
+      width: targetNode.width ?? 100,
+      height: targetNode.height ?? 160,
+    }),
+    [targetAbsolutePosition, targetNode.width, targetNode.height]
+  )
+  const autoRoute = useMemo(() => {
+    if (resolvedEdgeMode !== "AUTO" || !enableStraightPath) {
+      return null
+    }
+
+    return computeAutoEdgeRoute({
+      sourceRect,
+      targetRect,
+      markerPadding: padding,
+      sourcePadding: 0,
+      targetEndpointPadding: autoTargetEndpointPadding,
+      sourceSideInset,
+      targetSideInset,
+      preferStraight: true,
+      allowOrthogonalFallback: false,
+      borderRadius: EDGES.STEP_BORDER_RADIUS,
+      offset: 30,
+    })
+  }, [
+    resolvedEdgeMode,
+    enableStraightPath,
+    sourceRect,
+    targetRect,
+    padding,
+    autoTargetEndpointPadding,
+    sourceSideInset,
+    targetSideInset,
+  ])
+
+  const resolvedSourcePosition = autoRoute?.sourcePosition ?? sourcePosition
+  const resolvedTargetPosition = autoRoute?.targetPosition ?? targetPosition
+  const resolvedSourcePoint = autoRoute?.sourcePoint ?? {
+    x: manualAdjustedSourceCoordinates.sourceX,
+    y: manualAdjustedSourceCoordinates.sourceY,
+  }
+  const resolvedTargetPoint = autoRoute?.targetPoint ?? {
+    x: manualAdjustedTargetCoordinates.targetX,
+    y: manualAdjustedTargetCoordinates.targetY,
+  }
+  const resolvedSourceCoordinates = {
+    sourceX: resolvedSourcePoint.x,
+    sourceY: resolvedSourcePoint.y,
+  }
+  const resolvedTargetCoordinates = {
+    targetX: resolvedTargetPoint.x,
+    targetY: resolvedTargetPoint.y,
+  }
+
   const basePath = useMemo(() => {
+    if (resolvedEdgeMode === "AUTO" && autoRoute) {
+      return pointsToSvgPath(autoRoute.points)
+    }
+
     if (!enableStraightPath) {
       const [edgePath] = getSmoothStepPath({
-        sourceX: adjustedSourceCoordinates.sourceX,
-        sourceY: adjustedSourceCoordinates.sourceY,
+        sourceX: manualAdjustedSourceCoordinates.sourceX,
+        sourceY: manualAdjustedSourceCoordinates.sourceY,
         sourcePosition,
-        targetX: adjustedTargetCoordinates.targetX,
-        targetY: adjustedTargetCoordinates.targetY,
+        targetX: manualAdjustedTargetCoordinates.targetX,
+        targetY: manualAdjustedTargetCoordinates.targetY,
         targetPosition,
         borderRadius: EDGES.STEP_BORDER_RADIUS,
         offset: 30,
@@ -195,11 +309,11 @@ export const useStepPathEdge = ({
       return pointsToSvgPath(straightPathPoints)
     } else {
       const [edgePath] = getSmoothStepPath({
-        sourceX: adjustedSourceCoordinates.sourceX,
-        sourceY: adjustedSourceCoordinates.sourceY,
+        sourceX: manualAdjustedSourceCoordinates.sourceX,
+        sourceY: manualAdjustedSourceCoordinates.sourceY,
         sourcePosition,
-        targetX: adjustedTargetCoordinates.targetX,
-        targetY: adjustedTargetCoordinates.targetY,
+        targetX: manualAdjustedTargetCoordinates.targetX,
+        targetY: manualAdjustedTargetCoordinates.targetY,
         targetPosition,
         borderRadius: EDGES.STEP_BORDER_RADIUS,
         offset: 30,
@@ -207,6 +321,8 @@ export const useStepPathEdge = ({
       return edgePath
     }
   }, [
+    resolvedEdgeMode,
+    autoRoute,
     enableStraightPath,
     sourceAbsolutePosition,
     targetAbsolutePosition,
@@ -219,6 +335,10 @@ export const useStepPathEdge = ({
     targetX,
     targetY,
     padding,
+    manualAdjustedSourceCoordinates.sourceX,
+    manualAdjustedSourceCoordinates.sourceY,
+    manualAdjustedTargetCoordinates.targetX,
+    manualAdjustedTargetCoordinates.targetY,
   ])
 
   const computedPoints = useMemo(() => {
@@ -275,7 +395,7 @@ export const useStepPathEdge = ({
         target: currentTargetPos,
       }
 
-      if (customPoints.length > 0) {
+      if (resolvedEdgeMode === "MANUAL" && customPoints.length > 0) {
         let newPoints = customPoints
 
         if (sourceChanged && targetChanged) {
@@ -291,15 +411,15 @@ export const useStepPathEdge = ({
         newPoints = alignCustomPathEndpointSegments(
           newPoints,
           {
-            x: adjustedSourceCoordinates.sourceX,
-            y: adjustedSourceCoordinates.sourceY,
+            x: resolvedSourceCoordinates.sourceX,
+            y: resolvedSourceCoordinates.sourceY,
           },
           {
-            x: adjustedTargetCoordinates.targetX,
-            y: adjustedTargetCoordinates.targetY,
+            x: resolvedTargetCoordinates.targetX,
+            y: resolvedTargetCoordinates.targetY,
           },
-          sourcePosition,
-          targetPosition
+          resolvedSourcePosition,
+          resolvedTargetPosition
         )
 
         setCustomPoints(newPoints)
@@ -308,7 +428,7 @@ export const useStepPathEdge = ({
             edge.id === id
               ? {
                   ...edge,
-                  data: { ...edge.data, points: newPoints },
+                  data: toManualEdgeData(newPoints, edge.data),
                 }
               : edge
           )
@@ -322,13 +442,14 @@ export const useStepPathEdge = ({
     targetNode.position.x,
     targetNode.position.y,
     targetNode.parentId,
+    resolvedEdgeMode,
     customPoints,
-    adjustedSourceCoordinates.sourceX,
-    adjustedSourceCoordinates.sourceY,
-    adjustedTargetCoordinates.targetX,
-    adjustedTargetCoordinates.targetY,
-    sourcePosition,
-    targetPosition,
+    resolvedSourceCoordinates.sourceX,
+    resolvedSourceCoordinates.sourceY,
+    resolvedTargetCoordinates.targetX,
+    resolvedTargetCoordinates.targetY,
+    resolvedSourcePosition,
+    resolvedTargetPosition,
     id,
     setEdges,
     setCustomPoints,
@@ -338,6 +459,8 @@ export const useStepPathEdge = ({
     let points: IPoint[]
     if (tempReconnectPoints) {
       points = tempReconnectPoints
+    } else if (resolvedEdgeMode === "AUTO" && autoRoute) {
+      points = autoRoute.points
     } else if (data?.points && data.points.length > 0) {
       points = data.points
     } else {
@@ -348,12 +471,12 @@ export const useStepPathEdge = ({
     // This handles stale stored points when nodes have moved
     if (points.length >= 2) {
       const adjustedFirst = {
-        x: adjustedSourceCoordinates.sourceX,
-        y: adjustedSourceCoordinates.sourceY,
+        x: resolvedSourceCoordinates.sourceX,
+        y: resolvedSourceCoordinates.sourceY,
       }
       const adjustedLast = {
-        x: adjustedTargetCoordinates.targetX,
-        y: adjustedTargetCoordinates.targetY,
+        x: resolvedTargetCoordinates.targetX,
+        y: resolvedTargetCoordinates.targetY,
       }
       // Only update if significantly different (more than 1px) to avoid unnecessary re-renders
       const firstDiff =
@@ -374,34 +497,36 @@ export const useStepPathEdge = ({
       }
     }
 
-    if (points.length > 2) {
+    if (resolvedEdgeMode === "MANUAL" && points.length > 2) {
       return alignCustomPathEndpointSegments(
         points,
         {
-          x: adjustedSourceCoordinates.sourceX,
-          y: adjustedSourceCoordinates.sourceY,
+          x: resolvedSourceCoordinates.sourceX,
+          y: resolvedSourceCoordinates.sourceY,
         },
         {
-          x: adjustedTargetCoordinates.targetX,
-          y: adjustedTargetCoordinates.targetY,
+          x: resolvedTargetCoordinates.targetX,
+          y: resolvedTargetCoordinates.targetY,
         },
-        sourcePosition,
-        targetPosition
+        resolvedSourcePosition,
+        resolvedTargetPosition
       )
     }
 
     return orthogonalizePoints(points)
   }, [
+    resolvedEdgeMode,
+    autoRoute,
     customPoints,
     computedPoints,
     tempReconnectPoints,
     data?.points,
-    adjustedSourceCoordinates.sourceX,
-    adjustedSourceCoordinates.sourceY,
-    adjustedTargetCoordinates.targetX,
-    adjustedTargetCoordinates.targetY,
-    sourcePosition,
-    targetPosition,
+    resolvedSourceCoordinates.sourceX,
+    resolvedSourceCoordinates.sourceY,
+    resolvedTargetCoordinates.targetX,
+    resolvedTargetCoordinates.targetY,
+    resolvedSourcePosition,
+    resolvedTargetPosition,
   ])
 
   const currentPath = useMemo(() => {
@@ -409,8 +534,8 @@ export const useStepPathEdge = ({
   }, [activePoints])
 
   const markerSegmentPath = useMemo(
-    () => getMarkerSegmentPath(activePoints, offset, targetPosition),
-    [activePoints, offset, targetPosition]
+    () => getMarkerSegmentPath(activePoints, offset, resolvedTargetPosition),
+    [activePoints, offset, resolvedTargetPosition]
   )
 
   const overlayPath = useMemo(() => {
@@ -566,7 +691,7 @@ export const useStepPathEdge = ({
         mainPath?.setAttribute("d", pathD)
         overlayPath?.setAttribute(
           "d",
-          `${pathD} ${getMarkerSegmentPath(newPoints, offset, targetPosition)}`
+          `${pathD} ${getMarkerSegmentPath(newPoints, offset, resolvedTargetPosition)}`
         )
 
         if (!isStraightPathBreakpoint) {
@@ -598,7 +723,7 @@ export const useStepPathEdge = ({
           setEdges((eds) =>
             eds.map((e) =>
               e.id === id
-                ? { ...e, data: { ...e.data, points: nextPoints } }
+                ? { ...e, data: toManualEdgeData(nextPoints, e.data) }
                 : e
             )
           )
@@ -606,7 +731,7 @@ export const useStepPathEdge = ({
           setCustomPoints([])
           setEdges((eds) =>
             eds.map((e) =>
-              e.id === id ? { ...e, data: { ...e.data, points: undefined } } : e
+              e.id === id ? { ...e, data: toAutoEdgeData(e.data) } : e
             )
           )
         } else {
@@ -635,7 +760,7 @@ export const useStepPathEdge = ({
       allowMidpointDragging,
       setCustomPoints,
       offset,
-      targetPosition,
+      resolvedTargetPosition,
       screenToFlowPosition,
     ]
   )
@@ -659,10 +784,12 @@ export const useStepPathEdge = ({
           y: moveEvent.clientY,
         })
 
-        let newSourceX = sourceX
-        let newSourceY = sourceY
-        let newTargetX = targetX
-        let newTargetY = targetY
+        let newSourceX = activePoints[0]?.x ?? sourceX
+        let newSourceY = activePoints[0]?.y ?? sourceY
+        let newTargetX =
+          activePoints[activePoints.length - 1]?.x ?? targetX
+        let newTargetY =
+          activePoints[activePoints.length - 1]?.y ?? targetY
 
         if (reconnectingEndRef.current === "source") {
           newSourceX = newEndpoint.x
@@ -679,23 +806,23 @@ export const useStepPathEdge = ({
           const adjustedTargetCoordinates = adjustTargetCoordinates(
             newTargetX,
             newTargetY,
-            targetPosition,
+            resolvedTargetPosition,
             padding
           )
           const adjustedSourceCoordinates = adjustSourceCoordinates(
             newSourceX,
             newSourceY,
-            sourcePosition,
+            resolvedSourcePosition,
             EDGES.SOURCE_CONNECTION_POINT_PADDING
           )
 
           const [edgePath] = getSmoothStepPath({
             sourceX: adjustedSourceCoordinates.sourceX,
             sourceY: adjustedSourceCoordinates.sourceY,
-            sourcePosition,
+            sourcePosition: resolvedSourcePosition,
             targetX: adjustedTargetCoordinates.targetX,
             targetY: adjustedTargetCoordinates.targetY,
-            targetPosition,
+            targetPosition: resolvedTargetPosition,
             borderRadius: EDGES.STEP_BORDER_RADIUS,
             offset: 30,
           })
@@ -717,13 +844,13 @@ export const useStepPathEdge = ({
               position: { x: newSourceAbsolute.x, y: newSourceAbsolute.y },
               width: sourceNode.width ?? 100,
               height: sourceNode.height ?? 160,
-              direction: sourcePosition,
+              direction: resolvedSourcePosition,
             },
             {
               position: { x: newTargetAbsolute.x, y: newTargetAbsolute.y },
               width: targetNode.width ?? 100,
               height: targetNode.height ?? 160,
-              direction: targetPosition,
+              direction: resolvedTargetPosition,
             },
             padding,
             {
@@ -740,23 +867,23 @@ export const useStepPathEdge = ({
             const adjustedTargetCoordinates = adjustTargetCoordinates(
               newTargetX,
               newTargetY,
-              targetPosition,
+              resolvedTargetPosition,
               padding
             )
             const adjustedSourceCoordinates = adjustSourceCoordinates(
               newSourceX,
               newSourceY,
-              sourcePosition,
+              resolvedSourcePosition,
               EDGES.SOURCE_CONNECTION_POINT_PADDING
             )
 
             const [edgePath] = getSmoothStepPath({
               sourceX: adjustedSourceCoordinates.sourceX,
               sourceY: adjustedSourceCoordinates.sourceY,
-              sourcePosition,
+              sourcePosition: resolvedSourcePosition,
               targetX: adjustedTargetCoordinates.targetX,
               targetY: adjustedTargetCoordinates.targetY,
-              targetPosition,
+              targetPosition: resolvedTargetPosition,
               borderRadius: EDGES.STEP_BORDER_RADIUS,
               offset: 30,
             })
@@ -805,8 +932,8 @@ export const useStepPathEdge = ({
       sourceY,
       targetX,
       targetY,
-      sourcePosition,
-      targetPosition,
+      resolvedSourcePosition,
+      resolvedTargetPosition,
       type,
       padding,
       sourceAbsolutePosition,
@@ -817,10 +944,10 @@ export const useStepPathEdge = ({
     ]
   )
 
-  const sourcePoint = activePoints[0] || { x: sourceX, y: sourceY }
+  const sourcePoint = activePoints[0] || resolvedSourcePoint
   const targetPoint = activePoints[activePoints.length - 1] || {
-    x: targetX,
-    y: targetY,
+    x: resolvedTargetPoint.x,
+    y: resolvedTargetPoint.y,
   }
 
   const edgeData: StepPathEdgeData = {
@@ -829,6 +956,9 @@ export const useStepPathEdge = ({
     isMiddlePathHorizontal,
     sourcePoint,
     targetPoint,
+    sourcePosition: resolvedSourcePosition,
+    targetPosition: resolvedTargetPosition,
+    edgeMode: resolvedEdgeMode,
   }
 
   return {

--- a/library/lib/hooks/useStepPathEdge.ts
+++ b/library/lib/hooks/useStepPathEdge.ts
@@ -92,22 +92,19 @@ export const useStepPathEdge = ({
   enableReconnection = true,
   enableStraightPath = false,
 }: UseStepPathEdgeProps) => {
-  const resolveMarkerSideInset = useCallback(
-    (markerUrl?: string): number => {
-      const markerId = extractMarkerId(markerUrl)
-      if (!markerId) {
-        return MARKER_BASE_SIZE
-      }
+  const resolveMarkerSideInset = useCallback((markerUrl?: string): number => {
+    const markerId = extractMarkerId(markerUrl)
+    if (!markerId) {
+      return MARKER_BASE_SIZE
+    }
 
-      if (!(markerId in MARKER_CONFIGS)) {
-        return MARKER_BASE_SIZE
-      }
+    if (!(markerId in MARKER_CONFIGS)) {
+      return MARKER_BASE_SIZE
+    }
 
-      const markerConfig = MARKER_CONFIGS[markerId as keyof typeof MARKER_CONFIGS]
-      return markerConfig.size * markerConfig.widthFactor
-    },
-    []
-  )
+    const markerConfig = MARKER_CONFIGS[markerId as keyof typeof MARKER_CONFIGS]
+    return markerConfig.size * markerConfig.widthFactor
+  }, [])
   const draggingIndexRef = useRef<number | null>(null)
   const dragOffsetRef = useRef<IPoint>({ x: 0, y: 0 })
   const pathRef = useRef<SVGPathElement | null>(null)
@@ -154,10 +151,7 @@ export const useStepPathEdge = ({
     offset = 0,
   } = getEdgeMarkerStyles(type)
   const padding = markerPadding ?? EDGES.MARKER_PADDING
-  const autoTargetEndpointPadding = Math.max(
-    0,
-    padding - EDGES.MARKER_PADDING
-  )
+  const autoTargetEndpointPadding = Math.max(0, padding - EDGES.MARKER_PADDING)
   const sourceSideInset = useMemo(
     () => resolveMarkerSideInset(markerStart),
     [markerStart, resolveMarkerSideInset]
@@ -786,10 +780,8 @@ export const useStepPathEdge = ({
 
         let newSourceX = activePoints[0]?.x ?? sourceX
         let newSourceY = activePoints[0]?.y ?? sourceY
-        let newTargetX =
-          activePoints[activePoints.length - 1]?.x ?? targetX
-        let newTargetY =
-          activePoints[activePoints.length - 1]?.y ?? targetY
+        let newTargetX = activePoints[activePoints.length - 1]?.x ?? targetX
+        let newTargetY = activePoints[activePoints.length - 1]?.y ?? targetY
 
         if (reconnectingEndRef.current === "source") {
           newSourceX = newEndpoint.x

--- a/library/lib/typings.ts
+++ b/library/lib/typings.ts
@@ -1,10 +1,12 @@
 import { DiagramEdgeType, IPoint } from "./edges/types"
+import { EdgeMode } from "./edges/edgeMode"
 import { DiagramNodeType } from "./nodes/types"
 import { UMLDiagramType } from "./types/DiagramType"
 import { Styles } from "./styles/theme"
 import { DeepPartial } from "./utils"
 
 export { UMLDiagramType, type DiagramNodeType, type DiagramEdgeType }
+export { type EdgeMode }
 export { type Styles }
 
 export type Unsubscriber = () => void
@@ -52,6 +54,7 @@ export type ApollonEdge = {
   data: {
     [key: string]: unknown
     points: IPoint[]
+    edgeMode?: EdgeMode
   }
 }
 

--- a/library/lib/utils/edgeRouting.ts
+++ b/library/lib/utils/edgeRouting.ts
@@ -1,0 +1,324 @@
+import { EDGES } from "@/constants"
+import { IPoint, tryFindStraightPath } from "@/edges/Connection"
+import { Position, getSmoothStepPath, type Rect } from "@xyflow/react"
+import {
+  adjustSourceCoordinates,
+  adjustTargetCoordinates,
+  orthogonalizePoints,
+  parseSvgPath,
+  removeDuplicatePoints,
+  simplifySvgPath,
+} from "./edgeUtils"
+
+interface SidePair {
+  source: Position
+  target: Position
+}
+
+const STRAIGHT_SIDE_PAIRS: SidePair[] = [
+  { source: Position.Right, target: Position.Left },
+  { source: Position.Left, target: Position.Right },
+  { source: Position.Bottom, target: Position.Top },
+  { source: Position.Top, target: Position.Bottom },
+]
+
+export interface ComputeAutoEdgeRouteParams {
+  sourceRect: Rect
+  targetRect: Rect
+  markerPadding: number
+  sourcePadding?: number
+  targetEndpointPadding?: number
+  sourceSideInset?: number
+  targetSideInset?: number
+  preferStraight?: boolean
+  allowOrthogonalFallback?: boolean
+  borderRadius?: number
+  offset?: number
+}
+
+export interface AutoEdgeRoute {
+  sourcePosition: Position
+  targetPosition: Position
+  sourcePoint: IPoint
+  targetPoint: IPoint
+  points: IPoint[]
+  pathType: "straight" | "step"
+}
+
+function getRectCenter(rect: Rect): IPoint {
+  return {
+    x: rect.x + rect.width / 2,
+    y: rect.y + rect.height / 2,
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function clampAxisWithInset(
+  axisValue: number,
+  start: number,
+  size: number,
+  inset: number
+): number {
+  const normalizedInset = Math.max(0, inset)
+  const min = start + normalizedInset
+  const max = start + size - normalizedInset
+
+  if (min <= max) {
+    return clamp(axisValue, min, max)
+  }
+
+  return start + size / 2
+}
+
+function getBoundaryPoint(
+  rect: Rect,
+  side: Position,
+  sideAxisValue: number,
+  sideInset: number
+): IPoint {
+  switch (side) {
+    case Position.Top:
+      return {
+        x: clampAxisWithInset(sideAxisValue, rect.x, rect.width, sideInset),
+        y: rect.y,
+      }
+    case Position.Right:
+      return {
+        x: rect.x + rect.width,
+        y: clampAxisWithInset(sideAxisValue, rect.y, rect.height, sideInset),
+      }
+    case Position.Bottom:
+      return {
+        x: clampAxisWithInset(sideAxisValue, rect.x, rect.width, sideInset),
+        y: rect.y + rect.height,
+      }
+    case Position.Left:
+      return {
+        x: rect.x,
+        y: clampAxisWithInset(sideAxisValue, rect.y, rect.height, sideInset),
+      }
+  }
+}
+
+function applySideInsetToBoundaryPoint(
+  point: IPoint,
+  rect: Rect,
+  side: Position,
+  sideInset: number
+): IPoint {
+  switch (side) {
+    case Position.Top:
+      return {
+        x: clampAxisWithInset(point.x, rect.x, rect.width, sideInset),
+        y: rect.y,
+      }
+    case Position.Right:
+      return {
+        x: rect.x + rect.width,
+        y: clampAxisWithInset(point.y, rect.y, rect.height, sideInset),
+      }
+    case Position.Bottom:
+      return {
+        x: clampAxisWithInset(point.x, rect.x, rect.width, sideInset),
+        y: rect.y + rect.height,
+      }
+    case Position.Left:
+      return {
+        x: rect.x,
+        y: clampAxisWithInset(point.y, rect.y, rect.height, sideInset),
+      }
+  }
+}
+
+function adjustedEndpoint(
+  point: IPoint,
+  side: Position,
+  padding: number,
+  kind: "source" | "target"
+): IPoint {
+  if (kind === "source") {
+    const adjusted = adjustSourceCoordinates(point.x, point.y, side, padding)
+    return { x: adjusted.sourceX, y: adjusted.sourceY }
+  }
+
+  const adjusted = adjustTargetCoordinates(point.x, point.y, side, padding)
+  return { x: adjusted.targetX, y: adjusted.targetY }
+}
+
+function getFallbackSidePair(sourceRect: Rect, targetRect: Rect): SidePair {
+  const sourceCenter = getRectCenter(sourceRect)
+  const targetCenter = getRectCenter(targetRect)
+  const dx = targetCenter.x - sourceCenter.x
+  const dy = targetCenter.y - sourceCenter.y
+
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    return dx >= 0
+      ? { source: Position.Right, target: Position.Left }
+      : { source: Position.Left, target: Position.Right }
+  }
+
+  return dy >= 0
+    ? { source: Position.Bottom, target: Position.Top }
+    : { source: Position.Top, target: Position.Bottom }
+}
+
+function calculatePairDistance(points: IPoint[]): number {
+  if (points.length < 2) return Number.POSITIVE_INFINITY
+  const start = points[0]
+  const end = points[points.length - 1]
+  return Math.hypot(end.x - start.x, end.y - start.y)
+}
+
+export function computeAutoEdgeRoute({
+  sourceRect,
+  targetRect,
+  markerPadding,
+  sourcePadding = EDGES.SOURCE_CONNECTION_POINT_PADDING,
+  targetEndpointPadding = markerPadding,
+  sourceSideInset = 0,
+  targetSideInset = 0,
+  preferStraight = true,
+  allowOrthogonalFallback = true,
+  borderRadius = EDGES.STEP_BORDER_RADIUS,
+  offset = 30,
+}: ComputeAutoEdgeRouteParams): AutoEdgeRoute | null {
+  const straightCandidates = STRAIGHT_SIDE_PAIRS.map((pair) => {
+    const straightPoints = tryFindStraightPath(
+      {
+        position: { x: sourceRect.x, y: sourceRect.y },
+        width: sourceRect.width,
+        height: sourceRect.height,
+        direction: pair.source,
+      },
+      {
+        position: { x: targetRect.x, y: targetRect.y },
+        width: targetRect.width,
+        height: targetRect.height,
+        direction: pair.target,
+      },
+      markerPadding
+    )
+
+    if (!straightPoints || straightPoints.length < 2) {
+      return null
+    }
+
+    const sourceBoundaryPoint = applySideInsetToBoundaryPoint(
+      straightPoints[0],
+      sourceRect,
+      pair.source,
+      sourceSideInset
+    )
+    const targetBoundaryPoint = applySideInsetToBoundaryPoint(
+      straightPoints[straightPoints.length - 1],
+      targetRect,
+      pair.target,
+      targetSideInset
+    )
+    const sourcePoint = adjustedEndpoint(
+      sourceBoundaryPoint,
+      pair.source,
+      sourcePadding,
+      "source"
+    )
+    const targetPoint = adjustedEndpoint(
+      targetBoundaryPoint,
+      pair.target,
+      targetEndpointPadding,
+      "target"
+    )
+
+    const points = [sourcePoint, targetPoint]
+    return {
+      sourcePosition: pair.source,
+      targetPosition: pair.target,
+      sourcePoint,
+      targetPoint,
+      points,
+      pathType: "straight" as const,
+    }
+  }).filter(
+    (candidate): candidate is NonNullable<typeof candidate> => candidate !== null
+  )
+
+  if (preferStraight && straightCandidates.length > 0) {
+    return straightCandidates.reduce((best, candidate) => {
+      return calculatePairDistance(candidate.points) <
+        calculatePairDistance(best.points)
+        ? candidate
+        : best
+    })
+  }
+
+  if (!allowOrthogonalFallback) {
+    return null
+  }
+
+  const pair = getFallbackSidePair(sourceRect, targetRect)
+  const sourceCenter = getRectCenter(sourceRect)
+  const targetCenter = getRectCenter(targetRect)
+  const sharedAxisValue =
+    pair.source === Position.Left || pair.source === Position.Right
+      ? (sourceCenter.y + targetCenter.y) / 2
+      : (sourceCenter.x + targetCenter.x) / 2
+
+  const rawSourcePoint = getBoundaryPoint(
+    sourceRect,
+    pair.source,
+    sharedAxisValue,
+    sourceSideInset
+  )
+  const rawTargetPoint = getBoundaryPoint(
+    targetRect,
+    pair.target,
+    sharedAxisValue,
+    targetSideInset
+  )
+  const sourcePoint = adjustedEndpoint(
+    rawSourcePoint,
+    pair.source,
+    sourcePadding,
+    "source"
+  )
+  const targetPoint = adjustedEndpoint(
+    rawTargetPoint,
+    pair.target,
+    targetEndpointPadding,
+    "target"
+  )
+
+  const [edgePath] = getSmoothStepPath({
+    sourceX: sourcePoint.x,
+    sourceY: sourcePoint.y,
+    sourcePosition: pair.source,
+    targetX: targetPoint.x,
+    targetY: targetPoint.y,
+    targetPosition: pair.target,
+    borderRadius,
+    offset,
+  })
+
+  const simplifiedPath = simplifySvgPath(edgePath)
+  const parsedPath = removeDuplicatePoints(parseSvgPath(simplifiedPath))
+  let points = orthogonalizePoints(parsedPath)
+
+  if (points.length < 2) {
+    points = [sourcePoint, targetPoint]
+  } else {
+    points = [...points]
+    points[0] = sourcePoint
+    points[points.length - 1] = targetPoint
+  }
+
+  return {
+    sourcePosition: pair.source,
+    targetPosition: pair.target,
+    sourcePoint,
+    targetPoint,
+    points,
+    pathType: "step",
+  }
+}

--- a/library/lib/utils/edgeRouting.ts
+++ b/library/lib/utils/edgeRouting.ts
@@ -241,7 +241,8 @@ export function computeAutoEdgeRoute({
       pathType: "straight" as const,
     }
   }).filter(
-    (candidate): candidate is NonNullable<typeof candidate> => candidate !== null
+    (candidate): candidate is NonNullable<typeof candidate> =>
+      candidate !== null
   )
 
   if (preferStraight && straightCandidates.length > 0) {

--- a/library/lib/utils/edgeUtils.ts
+++ b/library/lib/utils/edgeUtils.ts
@@ -339,6 +339,280 @@ function distance(p1: XYPosition, p2: XYPosition): number {
   return Math.sqrt((p1.x - p2.x) ** 2 + (p1.y - p2.y) ** 2)
 }
 
+type HandleAxis = "x" | "y"
+
+interface HandlePositionSpec {
+  label: string
+  side: Position
+  ratio: number
+}
+
+interface HandlePositionCandidate extends HandlePositionSpec {
+  position: XYPosition
+}
+
+const BASIC_HANDLE_IDS = new Set(["top", "right", "bottom", "left"])
+
+// Mirrors DefaultNodeWrapper's rectangular handle layout. Hidden midpoint
+// handles are included because edges may attach to them programmatically.
+const RECTANGULAR_HANDLE_SPECS: HandlePositionSpec[] = [
+  { label: "top-left", side: Position.Top, ratio: 0.2 },
+  { label: "top-mid-left", side: Position.Top, ratio: 0.35 },
+  { label: "top", side: Position.Top, ratio: 0.5 },
+  { label: "top-mid-right", side: Position.Top, ratio: 0.65 },
+  { label: "top-right", side: Position.Top, ratio: 0.8 },
+  { label: "right-top", side: Position.Right, ratio: 0.2 },
+  { label: "right-mid-top", side: Position.Right, ratio: 0.35 },
+  { label: "right", side: Position.Right, ratio: 0.5 },
+  { label: "right-mid-bottom", side: Position.Right, ratio: 0.65 },
+  { label: "right-bottom", side: Position.Right, ratio: 0.8 },
+  { label: "bottom-right", side: Position.Bottom, ratio: 0.8 },
+  { label: "bottom-mid-right", side: Position.Bottom, ratio: 0.65 },
+  { label: "bottom", side: Position.Bottom, ratio: 0.5 },
+  { label: "bottom-mid-left", side: Position.Bottom, ratio: 0.35 },
+  { label: "bottom-left", side: Position.Bottom, ratio: 0.2 },
+  { label: "left-bottom", side: Position.Left, ratio: 0.8 },
+  { label: "left-mid-bottom", side: Position.Left, ratio: 0.65 },
+  { label: "left", side: Position.Left, ratio: 0.5 },
+  { label: "left-mid-top", side: Position.Left, ratio: 0.35 },
+  { label: "left-top", side: Position.Left, ratio: 0.2 },
+]
+
+function getRectangularHandlePosition(
+  rect: Rect,
+  spec: HandlePositionSpec
+): XYPosition {
+  switch (spec.side) {
+    case Position.Top:
+      return { x: rect.x + rect.width * spec.ratio, y: rect.y }
+    case Position.Right:
+      return { x: rect.x + rect.width, y: rect.y + rect.height * spec.ratio }
+    case Position.Bottom:
+      return { x: rect.x + rect.width * spec.ratio, y: rect.y + rect.height }
+    case Position.Left:
+      return { x: rect.x, y: rect.y + rect.height * spec.ratio }
+  }
+}
+
+function getRectangularHandleCandidates({
+  rect,
+  side,
+  useFourHandles = false,
+}: {
+  rect: Rect
+  side?: Position
+  useFourHandles?: boolean
+}): HandlePositionCandidate[] {
+  return RECTANGULAR_HANDLE_SPECS.filter((spec) => {
+    if (useFourHandles && !BASIC_HANDLE_IDS.has(spec.label)) return false
+    if (side && spec.side !== side) return false
+    return true
+  }).map((spec) => ({
+    ...spec,
+    position: getRectangularHandlePosition(rect, spec),
+  }))
+}
+
+export function getPositionFromHandleId(
+  handleId?: string | null
+): Position | null {
+  if (!handleId) return null
+
+  if (handleId === "top" || handleId.startsWith("top-")) {
+    return Position.Top
+  }
+  if (handleId === "right" || handleId.startsWith("right-")) {
+    return Position.Right
+  }
+  if (handleId === "bottom" || handleId.startsWith("bottom-")) {
+    return Position.Bottom
+  }
+  if (handleId === "left" || handleId.startsWith("left-")) {
+    return Position.Left
+  }
+
+  return null
+}
+
+function getOppositePosition(position: Position): Position {
+  switch (position) {
+    case Position.Top:
+      return Position.Bottom
+    case Position.Right:
+      return Position.Left
+    case Position.Bottom:
+      return Position.Top
+    case Position.Left:
+      return Position.Right
+  }
+}
+
+function getStraightPathAxis(position: Position): HandleAxis {
+  return position === Position.Left || position === Position.Right ? "y" : "x"
+}
+
+function getSideRange(rect: Rect, side: Position): [number, number] {
+  if (side === Position.Top || side === Position.Bottom) {
+    return [rect.x, rect.x + rect.width]
+  }
+
+  return [rect.y, rect.y + rect.height]
+}
+
+function isInRange(
+  value: number,
+  [start, end]: [number, number],
+  tolerance: number
+): boolean {
+  return value >= start - tolerance && value <= end + tolerance
+}
+
+function isTargetInStraightDirection(
+  sourceRect: Rect,
+  targetRect: Rect,
+  sourceSide: Position
+): boolean {
+  switch (sourceSide) {
+    case Position.Top:
+      return sourceRect.y >= targetRect.y + targetRect.height
+    case Position.Right:
+      return targetRect.x >= sourceRect.x + sourceRect.width
+    case Position.Bottom:
+      return targetRect.y >= sourceRect.y + sourceRect.height
+    case Position.Left:
+      return sourceRect.x >= targetRect.x + targetRect.width
+  }
+}
+
+function getHandlePoint(
+  rect: Rect,
+  handleId?: string | null
+): XYPosition | null {
+  if (!handleId) return null
+
+  const spec = RECTANGULAR_HANDLE_SPECS.find(
+    (candidate) => candidate.label === handleId
+  )
+  if (!spec) return null
+
+  return getRectangularHandlePosition(rect, spec)
+}
+
+interface FindStraightConnectionHandlesParams {
+  sourceRect: Rect
+  targetRect: Rect
+  sourceHandle?: string | null
+  targetHandle?: string | null
+  targetPoint?: XYPosition
+  useFourSourceHandles?: boolean
+  useFourTargetHandles?: boolean
+  allowSourceHandleAdjustment?: boolean
+  alignmentTolerance?: number
+}
+
+export function findStraightConnectionHandles({
+  sourceRect,
+  targetRect,
+  sourceHandle,
+  targetHandle,
+  targetPoint,
+  useFourSourceHandles = false,
+  useFourTargetHandles = false,
+  allowSourceHandleAdjustment = false,
+  alignmentTolerance = 1,
+}: FindStraightConnectionHandlesParams):
+  | { sourceHandle: string; targetHandle: string }
+  | null {
+  const sourceSide = getPositionFromHandleId(sourceHandle)
+  if (!sourceHandle || !sourceSide) return null
+
+  if (!isTargetInStraightDirection(sourceRect, targetRect, sourceSide)) {
+    return null
+  }
+
+  const targetSide = getPositionFromHandleId(targetHandle)
+  if (targetSide !== getOppositePosition(sourceSide)) {
+    return null
+  }
+
+  const sourcePoint = getHandlePoint(sourceRect, sourceHandle)
+  if (!sourcePoint) return null
+
+  const axis = getStraightPathAxis(sourceSide)
+  const targetSideRange = getSideRange(targetRect, targetSide)
+
+  const sourceCandidates = allowSourceHandleAdjustment
+    ? getRectangularHandleCandidates({
+        rect: sourceRect,
+        side: sourceSide,
+        useFourHandles: useFourSourceHandles,
+      })
+    : [
+        {
+          label: sourceHandle,
+          side: sourceSide,
+          ratio: 0,
+          position: sourcePoint,
+        },
+      ]
+
+  const candidates = getRectangularHandleCandidates({
+    rect: targetRect,
+    side: targetSide,
+    useFourHandles: useFourTargetHandles,
+  })
+
+  if (candidates.length === 0) return null
+
+  const preferredPoint = targetPoint ?? getHandlePoint(targetRect, targetHandle)
+
+  const pairs = sourceCandidates.flatMap((sourceCandidate) => {
+    const sourceAxisValue = sourceCandidate.position[axis]
+    if (!isInRange(sourceAxisValue, targetSideRange, alignmentTolerance)) {
+      return []
+    }
+
+    return candidates.map((targetCandidate) => ({
+      source: sourceCandidate,
+      target: targetCandidate,
+    }))
+  })
+
+  if (pairs.length === 0) return null
+
+  const bestPair = pairs.reduce((best, pair) => {
+    const bestAxisDistance = Math.abs(
+      best.target.position[axis] - best.source.position[axis]
+    )
+    const candidateAxisDistance = Math.abs(
+      pair.target.position[axis] - pair.source.position[axis]
+    )
+
+    if (candidateAxisDistance !== bestAxisDistance) {
+      return candidateAxisDistance < bestAxisDistance ? pair : best
+    }
+
+    const bestSourceDistance = distance(best.source.position, sourcePoint)
+    const candidateSourceDistance = distance(pair.source.position, sourcePoint)
+
+    if (candidateSourceDistance !== bestSourceDistance) {
+      return candidateSourceDistance < bestSourceDistance ? pair : best
+    }
+
+    if (!preferredPoint) return best
+
+    return distance(pair.target.position, preferredPoint) <
+      distance(best.target.position, preferredPoint)
+      ? pair
+      : best
+  })
+
+  return {
+    sourceHandle: bestPair.source.label,
+    targetHandle: bestPair.target.label,
+  }
+}
+
 interface FindClosestHandleParams {
   point: XYPosition
   rect: Rect

--- a/library/lib/utils/edgeUtils.ts
+++ b/library/lib/utils/edgeUtils.ts
@@ -608,6 +608,266 @@ export function simplifyPoints(points: IPoint[]): IPoint[] {
   return result
 }
 
+export type StraightPathOrientation = "horizontal" | "vertical"
+
+export function getStraightPathOrientation(
+  points: IPoint[],
+  tolerance: number = 1
+): StraightPathOrientation | null {
+  if (points.length !== 2) return null
+
+  const [start, end] = points
+  const isVertical = Math.abs(start.x - end.x) <= tolerance
+  const isHorizontal = Math.abs(start.y - end.y) <= tolerance
+
+  if (isVertical && Math.abs(start.y - end.y) > tolerance) {
+    return "vertical"
+  }
+
+  if (isHorizontal && Math.abs(start.x - end.x) > tolerance) {
+    return "horizontal"
+  }
+
+  return null
+}
+
+export function orthogonalizePoints(
+  points: IPoint[],
+  tolerance: number = 1
+): IPoint[] {
+  if (points.length < 2) return points
+
+  const orthogonalPoints: IPoint[] = [{ ...points[0] }]
+
+  for (let i = 1; i < points.length; i++) {
+    const previous = orthogonalPoints[orthogonalPoints.length - 1]
+    const next = { ...points[i] }
+    const isVertical = Math.abs(previous.x - next.x) <= tolerance
+    const isHorizontal = Math.abs(previous.y - next.y) <= tolerance
+
+    if (isVertical || isHorizontal) {
+      orthogonalPoints.push(next)
+      continue
+    }
+
+    const previousOrientation =
+      orthogonalPoints.length >= 2
+        ? getStraightPathOrientation(
+            [orthogonalPoints[orthogonalPoints.length - 2], previous],
+            tolerance
+          )
+        : null
+    const elbow =
+      previousOrientation === "vertical"
+        ? { x: next.x, y: previous.y }
+        : { x: previous.x, y: next.y }
+
+    orthogonalPoints.push(elbow, next)
+  }
+
+  return simplifyPoints(removeDuplicatePoints(orthogonalPoints))
+}
+
+function midpointBetween(start: IPoint, end: IPoint): IPoint {
+  return {
+    x: start.x + (end.x - start.x) / 2,
+    y: start.y + (end.y - start.y) / 2,
+  }
+}
+
+function isPointOutsideSide(
+  point: IPoint,
+  anchor: IPoint,
+  side: Position,
+  minDistance: number
+): boolean {
+  switch (side) {
+    case Position.Top:
+      return point.y <= anchor.y - minDistance
+    case Position.Bottom:
+      return point.y >= anchor.y + minDistance
+    case Position.Left:
+      return point.x <= anchor.x - minDistance
+    case Position.Right:
+      return point.x >= anchor.x + minDistance
+  }
+}
+
+function alignPointOutsideSide(
+  point: IPoint,
+  anchor: IPoint,
+  side: Position,
+  minDistance: number
+): IPoint {
+  switch (side) {
+    case Position.Top:
+      return {
+        x: anchor.x,
+        y: isPointOutsideSide(point, anchor, side, minDistance)
+          ? point.y
+          : anchor.y - minDistance,
+      }
+    case Position.Bottom:
+      return {
+        x: anchor.x,
+        y: isPointOutsideSide(point, anchor, side, minDistance)
+          ? point.y
+          : anchor.y + minDistance,
+      }
+    case Position.Left:
+      return {
+        x: isPointOutsideSide(point, anchor, side, minDistance)
+          ? point.x
+          : anchor.x - minDistance,
+        y: anchor.y,
+      }
+    case Position.Right:
+      return {
+        x: isPointOutsideSide(point, anchor, side, minDistance)
+          ? point.x
+          : anchor.x + minDistance,
+        y: anchor.y,
+      }
+  }
+}
+
+export function calculateStraightPathDetourRange(
+  points: IPoint[],
+  breakpoints: IPoint[],
+  breakpointIndex: number
+): { start: IPoint; end: IPoint } | null {
+  if (!getStraightPathOrientation(points) || breakpoints.length === 0) {
+    return null
+  }
+
+  const breakpoint = breakpoints[breakpointIndex]
+  if (!breakpoint) return null
+
+  const [sourcePoint, targetPoint] = points
+  const previousBreakpoint = breakpoints[breakpointIndex - 1]
+  const nextBreakpoint = breakpoints[breakpointIndex + 1]
+
+  return {
+    start: previousBreakpoint ?? midpointBetween(sourcePoint, breakpoint),
+    end: nextBreakpoint ?? midpointBetween(breakpoint, targetPoint),
+  }
+}
+
+export function calculateStraightPathBreakpoints(
+  points: IPoint[],
+  maxBreakpoints: number = 1,
+  minSpacing: number = 40
+): IPoint[] {
+  const orientation = getStraightPathOrientation(points)
+  if (!orientation) return []
+
+  const [start, end] = points
+  const length =
+    orientation === "vertical"
+      ? Math.abs(end.y - start.y)
+      : Math.abs(end.x - start.x)
+  const breakpointCount = Math.min(
+    maxBreakpoints,
+    Math.max(0, Math.floor(length / minSpacing) - 1)
+  )
+
+  if (breakpointCount === 0) return []
+
+  return Array.from({ length: breakpointCount }, (_, index) => {
+    const ratio = (index + 1) / (breakpointCount + 1)
+    return {
+      x: Number((start.x + (end.x - start.x) * ratio).toFixed(2)),
+      y: Number((start.y + (end.y - start.y) * ratio).toFixed(2)),
+    }
+  })
+}
+
+export function createStraightPathDetour(
+  points: IPoint[],
+  breakpoint: IPoint,
+  dragPoint: IPoint,
+  minDetourOffset: number = 4,
+  breakpoints: IPoint[] = [breakpoint],
+  breakpointIndex: number = 0
+): IPoint[] {
+  const orientation = getStraightPathOrientation(points)
+  if (!orientation) return points
+
+  const [start, end] = points
+  const detourRange = calculateStraightPathDetourRange(
+    points,
+    breakpoints,
+    breakpointIndex
+  )
+  if (!detourRange) return points
+
+  const detourOffset =
+    orientation === "vertical"
+      ? Math.abs(dragPoint.x - start.x)
+      : Math.abs(dragPoint.y - start.y)
+
+  if (detourOffset < minDetourOffset) {
+    return points
+  }
+
+  const detourPoints =
+    orientation === "vertical"
+      ? [
+          start,
+          detourRange.start,
+          { x: dragPoint.x, y: detourRange.start.y },
+          { x: dragPoint.x, y: detourRange.end.y },
+          detourRange.end,
+          end,
+        ]
+      : [
+          start,
+          detourRange.start,
+          { x: detourRange.start.x, y: dragPoint.y },
+          { x: detourRange.end.x, y: dragPoint.y },
+          detourRange.end,
+          end,
+        ]
+
+  return orthogonalizePoints(detourPoints)
+}
+
+export function alignCustomPathEndpointSegments(
+  points: IPoint[],
+  sourcePoint: IPoint,
+  targetPoint: IPoint,
+  sourcePosition: Position,
+  targetPosition: Position,
+  minEndpointSegmentLength: number = 20
+): IPoint[] {
+  if (points.length === 0) return points
+  if (points.length === 1) return [sourcePoint, targetPoint]
+
+  const nextPoints = points.map((point) => ({ ...point }))
+  const lastIndex = nextPoints.length - 1
+  nextPoints[0] = sourcePoint
+  nextPoints[lastIndex] = targetPoint
+
+  if (nextPoints.length > 2) {
+    nextPoints[1] = alignPointOutsideSide(
+      nextPoints[1],
+      sourcePoint,
+      sourcePosition,
+      minEndpointSegmentLength
+    )
+
+    const beforeTargetIndex = lastIndex - 1
+    nextPoints[beforeTargetIndex] = alignPointOutsideSide(
+      nextPoints[beforeTargetIndex],
+      targetPoint,
+      targetPosition,
+      minEndpointSegmentLength
+    )
+  }
+
+  return orthogonalizePoints(nextPoints)
+}
+
 export function parseSvgPath(path: string): IPoint[] {
   const tokens = simplifySvgPath(path).replace(/,/g, " ").trim().split(/\s+/)
   const points: IPoint[] = []

--- a/library/lib/utils/edgeUtils.ts
+++ b/library/lib/utils/edgeUtils.ts
@@ -520,9 +520,10 @@ export function findStraightConnectionHandles({
   useFourTargetHandles = false,
   allowSourceHandleAdjustment = false,
   alignmentTolerance = 1,
-}: FindStraightConnectionHandlesParams):
-  | { sourceHandle: string; targetHandle: string }
-  | null {
+}: FindStraightConnectionHandlesParams): {
+  sourceHandle: string
+  targetHandle: string
+} | null {
   const sourceSide = getPositionFromHandleId(sourceHandle)
   if (!sourceHandle || !sourceSide) return null
 

--- a/library/tests/unit/CustomEdgeToolbar.test.tsx
+++ b/library/tests/unit/CustomEdgeToolbar.test.tsx
@@ -1,0 +1,63 @@
+import { render } from "@testing-library/react"
+import { createRef } from "react"
+import { describe, expect, it, vi } from "vitest"
+import { CustomEdgeToolbar } from "@/components/toolbars/edgeToolBar/CustomEdgeToolBar"
+
+vi.mock("@/hooks/useDiagramModifiable", () => ({
+  useDiagramModifiable: () => true,
+}))
+
+vi.mock("@/hooks/useIsOnlyThisElementSelected", () => ({
+  useIsOnlyThisElementSelected: () => true,
+}))
+
+const renderToolbar = (draggers: { x: number; y: number }[] = []) => {
+  const anchorRef = createRef<SVGForeignObjectElement>()
+  const result = render(
+    <svg>
+      <g>
+        <g className="edge-container">
+          {draggers.map((dragger, index) => (
+            <circle
+              className="edge-circle"
+              key={index}
+              cx={dragger.x}
+              cy={dragger.y}
+              r={10}
+            />
+          ))}
+        </g>
+        <CustomEdgeToolbar
+          edgeId="edge-1"
+          position={{ x: 100, y: 100 }}
+          anchorRef={anchorRef}
+          onDeleteClick={vi.fn()}
+          onEditClick={vi.fn()}
+        />
+      </g>
+    </svg>
+  )
+
+  const toolbar = result.container.querySelector("foreignObject")
+  if (!toolbar) {
+    throw new Error("Expected edge toolbar foreignObject to be rendered")
+  }
+
+  return { ...result, toolbar }
+}
+
+describe("CustomEdgeToolbar", () => {
+  it("keeps the existing toolbar position when there are no edge draggers", () => {
+    const { toolbar } = renderToolbar()
+
+    expect(toolbar.getAttribute("x")).toBe("104")
+    expect(toolbar.getAttribute("y")).toBe("92")
+  })
+
+  it("moves the toolbar away when the default position overlaps an edge dragger", () => {
+    const { toolbar } = renderToolbar([{ x: 100, y: 100 }])
+
+    expect(toolbar.getAttribute("x")).toBe("120")
+    expect(toolbar.getAttribute("y")).toBe("72")
+  })
+})

--- a/library/tests/unit/edgeRouting.test.ts
+++ b/library/tests/unit/edgeRouting.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest"
+import { Position } from "@xyflow/react"
+import { computeAutoEdgeRoute } from "@/utils/edgeRouting"
+import { resolveEdgeMode, toAutoEdgeData, toManualEdgeData } from "@/edges/edgeMode"
+import { EDGES, MARKER_BASE_SIZE } from "@/constants"
+
+describe("resolveEdgeMode", () => {
+  it("defaults to AUTO for edges without explicit mode", () => {
+    expect(resolveEdgeMode(undefined)).toBe("AUTO")
+    expect(resolveEdgeMode({ points: [] })).toBe("AUTO")
+  })
+
+  it("infers MANUAL for legacy edges with routed points", () => {
+    expect(
+      resolveEdgeMode({
+        points: [
+          { x: 0, y: 0 },
+          { x: 0, y: 100 },
+          { x: 100, y: 100 },
+        ],
+      })
+    ).toBe("MANUAL")
+  })
+})
+
+describe("edgeMode data helpers", () => {
+  it("sets AUTO mode and drops routed points while preserving custom data", () => {
+    const data = toAutoEdgeData({
+      edgeMode: "MANUAL",
+      points: [
+        { x: 0, y: 0 },
+        { x: 10, y: 10 },
+      ],
+      customFlag: true,
+    })
+
+    expect(data).toEqual({
+      edgeMode: "AUTO",
+      points: undefined,
+      customFlag: true,
+    })
+  })
+
+  it("sets MANUAL mode and stores points while preserving custom data", () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 10, y: 10 },
+      { x: 20, y: 10 },
+    ]
+
+    const data = toManualEdgeData(points, {
+      edgeMode: "AUTO",
+      customFlag: true,
+    })
+
+    expect(data).toEqual({
+      edgeMode: "MANUAL",
+      points,
+      customFlag: true,
+    })
+  })
+})
+
+describe("computeAutoEdgeRoute", () => {
+  it("prefers a straight right-to-left route when nodes overlap on y-axis", () => {
+    const route = computeAutoEdgeRoute({
+      sourceRect: { x: 0, y: 0, width: 100, height: 100 },
+      targetRect: { x: 300, y: 20, width: 100, height: 100 },
+      markerPadding: EDGES.MARKER_PADDING,
+      preferStraight: true,
+    })
+
+    expect(route.pathType).toBe("straight")
+    expect(route.sourcePosition).toBe(Position.Right)
+    expect(route.targetPosition).toBe(Position.Left)
+    expect(route.points).toHaveLength(2)
+    expect(route.points[0]).toEqual({ x: 97, y: 60 })
+    expect(route.points[1]).toEqual({ x: 303, y: 60 })
+  })
+
+  it("can keep AUTO straight endpoints on the boundary with explicit endpoint padding", () => {
+    const route = computeAutoEdgeRoute({
+      sourceRect: { x: 0, y: 0, width: 100, height: 100 },
+      targetRect: { x: 300, y: 20, width: 100, height: 100 },
+      markerPadding: EDGES.MARKER_PADDING,
+      sourcePadding: 0,
+      targetEndpointPadding: 0,
+      preferStraight: true,
+    })
+
+    expect(route.pathType).toBe("straight")
+    expect(route.points[0]).toEqual({ x: 100, y: 60 })
+    expect(route.points[1]).toEqual({ x: 300, y: 60 })
+  })
+
+  it("falls back to orthogonal step routing when straight path is not possible", () => {
+    const route = computeAutoEdgeRoute({
+      sourceRect: { x: 0, y: 0, width: 100, height: 100 },
+      targetRect: { x: 130, y: 130, width: 100, height: 100 },
+      markerPadding: EDGES.MARKER_PADDING,
+      preferStraight: true,
+    })
+
+    expect(route.pathType).toBe("step")
+    expect(route.sourcePosition).toBe(Position.Right)
+    expect(route.targetPosition).toBe(Position.Left)
+    expect(route.points.length).toBeGreaterThanOrEqual(2)
+    expect(route.points[0]).toEqual({ x: 97, y: 100 })
+    expect(route.points[route.points.length - 1]).toEqual({ x: 133, y: 130 })
+  })
+
+  it("returns no AUTO optimization when straight routing is impossible and fallback is disabled", () => {
+    const route = computeAutoEdgeRoute({
+      sourceRect: { x: 0, y: 0, width: 100, height: 100 },
+      targetRect: { x: 130, y: 130, width: 100, height: 100 },
+      markerPadding: EDGES.MARKER_PADDING,
+      preferStraight: true,
+      allowOrthogonalFallback: false,
+    })
+
+    expect(route).toBeNull()
+  })
+
+  it("keeps AUTO endpoints away from node corners when side insets are configured", () => {
+    const route = computeAutoEdgeRoute({
+      sourceRect: { x: 0, y: 0, width: 100, height: 100 },
+      targetRect: { x: 130, y: 130, width: 100, height: 100 },
+      markerPadding: EDGES.MARKER_PADDING,
+      sourceSideInset: MARKER_BASE_SIZE,
+      targetSideInset: MARKER_BASE_SIZE,
+      preferStraight: true,
+    })
+
+    expect(route.pathType).toBe("step")
+    expect(route.sourcePosition).toBe(Position.Right)
+    expect(route.targetPosition).toBe(Position.Left)
+    expect(route.points[0]).toEqual({ x: 97, y: 82 })
+    expect(route.points[route.points.length - 1]).toEqual({ x: 133, y: 148 })
+  })
+})

--- a/library/tests/unit/edgeRouting.test.ts
+++ b/library/tests/unit/edgeRouting.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest"
 import { Position } from "@xyflow/react"
 import { computeAutoEdgeRoute } from "@/utils/edgeRouting"
-import { resolveEdgeMode, toAutoEdgeData, toManualEdgeData } from "@/edges/edgeMode"
+import {
+  resolveEdgeMode,
+  toAutoEdgeData,
+  toManualEdgeData,
+} from "@/edges/edgeMode"
 import { EDGES, MARKER_BASE_SIZE } from "@/constants"
 
 describe("resolveEdgeMode", () => {

--- a/library/tests/unit/edgeUtils.test.ts
+++ b/library/tests/unit/edgeUtils.test.ts
@@ -13,10 +13,12 @@ import {
   createStraightPathDetour,
   calculateTextPlacement,
   findClosestHandle,
+  findStraightConnectionHandles,
   getConnectionLineType,
   getDefaultEdgeType,
   getEdgeMarkerStyles,
   getMarkerSegmentPath,
+  getPositionFromHandleId,
   getStraightPathOrientation,
   orthogonalizePoints,
   parseSvgPath,
@@ -587,6 +589,132 @@ describe("findClosestHandle", () => {
       rect,
     })
     expect(result).toBe("top-left")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// straight connection handle selection
+// ---------------------------------------------------------------------------
+describe("straight connection handle selection", () => {
+  describe("getPositionFromHandleId", () => {
+    it("uses the handle prefix as the attached side", () => {
+      expect(getPositionFromHandleId("top-left")).toBe(Position.Top)
+      expect(getPositionFromHandleId("right-mid-bottom")).toBe(Position.Right)
+      expect(getPositionFromHandleId("bottom-right")).toBe(Position.Bottom)
+      expect(getPositionFromHandleId("left-top")).toBe(Position.Left)
+    })
+
+    it("returns null for empty or unknown handles", () => {
+      expect(getPositionFromHandleId(null)).toBeNull()
+      expect(getPositionFromHandleId("unknown")).toBeNull()
+    })
+  })
+
+  describe("findStraightConnectionHandles", () => {
+    it("selects the opposite target handle for a vertical straight route", () => {
+      const result = findStraightConnectionHandles({
+        sourceRect: { x: 0, y: 0, width: 100, height: 60 },
+        targetRect: { x: 0, y: 120, width: 100, height: 60 },
+        sourceHandle: "bottom",
+        targetHandle: "top",
+      })
+
+      expect(result).toEqual({
+        sourceHandle: "bottom",
+        targetHandle: "top",
+      })
+    })
+
+    it("uses hidden target midpoint handles when they make the route straighter", () => {
+      const result = findStraightConnectionHandles({
+        sourceRect: { x: 0, y: 0, width: 100, height: 60 },
+        targetRect: { x: 20, y: 120, width: 100, height: 60 },
+        sourceHandle: "bottom-right",
+        targetHandle: "top",
+      })
+
+      expect(result).toEqual({
+        sourceHandle: "bottom-right",
+        targetHandle: "top-mid-right",
+      })
+    })
+
+    it("can slide the source handle on the same side for a straighter new edge", () => {
+      const result = findStraightConnectionHandles({
+        sourceRect: { x: 0, y: 0, width: 100, height: 60 },
+        targetRect: { x: 15, y: 120, width: 100, height: 60 },
+        sourceHandle: "bottom-left",
+        targetHandle: "top-left",
+        allowSourceHandleAdjustment: true,
+      })
+
+      expect(result).toEqual({
+        sourceHandle: "bottom-mid-left",
+        targetHandle: "top-left",
+      })
+    })
+
+    it("selects the opposite target handle for a horizontal straight route", () => {
+      const result = findStraightConnectionHandles({
+        sourceRect: { x: 0, y: 0, width: 100, height: 100 },
+        targetRect: { x: 150, y: 0, width: 100, height: 100 },
+        sourceHandle: "right-bottom",
+        targetHandle: "left-bottom",
+      })
+
+      expect(result).toEqual({
+        sourceHandle: "right-bottom",
+        targetHandle: "left-bottom",
+      })
+    })
+
+    it("respects nodes that only expose four handles", () => {
+      const result = findStraightConnectionHandles({
+        sourceRect: { x: 0, y: 0, width: 100, height: 100 },
+        targetRect: { x: 150, y: 0, width: 100, height: 100 },
+        sourceHandle: "right-bottom",
+        targetHandle: "left",
+        useFourTargetHandles: true,
+      })
+
+      expect(result).toEqual({
+        sourceHandle: "right-bottom",
+        targetHandle: "left",
+      })
+    })
+
+    it("falls back when the source side does not face the target", () => {
+      const result = findStraightConnectionHandles({
+        sourceRect: { x: 0, y: 120, width: 100, height: 60 },
+        targetRect: { x: 0, y: 0, width: 100, height: 60 },
+        sourceHandle: "bottom",
+        targetHandle: "top",
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it("falls back when no target-side point can continue the source axis", () => {
+      const result = findStraightConnectionHandles({
+        sourceRect: { x: 0, y: 0, width: 100, height: 60 },
+        targetRect: { x: 200, y: 120, width: 100, height: 60 },
+        sourceHandle: "bottom",
+        targetHandle: "top",
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it("falls back immediately when the selected target side is not opposite", () => {
+      const result = findStraightConnectionHandles({
+        sourceRect: { x: 0, y: 0, width: 100, height: 100 },
+        targetRect: { x: 150, y: 0, width: 100, height: 100 },
+        sourceHandle: "right",
+        targetHandle: "top",
+      })
+
+      expect(result).toBeNull()
+    })
   })
 })
 

--- a/library/tests/unit/edgeUtils.test.ts
+++ b/library/tests/unit/edgeUtils.test.ts
@@ -7,12 +7,18 @@ import {
   calculateInnerMidpoints,
   calculateOverlayPath,
   calculateStraightPath,
+  alignCustomPathEndpointSegments,
+  calculateStraightPathDetourRange,
+  calculateStraightPathBreakpoints,
+  createStraightPathDetour,
   calculateTextPlacement,
   findClosestHandle,
   getConnectionLineType,
   getDefaultEdgeType,
   getEdgeMarkerStyles,
   getMarkerSegmentPath,
+  getStraightPathOrientation,
+  orthogonalizePoints,
   parseSvgPath,
   removeDuplicatePoints,
   simplifyPoints,
@@ -923,6 +929,414 @@ describe("calculateInnerMidpoints", () => {
     expect(result[0]).toEqual({ x: 100, y: 50 })
     expect(result[1]).toEqual({ x: 150, y: 100 })
     expect(result[2]).toEqual({ x: 200, y: 150 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// straight path breakpoint helpers
+// ---------------------------------------------------------------------------
+describe("straight path breakpoint helpers", () => {
+  describe("getStraightPathOrientation", () => {
+    it("detects vertical two-point paths", () => {
+      expect(
+        getStraightPathOrientation([
+          { x: 10, y: 0 },
+          { x: 10, y: 200 },
+        ])
+      ).toBe("vertical")
+    })
+
+    it("detects horizontal two-point paths", () => {
+      expect(
+        getStraightPathOrientation([
+          { x: 0, y: 20 },
+          { x: 200, y: 20 },
+        ])
+      ).toBe("horizontal")
+    })
+
+    it("rejects diagonal, zero-length, and multi-point paths", () => {
+      expect(
+        getStraightPathOrientation([
+          { x: 0, y: 0 },
+          { x: 100, y: 50 },
+        ])
+      ).toBeNull()
+      expect(
+        getStraightPathOrientation([
+          { x: 5, y: 5 },
+          { x: 5, y: 5 },
+        ])
+      ).toBeNull()
+      expect(
+        getStraightPathOrientation([
+          { x: 0, y: 0 },
+          { x: 0, y: 50 },
+          { x: 50, y: 50 },
+        ])
+      ).toBeNull()
+    })
+  })
+
+  describe("calculateStraightPathBreakpoints", () => {
+    it("creates one centered handle for a long vertical path", () => {
+      const result = calculateStraightPathBreakpoints([
+        { x: 10, y: 0 },
+        { x: 10, y: 200 },
+      ])
+
+      expect(result).toEqual([{ x: 10, y: 100 }])
+    })
+
+    it("creates one handle for a medium horizontal path", () => {
+      const result = calculateStraightPathBreakpoints([
+        { x: 0, y: 20 },
+        { x: 100, y: 20 },
+      ])
+
+      expect(result).toEqual([{ x: 50, y: 20 }])
+    })
+
+    it("centers reversed paths", () => {
+      const result = calculateStraightPathBreakpoints([
+        { x: 10, y: 200 },
+        { x: 10, y: 0 },
+      ])
+
+      expect(result).toEqual([{ x: 10, y: 100 }])
+    })
+
+    it("returns no handles for short or non-orthogonal paths", () => {
+      expect(
+        calculateStraightPathBreakpoints([
+          { x: 0, y: 0 },
+          { x: 0, y: 70 },
+        ])
+      ).toEqual([])
+      expect(
+        calculateStraightPathBreakpoints([
+          { x: 0, y: 0 },
+          { x: 100, y: 50 },
+        ])
+      ).toEqual([])
+    })
+  })
+
+  describe("orthogonalizePoints", () => {
+    it("turns a diagonal segment into orthogonal elbow segments", () => {
+      const result = orthogonalizePoints([
+        { x: 0, y: 0 },
+        { x: 100, y: 80 },
+      ])
+
+      expect(result).toEqual([
+        { x: 0, y: 0 },
+        { x: 0, y: 80 },
+        { x: 100, y: 80 },
+      ])
+    })
+
+    it("alternates after an existing vertical segment to avoid diagonal tilt", () => {
+      const result = orthogonalizePoints([
+        { x: 0, y: 0 },
+        { x: 0, y: 50 },
+        { x: 100, y: 80 },
+      ])
+
+      expect(result).toEqual([
+        { x: 0, y: 0 },
+        { x: 0, y: 50 },
+        { x: 100, y: 50 },
+        { x: 100, y: 80 },
+      ])
+    })
+
+    it("leaves already orthogonal paths unchanged", () => {
+      const points = [
+        { x: 0, y: 0 },
+        { x: 0, y: 50 },
+        { x: 100, y: 50 },
+      ]
+
+      expect(orthogonalizePoints(points)).toEqual(points)
+    })
+  })
+
+  describe("calculateStraightPathDetourRange", () => {
+    const straightPath = [
+      { x: 10, y: 0 },
+      { x: 10, y: 200 },
+    ]
+    const breakpoints = [
+      { x: 10, y: 50 },
+      { x: 10, y: 100 },
+      { x: 10, y: 150 },
+    ]
+
+    it("maps the first handle to the source-side span", () => {
+      expect(
+        calculateStraightPathDetourRange(straightPath, breakpoints, 0)
+      ).toEqual({
+        start: { x: 10, y: 25 },
+        end: { x: 10, y: 100 },
+      })
+    })
+
+    it("maps the middle handle to the neighboring handles", () => {
+      expect(
+        calculateStraightPathDetourRange(straightPath, breakpoints, 1)
+      ).toEqual({
+        start: { x: 10, y: 50 },
+        end: { x: 10, y: 150 },
+      })
+    })
+
+    it("maps the last handle to the target-side span", () => {
+      expect(
+        calculateStraightPathDetourRange(straightPath, breakpoints, 2)
+      ).toEqual({
+        start: { x: 10, y: 100 },
+        end: { x: 10, y: 175 },
+      })
+    })
+  })
+
+  describe("createStraightPathDetour", () => {
+    it("creates an orthogonal detour from the middle vertical handle", () => {
+      const straightPath = [
+        { x: 10, y: 0 },
+        { x: 10, y: 200 },
+      ]
+      const breakpoints = [
+        { x: 10, y: 50 },
+        { x: 10, y: 100 },
+        { x: 10, y: 150 },
+      ]
+      const result = createStraightPathDetour(
+        straightPath,
+        breakpoints[1],
+        { x: 70, y: 100 },
+        4,
+        breakpoints,
+        1
+      )
+
+      expect(result).toEqual([
+        { x: 10, y: 0 },
+        { x: 10, y: 50 },
+        { x: 70, y: 50 },
+        { x: 70, y: 150 },
+        { x: 10, y: 150 },
+        { x: 10, y: 200 },
+      ])
+    })
+
+    it("creates an orthogonal detour from the target-side vertical handle", () => {
+      const straightPath = [
+        { x: 10, y: 0 },
+        { x: 10, y: 200 },
+      ]
+      const breakpoints = [
+        { x: 10, y: 50 },
+        { x: 10, y: 100 },
+        { x: 10, y: 150 },
+      ]
+      const result = createStraightPathDetour(
+        straightPath,
+        breakpoints[2],
+        { x: 70, y: 150 },
+        4,
+        breakpoints,
+        2
+      )
+
+      expect(result).toEqual([
+        { x: 10, y: 0 },
+        { x: 10, y: 100 },
+        { x: 70, y: 100 },
+        { x: 70, y: 175 },
+        { x: 10, y: 175 },
+        { x: 10, y: 200 },
+      ])
+    })
+
+    it("creates an orthogonal detour from the source-side vertical handle", () => {
+      const straightPath = [
+        { x: 10, y: 0 },
+        { x: 10, y: 200 },
+      ]
+      const breakpoints = [
+        { x: 10, y: 50 },
+        { x: 10, y: 100 },
+        { x: 10, y: 150 },
+      ]
+      const result = createStraightPathDetour(
+        straightPath,
+        breakpoints[0],
+        { x: 70, y: 50 },
+        4,
+        breakpoints,
+        0
+      )
+
+      expect(result).toEqual([
+        { x: 10, y: 0 },
+        { x: 10, y: 25 },
+        { x: 70, y: 25 },
+        { x: 70, y: 100 },
+        { x: 10, y: 100 },
+        { x: 10, y: 200 },
+      ])
+    })
+
+    it("creates an orthogonal detour from the middle horizontal handle", () => {
+      const straightPath = [
+        { x: 0, y: 20 },
+        { x: 200, y: 20 },
+      ]
+      const breakpoints = [
+        { x: 50, y: 20 },
+        { x: 100, y: 20 },
+        { x: 150, y: 20 },
+      ]
+      const result = createStraightPathDetour(
+        straightPath,
+        breakpoints[1],
+        { x: 100, y: 80 },
+        4,
+        breakpoints,
+        1
+      )
+
+      expect(result).toEqual([
+        { x: 0, y: 20 },
+        { x: 50, y: 20 },
+        { x: 50, y: 80 },
+        { x: 150, y: 80 },
+        { x: 150, y: 20 },
+        { x: 200, y: 20 },
+      ])
+    })
+
+    it("does not persist tiny detours or diagonal paths", () => {
+      const verticalPath = [
+        { x: 10, y: 0 },
+        { x: 10, y: 200 },
+      ]
+
+      expect(
+        createStraightPathDetour(
+          verticalPath,
+          { x: 10, y: 50 },
+          { x: 12, y: 50 }
+        )
+      ).toEqual(verticalPath)
+
+      const diagonalPath = [
+        { x: 0, y: 0 },
+        { x: 100, y: 50 },
+      ]
+
+      expect(
+        createStraightPathDetour(
+          diagonalPath,
+          { x: 50, y: 25 },
+          { x: 70, y: 50 }
+        )
+      ).toEqual(diagonalPath)
+    })
+  })
+
+  describe("alignCustomPathEndpointSegments", () => {
+    it("preserves a custom route while updating vertical endpoint approaches", () => {
+      const result = alignCustomPathEndpointSegments(
+        [
+          { x: 10, y: 0 },
+          { x: 10, y: 50 },
+          { x: 70, y: 50 },
+          { x: 70, y: 125 },
+          { x: 10, y: 125 },
+          { x: 10, y: 200 },
+        ],
+        { x: 30, y: 20 },
+        { x: 10, y: 240 },
+        Position.Bottom,
+        Position.Top
+      )
+
+      expect(result).toEqual([
+        { x: 30, y: 20 },
+        { x: 30, y: 50 },
+        { x: 70, y: 50 },
+        { x: 70, y: 125 },
+        { x: 10, y: 125 },
+        { x: 10, y: 240 },
+      ])
+    })
+
+    it("preserves a custom route while updating horizontal endpoint approaches", () => {
+      const result = alignCustomPathEndpointSegments(
+        [
+          { x: 0, y: 20 },
+          { x: 50, y: 20 },
+          { x: 50, y: 80 },
+          { x: 125, y: 80 },
+          { x: 125, y: 20 },
+          { x: 200, y: 20 },
+        ],
+        { x: -20, y: 40 },
+        { x: 240, y: 10 },
+        Position.Right,
+        Position.Left
+      )
+
+      expect(result).toEqual([
+        { x: -20, y: 40 },
+        { x: 50, y: 40 },
+        { x: 50, y: 80 },
+        { x: 125, y: 80 },
+        { x: 125, y: 10 },
+        { x: 240, y: 10 },
+      ])
+    })
+
+    it("forces the target approach to respect the attached top side", () => {
+      const result = alignCustomPathEndpointSegments(
+        [
+          { x: 0, y: 0 },
+          { x: 0, y: 80 },
+          { x: 100, y: 80 },
+          { x: 100, y: 140 },
+          { x: 50, y: 140 },
+        ],
+        { x: 0, y: 0 },
+        { x: 50, y: 100 },
+        Position.Bottom,
+        Position.Top
+      )
+
+      expect(result[result.length - 2]).toEqual({ x: 50, y: 80 })
+      expect(result[result.length - 1]).toEqual({ x: 50, y: 100 })
+    })
+
+    it("forces the target approach to respect the attached left side", () => {
+      const result = alignCustomPathEndpointSegments(
+        [
+          { x: 0, y: 0 },
+          { x: 80, y: 0 },
+          { x: 80, y: 100 },
+          { x: 140, y: 100 },
+          { x: 100, y: 50 },
+        ],
+        { x: 0, y: 0 },
+        { x: 100, y: 50 },
+        Position.Right,
+        Position.Left
+      )
+
+      expect(result[result.length - 2]).toEqual({ x: 80, y: 50 })
+      expect(result[result.length - 1]).toEqual({ x: 100, y: 50 })
+    })
   })
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
     },
     "library": {
       "name": "@tumaet/apollon",
-      "version": "4.2.23",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "@chenglou/pretext": "0.0.6",
@@ -535,6 +535,7 @@
       "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -18551,7 +18552,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -20209,6 +20209,7 @@
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "devOptional": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",


### PR DESCRIPTION
### Checklist

- [ ] I linked PR with a related issue
- [ ] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

Assessment popovers stopped opening in writable assessment mode after quiz-mode interaction gating changes.  
The popup-open logic was coupled to `isDiagramModifiable`, which is intentionally false in assessment mode, so double-click did not open the assessment popup and Artemis modeling assessment flows broke.

This PR completes https://github.com/ls1intum/Apollon/issues/xx

### Description

This PR introduces a minimal, source-level fix in Apollon interaction handling:

- Updated `useElementInteractions` so popovers can open when:
1. diagram is modifiable (existing behavior), or
2. editor is in `ApollonMode.Assessment` and not readonly.

Concretely:
- Added `canOpenAssessmentPopover = mode === ApollonMode.Assessment && !readonly`
- Added `canOpenPopover = isDiagramModifiable || canOpenAssessmentPopover`
- Replaced double-click guards in `onNodeDoubleClick` and `onEdgeDoubleClick` to use `canOpenPopover`

What stays unchanged:
- Delete protection still uses `isDiagramModifiable` (`onBeforeDelete`)
- No broad refactor, no behavior changes outside popup opening conditions

### Steps for Testing

1. Build Apollon library:
   - `npm run build:lib`
2. Open a diagram in assessment mode with `readonly = false`.
3. Double-click a node:
   - Verify assessment popover opens (score/feedback fields visible).
4. Double-click an edge:
   - Verify edge assessment popover opens.
5. Switch to readonly assessment mode:
   - Verify give-feedback popovers are not opened by editing interactions.
6. Switch to modelling mode:
   - Verify existing modelling popup behavior remains unchanged.
7. Regression check with Artemis modeling assessment flow:
   - Run the previously failing modeling assessment e2e path and verify it no longer times out waiting for assessment fields.
