### PR TITLE
docs(legal): name Stephan Krusche, fix address line breaks, label paste blocks

### DIFF
--- a/docs/admin/dsms/record-of-processing.md
+++ b/docs/admin/dsms/record-of-processing.md
@@ -13,6 +13,7 @@ The Art. 30 GDPR record of processing for the TUM-AET-operated Apollon deploymen
 
 Responsible department: TUM School of Computation, Information and Technology.
 
+:::{tip} Paste-ready — DSMS "Contact info of the person in charge"
 ```
 Prof. Dr. Stephan Krusche, Head of AET
 Research Group for Applied Education Technologies
@@ -22,14 +23,17 @@ Boltzmannstraße 3, 85748 Garching bei München, Germany
 
 Operational technical contact: ls1.admin@in.tum.de
 ```
+:::
 
 TUM Org identifier: `TUS1322`.
 
 ## Purpose and description (Art. 30(1)(b))
 
+:::{tip} Paste-ready — DSMS "Description and Purpose of Processing Activity"
 ```
 Apollon is a UML modelling editor that runs in a web browser. The Research Group for Applied Education Technologies (AET, Prof. Krusche) at the Technical University of Munich operates a public instance at apollon.aet.cit.tum.de for software-engineering teaching, student project work, and public use. The purpose of the processing is to let users draw UML diagrams and share them with collaborators. Personal data is collected only when a user actively shares a diagram (the diagram content is sent to and stored on TUM servers) or opens the live-collaboration dialog and enters a display name (the name and the user's cursor position and current selection are then visible to other participants in the same diagram session). Data subjects are TUM students and staff, external collaborators, and members of the public.
 ```
+:::
 
 ## Data subjects (Art. 30(1)(c))
 
@@ -45,17 +49,21 @@ Apollon is unauthenticated. The live-collaboration display name and the transien
 
 Structured categories processed: **Name(s)** (the user-chosen live-collaboration display name) and **IP address** (transmitted automatically with each HTTP request; visible to the server only for the duration of the request; not persistently stored). No contact data, identifiers, or special categories (Art. 9 / Art. 10).
 
+:::{tip} Paste-ready — DSMS "Other data categories"
 ```
 - Diagram content (free text): the UML diagram a user actively shares is stored on TUM servers. Labels are free text and may contain personal data the user types; the platform does not require, validate, or inspect their content.
 - Live-collaboration cursor + selection: alongside the display name, the user's cursor position in the editor and the ID of the currently selected element are forwarded in real time to other participants in the same diagram session, while the user is connected.
 - User-agent string: transmitted automatically by the browser on every HTTP request; visible to the server only for the duration of the request; not persistently stored.
 ```
+:::
 
 ## Recipients (Art. 30(1)(d))
 
+:::{tip} Paste-ready — DSMS "Recipient Categories"
 ```
 None. Apollon has no external processors and transfers no personal data to external entities. Within the service, users who hold a diagram's share link can view and edit that diagram, and users who enter the live-collaboration dialog see one another's display name, cursor position, and current selection in real time. These are users of the same TUM/AET-operated Apollon, not external recipients.
 ```
+:::
 
 ## Third-country transfers (Art. 30(1)(e))
 
@@ -65,6 +73,7 @@ None. All processing on TUM/AET infrastructure in Germany.
 
 **Where stored**
 
+:::{tip} Paste-ready — DSMS "Where is this data located and how is it stored?"
 ```
 On AET-operated VMs on TUM premises (Boltzmannstraße 3, 85748 Garching bei München, Germany).
 
@@ -74,38 +83,48 @@ On AET-operated VMs on TUM premises (Boltzmannstraße 3, 85748 Garching bei Mün
 
 No off-host backups of personal data exist. No personal data leaves the EU.
 ```
+:::
 
 **Retention**
 
+:::{tip} Paste-ready — DSMS "Custom Erasure Time"
 ```
 - Diagram content (Redis): 120 days from the last write, enforced by a native database TTL.
 - Live-collaboration data (display name, cursor, selection): held only while the user is connected; dropped from server memory on disconnect.
 - IP address and user-agent: visible to the server only for the duration of an HTTP request; not persistently stored.
 - Operational events about the service (no personal data by design): size-bounded ring buffer, ~250 MB per container.
 ```
