### PR TITLE
fix(ci): set MARKETING_VERSION from package.json for TestFlight upload

### DIFF
--- a/.github/workflows/ios-testflight-release.yml
+++ b/.github/workflows/ios-testflight-release.yml
@@ -55,13 +55,17 @@ jobs:
         working-directory: standalone/webapp
         run: pnpm exec cap sync ios
 
-      - name: Generate build number
-        run: echo "BUILD_NUMBER=$(date +'%Y%m%d%H%M')" >> "$GITHUB_ENV"
+      - name: Resolve marketing version and build number
+        run: |
+          MARKETING_VERSION=$(node -p "require('./standalone/webapp/package.json').version")
+          echo "MARKETING_VERSION=$MARKETING_VERSION" >> "$GITHUB_ENV"
+          echo "BUILD_NUMBER=$(date +'%Y%m%d%H%M')" >> "$GITHUB_ENV"
 
       - name: Build iOS app (Fastlane)
         working-directory: standalone/webapp
         env:
           BUILD_NUMBER: ${{ env.BUILD_NUMBER }}
+          MARKETING_VERSION: ${{ env.MARKETING_VERSION }}
           MATCH_GITLAB_AUTH: ${{ secrets.IOS_MATCH_GITLAB_AUTH }}
           MATCH_PASSWORD: ${{ secrets.IOS_MATCH_PASSWORD }}
           MATCH_GIT_URL: ${{ vars.IOS_MATCH_GIT_URL }}

--- a/standalone/webapp/fastlane/Fastfile
+++ b/standalone/webapp/fastlane/Fastfile
@@ -32,6 +32,13 @@ platform :ios do
       team_id: team_id
     )
 
+    if ENV["MARKETING_VERSION"] && !ENV["MARKETING_VERSION"].empty?
+      increment_version_number(
+        version_number: ENV["MARKETING_VERSION"],
+        xcodeproj: XCODE_PROJECT
+      )
+    end
+
     if ENV["BUILD_NUMBER"] && !ENV["BUILD_NUMBER"].empty?
       increment_build_number(
         build_number: ENV["BUILD_NUMBER"],


### PR DESCRIPTION
### Motivation and Context

The first end-to-end run of `ios-testflight-release` got all the way through match, signing, and `gym`. Only the TestFlight upload failed:

```
Validation failed (409) Invalid Version. The build with the version "1.0.1" can't be imported
because a later version has been closed for new build submissions.
Invalid Pre-Release Train. The train version '1.0' is closed for new build submissions.
```

Capacitor generates the iOS project with `MARKETING_VERSION = 1.0` by default. App Store Connect already has a closed `1.0` train (likely from earlier manual uploads), so Apple rejects any new build with that version.

### Description

- Workflow step now resolves `MARKETING_VERSION` from `standalone/webapp/package.json` (currently `4.4.1`) and exposes both `MARKETING_VERSION` and `BUILD_NUMBER` via `$GITHUB_ENV`.
- Fastfile `build` lane calls `increment_version_number` when `MARKETING_VERSION` is set, in addition to the existing `increment_build_number`. Both happen before `build_app`, so the IPA carries the right `CFBundleShortVersionString` and `CFBundleVersion`.

This keeps the TestFlight version in sync with the webapp release version going forward.

### Steps for Testing

1. Merge.
2. Actions → `ios-testflight-release` → "Run workflow" → branch `main`.
3. Confirm the upload to TestFlight succeeds and the build appears in App Store Connect under version `4.4.1`.