### PR TITLE
fix(ci): install CocoaPods via bundle for iOS TestFlight workflow

### DIFF
--- a/.github/workflows/ios-testflight-release.yml
+++ b/.github/workflows/ios-testflight-release.yml
@@ -32,6 +32,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Ruby gems (fastlane + cocoapods)
+        working-directory: standalone/webapp
+        run: |
+          eval "$(/opt/homebrew/bin/rbenv init - --no-rehash bash)"
+          bundle install
+          # Persist rbenv shims on PATH so bundle, pod, and fastlane are
+          # resolvable in every subsequent step without re-init.
+          echo "$(rbenv root)/shims" >> "$GITHUB_PATH"
+
       - name: Build library + web assets
         run: pnpm run build:lib && pnpm --filter @tumaet/webapp run build
 
@@ -46,12 +55,6 @@ jobs:
         working-directory: standalone/webapp
         run: pnpm exec cap sync ios
 
-      - name: Install Gems
-        working-directory: standalone/webapp
-        run: |
-          eval "$(/opt/homebrew/bin/rbenv init - --no-rehash bash)"
-          bundle install
-
       - name: Generate build number
         run: echo "BUILD_NUMBER=$(date +'%Y%m%d%H%M')" >> "$GITHUB_ENV"
 
@@ -65,9 +68,7 @@ jobs:
           API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_KEY_ID }}
           API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           API_KEY_PASSWORD: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_PASSWORD }}
-        run: |
-          eval "$(/opt/homebrew/bin/rbenv init - --no-rehash bash)"
-          bundle exec fastlane build
+        run: bundle exec fastlane build
 
       - name: Upload to TestFlight (Fastlane)
         working-directory: standalone/webapp
@@ -75,9 +76,7 @@ jobs:
           API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_KEY_ID }}
           API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           API_KEY_PASSWORD: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_PASSWORD }}
-        run: |
-          eval "$(/opt/homebrew/bin/rbenv init - --no-rehash bash)"
-          bundle exec fastlane release
+        run: bundle exec fastlane release
 
       - name: Upload IPA artifact
         if: always()

--- a/standalone/webapp/Gemfile
+++ b/standalone/webapp/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+gem "cocoapods"
 gem "abbrev"
 gem "logger"
 gem "mutex_m"


### PR DESCRIPTION
### Motivation and Context

The first three steps of \`ios-testflight-release\` now succeed (Node, pnpm, install, build), but \`cap add ios\` fails with:

\`\`\`
[error] CocoaPods is not installed.
\`\`\`

The self-hosted Mac runner does not ship a system \`pod\`, so Capacitor's CocoaPods integration fails the moment it tries to install the iOS pods.

### Description

- Add \`cocoapods\` to \`standalone/webapp/Gemfile\` so it ships with the bundle — no system pod required.
- Hoist the gem install step ahead of the Capacitor steps so \`pod\` is on PATH before \`cap add ios\` runs.
- Write \`\$(rbenv root)/shims\` to \`\$GITHUB_PATH\` after \`bundle install\`. That makes \`bundle\`, \`pod\`, and \`fastlane\` available to every subsequent step without needing a per-step \`eval "\$(rbenv init ...)"\`. The two Fastlane steps simplify to a plain \`bundle exec fastlane …\`.

### Steps for Testing

1. Merge this PR.
2. Actions → \`ios-testflight-release\` → "Run workflow" → branch \`main\`.
3. Confirm \`Install Ruby gems (fastlane + cocoapods)\` is green and \`Add iOS platform (if missing)\` no longer fails with the CocoaPods error.