### PR TITLE
fix(ci): install pnpm in standalone mode on self-hosted mac runner

### DIFF
--- a/.github/workflows/ios-testflight-release.yml
+++ b/.github/workflows/ios-testflight-release.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6.0.8
+        with:
+          standalone: true
 
       - name: Set up Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6


### PR DESCRIPTION
The self-hosted runner ships a Node 24 whose bundled `npm` crashes
with `Cannot find module '../lib/cli.js'`, so pnpm/action-setup's
default `npm install -g pnpm` flow dies before pnpm is on PATH.
`standalone: true` downloads a prebuilt pnpm binary directly and
sidesteps the broken npm.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
