### PR TITLE
feat: enhance element interaction logic to support assessment popover…

### DIFF
--- a/library/lib/hooks/useElementInteractions.ts
+++ b/library/lib/hooks/useElementInteractions.ts
@@ -1,4 +1,6 @@
 import { usePopoverStore } from "@/store/context"
+import { useMetadataStore } from "@/store"
+import { ApollonMode } from "@/typings"
 import {
   NodeMouseHandler,
   OnBeforeDelete,
@@ -11,25 +13,33 @@ import { useDiagramModifiable } from "./useDiagramModifiable"
 
 export const useElementInteractions = () => {
   const isDiagramModifiable = useDiagramModifiable()
+  const { mode, readonly } = useMetadataStore(
+    useShallow((state) => ({
+      mode: state.mode,
+      readonly: state.readonly,
+    }))
+  )
   const { setPopOverElementId } = usePopoverStore(
     useShallow((state) => ({
       setPopOverElementId: state.setPopOverElementId,
     }))
   )
+  const canOpenAssessmentPopover = mode === ApollonMode.Assessment && !readonly
+  const canOpenPopover = isDiagramModifiable || canOpenAssessmentPopover
 
   const onBeforeDelete: OnBeforeDelete = () => {
     return new Promise((resolve) => resolve(isDiagramModifiable))
   }
 
   const onNodeDoubleClick: NodeMouseHandler<Node> = (_event, node) => {
-    if (!isDiagramModifiable) {
+    if (!canOpenPopover) {
       return
     }
     setPopOverElementId(node.id)
   }
 
   const onEdgeDoubleClick: EdgeMouseHandler<Edge> = (_event, edge) => {
-    if (!isDiagramModifiable) {
+    if (!canOpenPopover) {
       return
     }
     setPopOverElementId(edge.id)

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
     },
     "library": {
       "name": "@tumaet/apollon",
-      "version": "4.2.23",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "@chenglou/pretext": "0.0.6",
@@ -538,6 +538,7 @@
       "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -2125,6 +2126,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -18607,7 +18609,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -20265,6 +20266,7 @@
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "devOptional": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",


### PR DESCRIPTION
### Checklist

- [ ] I linked PR with a related issue
- [ ] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

Assessment popovers stopped opening in writable assessment mode after quiz-mode interaction gating changes.  
The popup-open logic was coupled to `isDiagramModifiable`, which is intentionally false in assessment mode, so double-click did not open the assessment popup and Artemis modeling assessment flows broke.

This PR completes https://github.com/ls1intum/Apollon/issues/xx

### Description

This PR introduces a minimal, source-level fix in Apollon interaction handling:

- Updated `useElementInteractions` so popovers can open when:
1. diagram is modifiable (existing behavior), or
2. editor is in `ApollonMode.Assessment` and not readonly.

Concretely:
- Added `canOpenAssessmentPopover = mode === ApollonMode.Assessment && !readonly`
- Added `canOpenPopover = isDiagramModifiable || canOpenAssessmentPopover`
- Replaced double-click guards in `onNodeDoubleClick` and `onEdgeDoubleClick` to use `canOpenPopover`

What stays unchanged:
- Delete protection still uses `isDiagramModifiable` (`onBeforeDelete`)
- No broad refactor, no behavior changes outside popup opening conditions

### Steps for Testing

1. Build Apollon library:
   - `npm run build:lib`
2. Open a diagram in assessment mode with `readonly = false`.
3. Double-click a node:
   - Verify assessment popover opens (score/feedback fields visible).
4. Double-click an edge:
   - Verify edge assessment popover opens.
5. Switch to readonly assessment mode:
   - Verify give-feedback popovers are not opened by editing interactions.
6. Switch to modelling mode:
   - Verify existing modelling popup behavior remains unchanged.
7. Regression check with Artemis modeling assessment flow:
   - Run the previously failing modeling assessment e2e path and verify it no longer times out waiting for assessment fields.