+:::
 
 **Reasoning**
 
+:::{tip} Paste-ready — DSMS "Reasoning for the erasure time"
 ```
 Diagram data is retained for 120 days from the last edit to support editing across teaching iterations. After 120 days of inactivity, deletion is performed automatically by the Redis engine. Operational events about the service are kept free of personal data by data minimisation at source (Art. 5(1)(c) + Art. 25 GDPR); a time-based retention period under Art. 5(1)(e) GDPR is therefore not required.
 ```
+:::
 
 **Deletion responsibility**
 
+:::{tip} Paste-ready — DSMS "Who is responsible for the deletion?"
 ```
 Day-to-day technical deletion: AET operations (ls1.admin@in.tum.de). Subject-rights deletion requests: Prof. Dr. Stephan Krusche as responsible PI, with technical execution by AET maintainers against the diagram ID provided by the data subject.
 ```
+:::
 
 **Deletion guarantee**
 
+:::{tip} Paste-ready — DSMS "How is deletion guaranteed?"
 ```
 - Diagram content: automatic via the database TTL once the 120-day window expires; no operator action required.
 - Live-collaboration data: cleared from server memory automatically when the user disconnects.
 - Subject-rights erasure (Art. 17 GDPR): AET maintainers delete the diagram against the diagram ID supplied by the data subject.
 ```
+:::
 
 ## Technical and organisational measures (Art. 30(1)(g) + Art. 32)
 
+:::{tip} Paste-ready — DSMS "Specific Technical and Organisational Measures"
 ```
 Pseudonymisation and encryption (Art. 32(1)(a))
 - Diagrams are stored under a cryptographically random diagram ID with no link to an identifying user.
@@ -134,13 +153,13 @@ Testing and evaluation (Art. 32(1)(d))
 - Dependency vulnerability scanning runs on CI.
 - TOMs are reviewed ad hoc on material changes (new processor, significant new feature). No periodic review cadence.
 ```
+:::
 
 ## Legal basis (Art. 6 GDPR + national norms)
 
 Selected basis: **Art. 6(1)(e) GDPR** (public-interest task), in conjunction with Art. 4(1) BayDSG and Art. 2 BayHIG.
 
-Paste-ready content for the DSMS "Other legal basis" textarea:
-
+:::{tip} Paste-ready — DSMS "Other legal basis"
 ```
 - Provision of the editor; storage and relay of diagrams the user has chosen to share; live collaboration (display name, cursor, selection): Art. 6(1)(e) GDPR in conjunction with Art. 4(1) of the Bavarian Data Protection Act (BayDSG) and Art. 2 of the Bavarian Higher Education Innovation Act (BayHIG) — performance of the university's statutory teaching and research tasks, including operation of the IT services required to carry them out.
 - Operational events about the service (no personal data by design): Art. 6(1)(e) GDPR in conjunction with Art. 4(1) BayDSG and Art. 2 BayHIG — operation and IT security of university services as part of fulfilling those tasks.
@@ -148,6 +167,7 @@ Paste-ready content for the DSMS "Other legal basis" textarea:
 
 Single legal basis for all user groups (TUM members and external participants): Art. 6(1)(e) GDPR. Lit. (f) is excluded for public authorities by the second subparagraph of Art. 6(1) GDPR; lit. (b) does not apply because the service is offered free of charge as part of TUM's public mission, not under a contract. Recital 45 GDPR requires the public-interest basis to be supplied by Member-State law (here: Art. 4(1) BayDSG and Art. 2 BayHIG).
 ```
+:::
 
 No special categories of personal data (Art. 9(1) GDPR) and no criminal-conviction data (Art. 10 GDPR) are processed.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,8 @@ extensions = [
 ]
 
 myst_enable_extensions = [
-    "attrs_inline"
+    "attrs_inline",
+    "colon_fence",
 ]
 
 # Enable mermaid code blocks in markdown

--- a/standalone/webapp/public/legal/profiles/tumaet/imprint.md
+++ b/standalone/webapp/public/legal/profiles/tumaet/imprint.md
@@ -2,12 +2,12 @@ Information in accordance with § 5 DDG (Digitale-Dienste-Gesetz).
 
 ## Service Provider
 
