### PR TITLE
fix(docker): pin redis-stack-server dir to /data

### DIFF
--- a/docker/compose.db.yml
+++ b/docker/compose.db.yml
@@ -13,6 +13,13 @@ services:
       - apollon-network
     command:
       - redis-stack-server
+      # `redis-stack-server` defaults `dir` to `/var/lib/redis-stack`, NOT
+      # `/data` like upstream `redis`. Without this flag the server writes
+      # its AOF/RDB into the container's writable layer instead of the
+      # `dbdata` volume — fine until the container is recreated, at which
+      # point every write since the previous recreate is lost.
+      - --dir
+      - /data
       - --appendonly
       - "yes"
       - --appendfsync


### PR DESCRIPTION
## Summary

`redis-stack-server` defaults its `dir` to `/var/lib/redis-stack`, NOT `/data` like upstream `redis:7-alpine`. Without `--dir /data` the server writes its AOF/RDB into the container's writable layer instead of the `dbdata` named volume — every write between two `docker compose up`s is silently discarded when the next deploy recreates the container.

## Context

Caught during the production redis-stack migration on 2026-05-19: the new container booted clean, the named volume held the correct pre-migration RDB, but `DBSIZE` was `0` until the container was relaunched with `--dir /data`. Hot-patched in place on prod at the time; this lands the same fix into the repo so the next `deploy-db` doesn't re-introduce the bug.

Staging is being patched in lockstep (separate operational task) because its named volume still holds stale data while live writes have accumulated in the writable layer.

## Test plan

- [x] `docker compose -f docker/compose.db.yml config` parses cleanly
- [x] Local verification on prod: with `--dir /data`, `redis-cli CONFIG GET dir` returns `/data` and `DBSIZE` matches expected (112 post-migration)
- [ ] After merge, next `deploy-db` on staging + prod recreates the container with the in-repo command block (no more drift between repo and the hot-patched VM file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)