### PR TITLE
fix(ci): set up Node before pnpm on self-hosted mac runner

### DIFF
--- a/.github/workflows/ios-testflight-release.yml
+++ b/.github/workflows/ios-testflight-release.yml
@@ -21,16 +21,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6.0.8
-        with:
-          standalone: true
-
       - name: Set up Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: ".nvmrc"
-          cache: "pnpm"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6.0.8
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
`standalone: true` on pnpm/action-setup still goes through npm
(installs @pnpm/exe instead of pnpm), so it still hits the
runner's broken bundled npm at externals.2.334.0/node24/bin/npm.

Running actions/setup-node first installs a working Node into the
tool cache, which pnpm/action-setup then uses instead of the
broken bundled one. The pnpm cache option goes away since it
requires pnpm to already be installed (chicken/egg).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