-Technical University of Munich (Technische Universität München)
-Arcisstraße 21
+Technical University of Munich (Technische Universität München)\
+Arcisstraße 21\
 80333 Munich, Germany
 
-Phone: +49 (0)89 289-01
-Email: [poststelle@tum.de](mailto:poststelle@tum.de)
+Phone: +49 (0)89 289-01\
+Email: [poststelle@tum.de](mailto:poststelle@tum.de)\
 Web: [www.tum.de](https://www.tum.de)
 
 ## Legal Form and Representation
@@ -16,7 +16,7 @@ TUM is a public university under Bavarian state law, organised as a public corpo
 
 ## Supervisory Authority
 
-Bayerisches Staatsministerium für Wissenschaft und Kunst
+Bayerisches Staatsministerium für Wissenschaft und Kunst\
 Salvatorstraße 2, 80333 Munich, Germany
 
 ## VAT Identification Number
@@ -25,11 +25,11 @@ DE811193231 (in accordance with § 27a UStG — German VAT Act).
 
 ## Responsible for Content
 
-Prof. Dr. Stephan Krusche
-Applied Education Technologies (AET)
-TUM School of Computation, Information and Technology
-Department of Computer Science
-Boltzmannstraße 3
+Prof. Dr. Stephan Krusche\
+Applied Education Technologies (AET)\
+TUM School of Computation, Information and Technology\
+Department of Computer Science\
+Boltzmannstraße 3\
 85748 Garching bei München, Germany
 
 ## Contact for Apollon

--- a/standalone/webapp/public/legal/profiles/tumaet/privacy.md
+++ b/standalone/webapp/public/legal/profiles/tumaet/privacy.md
@@ -94,8 +94,8 @@ TUM responds to requests without undue delay, in any case within one month of re
 
 You can lodge a complaint with a supervisory authority, in particular the authority competent for TUM:
 
-Bayerischer Landesbeauftragter für den Datenschutz (BayLfD)
-Wagmüllerstraße 18, 80538 Munich, Germany
+Bayerischer Landesbeauftragter für den Datenschutz (BayLfD)\
+Wagmüllerstraße 18, 80538 Munich, Germany\
 Website: [datenschutz-bayern.de](https://www.datenschutz-bayern.de)
 
 ## 8. Automated decision-making
@@ -110,16 +110,20 @@ Use of Apollon is voluntary. You are under no statutory or contractual obligatio
 
 **Controller** under Art. 4(7) GDPR:
 
-Technical University of Munich (Technische Universität München)
-Arcisstraße 21, 80333 Munich, Germany
+Technical University of Munich (Technische Universität München)\
+Arcisstraße 21, 80333 Munich, Germany\
 Represented by its President, Prof. Dr. Thomas F. Hofmann.
 
-Operational responsibility for Apollon lies with the Research Group for Applied Education Technologies (AET), TUM School of Computation, Information and Technology, Department of Computer Science, Boltzmannstraße 3, 85748 Garching bei München, Germany — [ls1.admin@in.tum.de](mailto:ls1.admin@in.tum.de).
+Operational responsibility lies with the Research Group for Applied Education Technologies (AET), led by Prof. Dr. Stephan Krusche:
+
+AET, TUM School of Computation, Information and Technology — Department of Computer Science\
+Boltzmannstraße 3, 85748 Garching bei München, Germany\
+Contact: [ls1.admin@in.tum.de](mailto:ls1.admin@in.tum.de)
 
 **Data Protection Officer:**
 
-Technical University of Munich — Office of the Data Protection Officer
-Arcisstraße 21, 80333 Munich, Germany (attn. Data Protection Officer)
+Technical University of Munich — Office of the Data Protection Officer\
+Arcisstraße 21, 80333 Munich, Germany (attn. Data Protection Officer)\
 Email: [beauftragter@datenschutz.tum.de](mailto:beauftragter@datenschutz.tum.de)
 
 ## 11. Changes to this statement

--- a/standalone/webapp/src/pages/LegalPage.tsx
+++ b/standalone/webapp/src/pages/LegalPage.tsx
@@ -218,10 +218,16 @@ export function LegalPage({
                 overflowX: "auto",
               },
               "& blockquote": {
-                borderLeft: "4px solid var(--apollon-gray)",
+                borderLeft: "4px solid var(--apollon-primary)",
+                bgcolor: "var(--apollon-background-variant)",
                 pl: 2,
+                pr: 2,
+                py: 1.5,
                 my: 2,
-                color: "var(--apollon-gray)",
+                borderRadius: 1,
+                color: "var(--apollon-primary-contrast)",
+                "& > :first-of-type": { mt: 0 },
+                "& > :last-child": { mb: 0 },
               },
               "& hr": {
                 border: "none",


### PR DESCRIPTION
### Checklist

- [x] I linked PR with a related issue *(follow-up to #665 / #666)*
- [ ] I added multiple screenshots/screencasts of my UI changes *(N/A — privacy / imprint copy + DSMS docs render)*

### Motivation and Context

Two readability problems on the live legal pages and the readthedocs DSMS docs:

1. **Privacy notice and imprint address blocks render as run-on paragraphs.** The webapp's markdown renderer is `react-markdown` + `remark-gfm` (no `remarkBreaks`) — so single newlines collapse into spaces and the controller / DPO / supervisory-authority / responsible-for-content / BayLfD blocks all render as one long line each. Plus, the privacy notice's §10 operational-responsibility line was a run-on sentence and didn't name **Prof. Dr. Stephan Krusche** (the operational lead and AET head) — the ROPA's controller block names him; the privacy notice should mirror.
2. **DSMS paste-ready content blocks in `record-of-processing.md` render as bare fenced code on the readthedocs docs site** — small monospace, low contrast, no field-name labelling. Particularly painful in dark mode (Read the Docs Addons toggle).

### Description

#### `standalone/webapp/public/legal/profiles/tumaet/privacy.md` and `imprint.md`

- Added CommonMark hard-break (trailing `\`) on each non-final line of every address block so they render with proper line breaks in both light and dark mode of the deployed `/privacy` and `/imprint` pages.
  - privacy: §7 BayLfD, §10 controller, §10 DPO blocks
  - imprint: service provider, supervisory authority, responsible-for-content, and contact (phone / email / web) blocks
- privacy §10 operational-responsibility line rewritten:
  - now names **Prof. Dr. Stephan Krusche** (Head of AET) explicitly
  - run-on sentence split into intro + structured address block + contact line, so the AET address renders properly instead of as one comma-chained paragraph

#### `docs/admin/dsms/record-of-processing.md` and `docs/conf.py`

- Enabled the MyST `colon_fence` extension so `:::{tip}` admonitions parse.
- Wrapped each of the 11 paste-ready content fences in a `:::{tip}` admonition titled with the DSMS form field it corresponds to (e.g. `Paste-ready — DSMS "Other legal basis"`). The inner code fence is preserved so the content still copy-pastes as plain text into the form's textareas.
- Affected blocks: contact, description, other-categories, recipients, storage location, custom erasure time, reasoning, deletion responsibility, deletion guarantee, TOMs, other-legal-basis.

The admonition gives the content a labelled, semantic-coloured container that the Sphinx theme styles consistently in both light and dark mode (no custom CSS needed). Copy-paste behaviour into DSMS textareas is unchanged because the inner fenced code block is still present.

### Steps for Testing

- [ ] Render `/privacy` and `/imprint` locally (or against the deploy after PR lands) and confirm the controller / DPO / BayLfD / service-provider / supervisory-authority / responsible-for-content blocks all show **multi-line addresses with proper breaks**, not collapsed into a single paragraph.
- [ ] On `/privacy` §10, confirm **Prof. Dr. Stephan Krusche** is named as the operational lead.
- [ ] Build the docs (`cd docs && make html`) and open `admin/dsms/record-of-processing.html`. Each paste-ready block should now render as a labelled "Tip" admonition with the DSMS field name in the title.
- [ ] Toggle the readthedocs dark-mode flyout and verify the paste-ready blocks remain readable.
- [ ] Copy-paste content from any admonition into a plain text field — should land as plain text without `•` bullets or HTML artefacts (because the inner fenced code block is preserved).