### PR TITLE
chore: Simplify docs GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,10 @@
-name: Docs
+# Documentation Deployment Pipeline
+#
+# - PR with docs changes: build a /-rooted bundle
+# - push to main with docs changes: build /Apollon/-rooted bundle and deploy
+#   it to GitHub Pages
 
-# - PR with docs changes: build a /-rooted bundle (preview)
-# - push to main with docs changes: build /Apollon/-rooted bundle, deploy
-#   to GitHub Pages
+name: Docs
 
 on:
   push:
@@ -10,20 +12,25 @@ on:
     paths:
       - "docs/**"
       - "library/**"
+      - "package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+      - ".nvmrc"
       - ".github/workflows/docs.yml"
   pull_request:
+    types: [opened, synchronize, reopened]
     paths:
       - "docs/**"
       - "library/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".nvmrc"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: docs-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || github.ref }}
@@ -48,7 +55,7 @@ jobs:
 
       - id: flag
         run: |
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          if [[ "${{ github.ref }}" == "refs/heads/main" && "${{ github.event_name }}" != "pull_request" ]]; then
             echo "is-production=true" >> "$GITHUB_OUTPUT"
           else
             echo "is-production=false" >> "$GITHUB_OUTPUT"
@@ -74,13 +81,6 @@ jobs:
         env:
           DOCUSAURUS_BASE_URL: ${{ steps.flag.outputs.is-production == 'true' && '/Apollon/' || '/' }}
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: docs-build
-          path: docs/build
-          retention-days: 7
-          if-no-files-found: error
-
       - if: steps.flag.outputs.is-production == 'true'
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
@@ -91,6 +91,9 @@ jobs:
     needs: build
     if: needs.build.outputs.is-production == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -38,7 +38,7 @@ const config: Config = {
   },
 
   url: "https://ls1intum.github.io",
-  // Surge preview ('/') vs GitHub Pages production ('/Apollon/').
+  // Pull request builds use '/', GitHub Pages production uses '/Apollon/'.
   baseUrl: process.env.DOCUSAURUS_BASE_URL || "/Apollon/",
   organizationName: "ls1intum",
   projectName: "Apollon",


### PR DESCRIPTION
### Checklist

- [ ] I linked PR with a related issue (no issue; requested directly)
- [ ] I added multiple screenshots/screencasts of my UI changes (not applicable; CI/docs workflow only)

### Motivation and Context

Apollon should publish documentation through the repository's GitHub Pages pipeline without carrying Read the Docs-era or heavier preview-deployment assumptions. The docs site is already Docusaurus-based, so this keeps the deployment path direct and understandable: pull requests validate the docs build, while `main` publishes the Pages artifact.

This PR does not complete a linked issue.

### Description

- Keeps the docs workflow focused on GitHub Pages: PRs build with `DOCUSAURUS_BASE_URL=/`, and pushes or manual runs on `main` build with `DOCUSAURUS_BASE_URL=/Apollon/` and deploy via `actions/deploy-pages`.
- Removes the redundant generic `docs-build` artifact upload and only uploads the GitHub Pages artifact for production deployments.
- Narrows elevated Pages permissions to the deploy job instead of granting them workflow-wide.
- Expands docs workflow path filters to include root dependency, workspace, and Node version files that can affect the documentation build.
- Updates the Docusaurus config comment so it describes the current PR-build/GitHub-Pages behavior instead of the old Surge wording.

### Steps for Testing

1. Run `actionlint .github/workflows/docs.yml`.
2. Run `pnpm exec prettier --check .github/workflows/docs.yml docs/docusaurus.config.ts`.
3. Run `pnpm run build:docs` to verify the default GitHub Pages base URL build.
4. Run `DOCUSAURUS_BASE_URL=/ pnpm --filter @tumaet/apollon-docs run build` to verify the PR/root base URL build.
5. Confirm that a PR docs workflow builds without publishing, and that a `main` docs workflow uploads and deploys the Pages artifact.

Local note: this machine currently runs Node `v22.14.0` while the repo pins `24.15.0`; the commands above completed successfully with engine warnings. GitHub Actions uses `.nvmrc`.

### Screenshots

Not applicable. This change only affects CI documentation deployment configuration.
