### PR TITLE
chore(legal): apply DSMS reviewer feedback + bump standalone to 4.3.0

### DIFF
--- a/docs/admin/dsms/record-of-processing.md
+++ b/docs/admin/dsms/record-of-processing.md
@@ -23,7 +23,7 @@ Boltzmannstraße 3, 85748 Garching bei München, Germany
 Operational technical contact: ls1.admin@in.tum.de
 ```
 
-TUM Org identifier: `CIT-I1`.
+TUM Org identifier: `TUS1322`.
 
 ## Purpose and description (Art. 30(1)(b))
 
@@ -33,7 +33,7 @@ Apollon is a UML modelling editor that runs in a web browser. The Research Group
 
 ## Data subjects (Art. 30(1)(c))
 
-Apollon is unauthenticated. Display name during live collaboration is the only per-individual identifier.
+Apollon is unauthenticated. The live-collaboration display name and the transient IP address transmitted with each HTTP request are the only per-individual identifiers.
 
 - Students (TUM)
 - Employees (TUM)
@@ -43,14 +43,13 @@ Apollon is unauthenticated. Display name during live collaboration is the only p
 
 ## Categories of personal data
 
-The only structured category processed is **Name(s)** — the user-chosen live-collaboration display name. No contact data, identifiers, or special categories (Art. 9 / Art. 10).
+Structured categories processed: **Name(s)** (the user-chosen live-collaboration display name) and **IP address** (transmitted automatically with each HTTP request; visible to the server only for the duration of the request; not persistently stored). No contact data, identifiers, or special categories (Art. 9 / Art. 10).
 
 ```
 - Diagram content (free text): the UML diagram a user actively shares is stored on TUM servers. Labels are free text and may contain personal data the user types; the platform does not require, validate, or inspect their content.
 - Live-collaboration cursor + selection: alongside the display name, the user's cursor position in the editor and the ID of the currently selected element are forwarded in real time to other participants in the same diagram session, while the user is connected.
+- User-agent string: transmitted automatically by the browser on every HTTP request; visible to the server only for the duration of the request; not persistently stored.
 ```
-
-IP addresses are transmitted automatically with each HTTP request but are not persistently stored.
 
 ## Recipients (Art. 30(1)(d))
 
@@ -71,6 +70,7 @@ On AET-operated VMs on TUM premises (Boltzmannstraße 3, 85748 Garching bei Mün
 
 - User-shared diagrams persist in a Redis instance with native time-based eviction.
 - Live-collaboration data (display name, cursor, selection) is held only in the WebSocket relay's working memory while a participant is connected; never persisted.
+- IP address and user-agent are visible to the reverse proxy only for the duration of an HTTP request; never persisted.
 
 No off-host backups of personal data exist. No personal data leaves the EU.
 ```
@@ -80,6 +80,7 @@ No off-host backups of personal data exist. No personal data leaves the EU.
 ```
 - Diagram content (Redis): 120 days from the last write, enforced by a native database TTL.
 - Live-collaboration data (display name, cursor, selection): held only while the user is connected; dropped from server memory on disconnect.
+- IP address and user-agent: visible to the server only for the duration of an HTTP request; not persistently stored.
 - Operational events about the service (no personal data by design): size-bounded ring buffer, ~250 MB per container.
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -538,7 +538,6 @@
       "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -999,7 +998,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1597,7 +1595,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.3.0.tgz",
       "integrity": "sha512-S4ajn4G/fS3VJj8salxqH/3LO5PPWv1VxGKQ27OCajnDcLJjEg9VXwgMPnlypgkIOqCJ2fmQLtk8GT+BlI9/rw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -2047,7 +2044,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -2094,7 +2090,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2126,7 +2121,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -2227,7 +2221,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
       "integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -2271,7 +2264,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
       "integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -3503,7 +3495,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.4.2.tgz",
       "integrity": "sha512-9jKr53KbAJyyBRx8LRmX7ATXHlGtxVQdPgm1uyXMoEPMVkSJW1yO3vFgfYoDbGx4ZHcCNuWa4FkFIPWVt9fghA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/core-downloads-tracker": "^6.4.2",
@@ -3856,7 +3847,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
       "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -5542,7 +5532,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5853,7 +5844,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
       "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -5929,7 +5919,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.0.tgz",
       "integrity": "sha512-7+K7zEQYu7NzOwQGLR91KwWXXDzmTFODRVizJyIALf6RfLv2GDpqpknX64pvRVILXCpXi7O/pua8NGk44dLvJw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -6078,7 +6067,6 @@
       "integrity": "sha512-rBnTWHCdbYM2lh7hjyXqxk70wvon3p2FyaniZuey5TrcGBpfhVp0OxOa6gxr9Q9YhZFKyfbEnxc24ZnVbbUkCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.18.1",
         "@typescript-eslint/types": "8.18.1",
@@ -7213,7 +7201,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7289,7 +7276,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7387,6 +7373,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8123,7 +8110,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -9412,7 +9398,6 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -9648,7 +9633,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10200,7 +10184,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -10732,7 +10717,6 @@
       "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -14516,6 +14500,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -17408,6 +17393,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -17422,7 +17408,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -17699,7 +17686,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -17712,7 +17698,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -20266,7 +20251,6 @@
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "devOptional": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -20953,7 +20937,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21424,7 +21407,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -21596,7 +21578,6 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -21731,7 +21712,6 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -21781,7 +21761,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -22379,7 +22358,6 @@
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "devOptional": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -22568,7 +22546,7 @@
     },
     "standalone/server": {
       "name": "@tumaet/server",
-      "version": "4.2.22",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "@tumaet/apollon": "*",
@@ -22710,7 +22688,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -22816,7 +22793,7 @@
     },
     "standalone/webapp": {
       "name": "@tumaet/webapp",
-      "version": "4.2.22",
+      "version": "4.3.0",
       "dependencies": {
         "@mui/icons-material": "6.4.2",
         "@mui/material": "6.4.2",
@@ -22967,7 +22944,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -23191,7 +23167,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/standalone/server/package.json
+++ b/standalone/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tumaet/server",
-  "version": "4.2.22",
+  "version": "4.3.0",
   "private": true,
   "license": "MIT",
   "dependencies": {

--- a/standalone/webapp/package.json
+++ b/standalone/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tumaet/webapp",
   "private": true,
-  "version": "4.2.22",
+  "version": "4.3.0",
   "type": "module",
   "scripts": {
     "start": "vite",

--- a/standalone/webapp/public/legal/profiles/tumaet/privacy.md
+++ b/standalone/webapp/public/legal/profiles/tumaet/privacy.md
@@ -4,7 +4,7 @@ Privacy Statement for Apollon in accordance with Art. 13 GDPR.
 
 ## In plain language
 
-Apollon is a free UML modelling editor hosted by TUM. **No accounts, no cookies, no tracking, no third parties.** Diagrams you choose to share live on TUM servers and are deleted automatically 120 days after your last edit. If you choose to collaborate live, you pick a display name that your collaborators see while you are connected; it is discarded when you close the tab. By design, the service keeps no per-request access logs: your IP address and browser identifier are not persistently recorded. Only operational events about the service itself (certificate renewals, critical errors) are captured, and they contain no personal data.
+Apollon is a free UML modelling editor hosted by TUM. **No accounts, no cookies, no tracking, no third parties.** Diagrams you choose to share live on TUM servers and are deleted automatically 120 days after your last edit. If you choose to collaborate live, you pick a display name that your collaborators see while you are connected; it is discarded when you close the tab. By design, the service keeps no per-request access logs: your IP address and user-agent are not persistently recorded. Only operational events about the service itself (certificate renewals, critical errors) are captured, and they contain no personal data.
 
 Diagram labels are free text. Do not type personal data about identifiable third parties into them. The server does not inspect label contents. **If you do enter such data, you may yourself become a controller for that data within the meaning of Art. 4(7) GDPR.** TUM remains controller only for storing and transporting your diagram.
 

--- a/standalone/webapp/public/legal/profiles/tumaet/privacy.md
+++ b/standalone/webapp/public/legal/profiles/tumaet/privacy.md
@@ -24,9 +24,11 @@ Apollon has **no user accounts, no login, no cookies, and no analytics**. You ar
 
 **Live-collaboration data.** Only if you have entered a display name in the *Collaborate* dialog: your display name, cursor position, and current selection. As described in §1, the server holds these in a per-diagram in-memory record while you are connected and forwards them to your collaborators in real time. Nothing is written to disk.
 
+**Request metadata (IP address and user-agent).** Transmitted automatically by your browser on every HTTP request and visible to TUM's servers only for the duration of the request, so the response can be routed back to your client. Not persistently stored, never used for tracking, profiling, or correlating individuals.
+
 **Operational events about the service itself.** Certificate renewals, critical errors from the reverse proxy or database engine, and unhandled-exception stack traces from the application server. Captured on TUM-operated servers in Germany. These events concern the service, not end users, and contain no personal data by design.
 
-*Legal basis — server-side processing (database, WebSocket, operational events): Art. 6(1)(e) GDPR, read with Art. 4(1) of the Bavarian Data Protection Act (BayDSG) and Art. 2 of the Bavarian Higher Education Innovation Act (BayHIG). TUM processes this data to perform its statutory teaching and research tasks, which require operating the IT services that support them.*
+*Legal basis — server-side processing (database, WebSocket, operational events, request metadata): Art. 6(1)(e) GDPR, read with Art. 4(1) of the Bavarian Data Protection Act (BayDSG) and Art. 2 of the Bavarian Higher Education Innovation Act (BayHIG). TUM processes this data to perform its statutory teaching and research tasks, which require operating the IT services that support them.*
 
 *Legal basis — browser-side storage (theme, draft diagrams, optional collaboration name; see §3): § 25(2) no. 2 of the German Telecommunications Digital Services Data Protection Act (TDDDG). Each entry is strictly necessary for a service you have explicitly requested, so no consent is required.*
 
@@ -60,6 +62,7 @@ Your data is processed by TUM and TUM's operational units only. Apollon does not
 |---|---|---|
 | Shared diagrams | 120 days after the last write (native database TTL) | TUM database (Germany) |
 | WebSocket session and live-collaboration data | While you are connected; dropped on disconnect | Server memory only |
+| Request metadata (IP address, user-agent) | Visible to the server only for the duration of an HTTP request; not persistently stored | TUM server (transient) |
 | Operational events about the service (no personal data by design) | Size-bounded ring buffer (~250 MB per container) | TUM-operated server |
 | Theme preference and locally drafted diagrams | Until you delete them or clear browser storage | Your own device |
 | Optional collaboration display name | Until you close the browser tab | Your own device (and server memory while connected) |


### PR DESCRIPTION
### Checklist

- [x] I linked PR with a related issue *(follow-up to #665)*
- [ ] I added multiple screenshots/screencasts of my UI changes *(N/A — DSMS documentation, privacy notice, version bump)*

### Motivation and Context

Three follow-ups to PR #665 that landed after the squash-merge:

1. **DSMS reviewer feedback.** The TUM data-protection reviewer flagged two issues on the just-filed VT-1699 record: (a) the TUM Org-Kennung `CIT-I1` cannot be resolved in TUMOnline (correct value: `TUS1322`); (b) the data categories on the record did not match the live privacy notice — IP address is mentioned on `apollon.aet.cit.tum.de/privacy` but was not listed in the structured "Datenkategorien" multi-select.

2. **Privacy notice mirror.** §2 ("What personal data is processed") listed only diagram content / WebSocket / live-collab / operational events — even though §1 and §9 mentioned IP and user-agent narratively. With IP added to the Art. 30 record's structured categories, the notice's own enumeration must mirror so the reviewer's website ↔ form check finds them aligned both directions.

3. **Standalone version bump.** PR #654 bumped `@tumaet/apollon` (library) to 4.3.0 but left `@tumaet/webapp` and `@tumaet/server` at 4.2.22, drifting them out of lockstep. Realigning so a 4.3.0 deploy ships consistent versions across all three workspaces.

### Description

#### `docs/admin/dsms/record-of-processing.md`

- Org-Kennung: `CIT-I1` → `TUS1322`.
- IP address added as a structured data category alongside `Name(s)` (transient — visible to the server only for the duration of an HTTP request, never persisted, but processed under GDPR while the request is in flight).
- User-agent string added to the "Other data categories" paste-block (privacy notice §9 mentions it explicitly, same logic as IP — pre-empts a second round trip on the same pattern).
- Storage Location and Retention paste-blocks extended with the IP/UA transient-visibility line so the form's storage / retention / categories fields stay internally consistent.
- Data-subjects intro line now lists IP alongside the live-collab display name as a per-individual identifier.

#### `standalone/webapp/public/legal/profiles/tumaet/privacy.md`

- §2: new bullet "Request metadata (IP address and user-agent)".
- §2 legal-basis footnote: `request metadata` added to the list of server-side processing covered by Art. 6(1)(e) GDPR + Art. 4(1) BayDSG + Art. 2 BayHIG.
- §5 retention table: new row for "Request metadata".
- TL;DR: `browser identifier` → `user-agent` so the term is consistent across §1, §2, §5, and §9.

#### `standalone/{webapp,server}/package.json` + `package-lock.json`

- `@tumaet/webapp` 4.2.22 → 4.3.0
- `@tumaet/server` 4.2.22 → 4.3.0
- `package-lock.json` churn is purely npm dropping `"peer": true` flags from transitive deps after the version bump removed a peer constraint — no actual dependency version changes.

### Steps for Testing

- [ ] After deploy, confirm `@tumaet/webapp` and `@tumaet/server` ship at 4.3.0 (e.g., `docker compose exec webapp cat package.json | jq -r .version` and same for `server`).
- [ ] Render the updated `/privacy` page locally; confirm §2 lists the new "Request metadata" bullet and §5 shows the new retention row.
- [ ] On DSMS portal VT-1699: tick `IP address` in the Page-1 "Datenkategorien" multi-select, paste the updated "Other data categories" / Storage / Retention textareas from `record-of-processing.md`, change Org-Kennung to `TUS1322`, save, and re-submit.
- [ ] Verify `https://apollon.aet.cit.tum.de/privacy` and the DSMS record now agree on which categories are processed (IP, user-agent, Name(s), diagram content, cursor, selection).