### PR TITLE
docs: overhaul npm README + auto-sync pinned CDN version

### DIFF
--- a/.github/workflows/pr-health-checks.yml
+++ b/.github/workflows/pr-health-checks.yml
@@ -51,6 +51,25 @@ jobs:
               - 'pnpm-workspace.yaml'
               - '.github/workflows/pr-health-checks.yml'
 
+  # No path filter: a stale CDN version can drift in via a doc edit OR a bump,
+  # so check every PR. Pure Node — no pnpm install needed.
+  version-sync-check:
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.should-skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Check README + docs version sync
+        run: node scripts/sync-library-version.mjs --check
+
   lint-and-format-check:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.should-skip != 'true' && needs.detect-changes.outputs.code == 'true'
@@ -270,6 +289,7 @@ jobs:
     needs:
       [
         detect-changes,
+        version-sync-check,
         lint-and-format-check,
         library-node22-compat,
         e2e-tests,

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -172,6 +172,10 @@ jobs:
           echo "standalone_version=${STANDALONE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "vscode_version=${VSCODE_VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Sync pinned library version in README + docs
+        # No-op for the standalone/vscode scopes — library version unchanged.
+        run: node scripts/sync-library-version.mjs
+
       - name: Regenerate pnpm-lock.yaml
         run: pnpm install --lockfile-only --ignore-scripts
 
@@ -190,7 +194,7 @@ jobs:
             library)
               BRANCH="chore/library-v${LIB_VERSION}"
               COMMIT_TITLE="chore: release @tumaet/apollon@${LIB_VERSION} + standalone v${STANDALONE_VERSION}"
-              FILES=(library/package.json standalone/webapp/package.json standalone/server/package.json pnpm-lock.yaml)
+              FILES=(library/package.json standalone/webapp/package.json standalone/server/package.json pnpm-lock.yaml library/README.md docs/library/embedding/vanilla.md docs/src/pages/index.tsx)
               ;;
             standalone)
               BRANCH="chore/standalone-v${STANDALONE_VERSION}"

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![npm version](https://img.shields.io/npm/v/@tumaet/apollon)](https://www.npmjs.com/package/@tumaet/apollon)
 [![npm license](https://img.shields.io/npm/l/@tumaet/apollon)](./LICENSE)
 
-Apollon is an open-source UML modeling editor for the web. Draw 13 UML and modeling diagram types — including class, component, activity, BPMN, and SFC — in the browser, collaborate in real time, and export to SVG, PNG, PDF, or JSON.
+Apollon is an open-source UML modeling editor for the web. Draw 13 UML and modeling diagram types (class, component, activity, BPMN, SFC, and more) in the browser, collaborate in real time, and export to SVG, PNG, PDF, or JSON.
 
 This monorepo contains every piece of the Apollon platform:
 
-- **[`library/`](./library)** — the embeddable `@tumaet/apollon` React component ([npm](https://www.npmjs.com/package/@tumaet/apollon)).
-- **[`standalone/`](./standalone)** — standalone web app (server + webapp) built on the library.
-- **[`vscode-extension/`](./vscode-extension)** — the Apollon VS Code extension.
-- **[`docs/`](./docs)** — Docusaurus documentation site, published at <https://ls1intum.github.io/Apollon/>.
+- **[`library/`](./library)**: the embeddable `@tumaet/apollon` editor ([npm](https://www.npmjs.com/package/@tumaet/apollon)).
+- **[`standalone/`](./standalone)**: the standalone web app (server and webapp) built on the library.
+- **[`vscode-extension/`](./vscode-extension)**: the Apollon VS Code extension.
+- **[`docs/`](./docs)**: the Docusaurus documentation site, published at <https://ls1intum.github.io/Apollon/>.
 
 ## Use the library
 
@@ -36,15 +36,15 @@ pnpm dev
 - Server (`tsx watch`) on a printed local HTTP port with a matching WebSocket relay port.
 - Webapp (Vite HMR) on a printed local dev URL.
 
-The launcher handles the boring parts:
+The launcher handles the setup:
 
 - Resolves port collisions for the webapp, server, WebSocket relay, and Redis.
-- Reuses an existing local Redis if one is running; otherwise starts a Redis container on a free host port (Docker required only in that case).
-- Needs no `.env` files — defaults match the local setup.
+- Reuses an existing local Redis if one is running; otherwise it starts a Redis container on a free host port (Docker is only required in that case).
+- Needs no `.env` files. The defaults match the local setup.
 
 Override ports via `APOLLON_WEBAPP_PORT`, `APOLLON_SERVER_PORT`, `APOLLON_WS_PORT`, or `APOLLON_REDIS_PORT`.
 
-To preview the documentation site instead, run `pnpm dev:docs` from the repo root — it builds the library and starts the Docusaurus dev server.
+To preview the documentation site instead, run `pnpm dev:docs` from the repo root. It builds the library and starts the Docusaurus dev server.
 
 ## Tech stack
 
@@ -58,19 +58,19 @@ To preview the documentation site instead, run `pnpm dev:docs` from the repo roo
 
 ## Requirements
 
-- **Node.js** — version pinned in [`.nvmrc`](./.nvmrc) (Node 24 LTS).
-- **pnpm 11+** — the package manager. The exact version is pinned in `package.json` (`packageManager` field). Install with `npm install -g pnpm@11`.
-- **Docker** — only when `pnpm dev` needs to start a local Redis.
+- **Node.js**: version pinned in [`.nvmrc`](./.nvmrc) (Node 24 LTS).
+- **pnpm 11+**: the package manager. The exact version is pinned in the `packageManager` field of `package.json`. Install it with `npm install -g pnpm@11`.
+- **Docker**: only when `pnpm dev` needs to start a local Redis.
 
 ## Documentation
 
-The docs are a [Docusaurus](https://docusaurus.io/) site published at <https://ls1intum.github.io/Apollon/>. Sources live in [`docs/`](./docs); preview locally with `pnpm dev:docs`.
+The docs are a [Docusaurus](https://docusaurus.io/) site published at <https://ls1intum.github.io/Apollon/>. Sources live in [`docs/`](./docs); preview them locally with `pnpm dev:docs`.
 
-- [Library](https://ls1intum.github.io/Apollon/library/) — embedding the `@tumaet/apollon` React component.
-- [User Guide](https://ls1intum.github.io/Apollon/user/) — getting started, requirements, and self-hosting.
-- [Contributor](https://ls1intum.github.io/Apollon/contributor/) — project structure, scripts, deployment, and troubleshooting.
+- [Library](https://ls1intum.github.io/Apollon/library/): embedding the `@tumaet/apollon` editor.
+- [User Guide](https://ls1intum.github.io/Apollon/user/): getting started, requirements, and self-hosting.
+- [Contributor](https://ls1intum.github.io/Apollon/contributor/): project structure, scripts, deployment, and troubleshooting.
 
-Operations, legal-pages, and TUM DSMS material lives in [`ops/`](./ops) in this repo.
+Operations, legal pages, and TUM DSMS material live in [`ops/`](./ops) in this repo.
 
 ## Contributing
 
@@ -78,4 +78,4 @@ Open an issue or a pull request at <https://github.com/ls1intum/Apollon>. Guidel
 
 ## License
 
-MIT — see [LICENSE](./LICENSE).
+MIT. See [LICENSE](./LICENSE).

--- a/docs/contributor/deployment/npm-publishing.md
+++ b/docs/contributor/deployment/npm-publishing.md
@@ -18,6 +18,8 @@ Standalone starts at `4.2.18` (the library version at the time of the release-pi
 
 All three workflows trigger automatically when their version changes on `main`. There is **one** manual step per release: merge the bump PR.
 
+The `library` bump also rewrites the pinned `@tumaet/apollon@X.Y.Z` CDN URLs in the README and docs (via `scripts/sync-library-version.mjs`) so the published examples never lag the package version. PR Health Checks run the same script with `--check`, so a drift can never merge — run `pnpm sync:version` locally to fix one.
+
 ## Cut a release
 
 1. Actions → **Version Bump** → pick `scope` and bump type. Merge the PR that opens.

--- a/docs/library/embedding/vanilla.md
+++ b/docs/library/embedding/vanilla.md
@@ -42,7 +42,7 @@ can shift between releases. [jsDelivr's `esm.run`](https://www.jsdelivr.com/esm)
 is an equivalent substitute.
 
 :::warning Pin the CDN version
-Both URLs above pin an exact version (`@4.4.0`). An **unpinned** URL —
+Both URLs above pin an exact version. An **unpinned** URL —
 `@tumaet/apollon` with no version — always resolves to the latest release, so
 a new major can land on the next page refresh and break your embed without
 any change on your side. Always pin to a known-good version and bump it

--- a/library/README.md
+++ b/library/README.md
@@ -1,20 +1,43 @@
+<div align="center">
+
 # @tumaet/apollon
 
 [![npm version](https://img.shields.io/npm/v/@tumaet/apollon)](https://www.npmjs.com/package/@tumaet/apollon)
-[![npm license](https://img.shields.io/npm/l/@tumaet/apollon)](https://github.com/ls1intum/Apollon/blob/main/LICENSE)
+[![npm downloads](https://img.shields.io/npm/dm/@tumaet/apollon)](https://www.npmjs.com/package/@tumaet/apollon)
+[![license](https://img.shields.io/npm/l/@tumaet/apollon)](https://github.com/ls1intum/Apollon/blob/main/LICENSE)
+[![types included](https://img.shields.io/npm/types/@tumaet/apollon)](https://www.npmjs.com/package/@tumaet/apollon)
 
-Embeddable UML modeling editor. Mounts into any DOM node — works inside Angular, Vue, Svelte, vanilla JS, or React hosts. 13 diagram types, SVG/PNG/PDF/JSON export, optional real-time collaboration via Yjs.
+**Embeddable UML modeling editor for the web.** Mounts into any DOM node — works inside Angular, Vue, Svelte, vanilla JS, or React hosts.
+
+[**▶ Live demo**](https://apollon.aet.cit.tum.de) · [Docs](https://ls1intum.github.io/Apollon/library/) · [API reference](https://ls1intum.github.io/Apollon/library/api) · [Examples](https://ls1intum.github.io/Apollon/library/embedding/react) · [GitHub](https://github.com/ls1intum/Apollon)
+
+</div>
+
+---
+
+Apollon is the modeling editor behind [Artemis](https://artemis.tum.de/), TUM's interactive learning platform. Its public API is **imperative** — `new ApollonEditor(container, options)` — so your host code never has to touch React, even though the editor mounts its own React tree inside the node you give it. React hosts get a first-class [`<Apollon>` component](#react) instead.
+
+## Features
+
+- **13 diagram types** — class, object, activity, use case, communication, component, deployment, Petri net, reachability graph, syntax tree, flowchart, BPMN, and SFC.
+- **Framework-agnostic** — one imperative API for Angular, Vue, Svelte, and vanilla JS; a dedicated React component, hooks, and provider for React.
+- **Real-time collaboration** — opt-in, transport-agnostic multi-user editing powered by [Yjs](https://yjs.dev/). Bring any WebSocket/WebRTC/BroadcastChannel transport.
+- **Export** — SVG and JSON out of the box; PNG/PDF derive from the SVG pipeline (reference implementations ship in the repo).
+- **Assessment mode** — attach scores and feedback to elements (the grading workflow used by Artemis).
+- **TypeScript-first** — full type definitions ship with the package.
 
 ## Install
 
-The package ships two builds with identical APIs:
+The package ships **two builds with an identical API.** Pick by whether your host already uses React:
 
-| Subpath                       | React / MUI / emotion / xyflow | Bundle  | Use when                                                                                          |
-| ----------------------------- | ------------------------------ | ------- | ------------------------------------------------------------------------------------------------- |
-| `@tumaet/apollon` _(default)_ | bundled                        | ~2.4 MB | Your host is Angular, Vue, Svelte, vanilla JS, or any framework that doesn't already have React.  |
-| `@tumaet/apollon/react`       | externalized (peer deps)       | ~875 KB | Your host is React 18.3 and you want the editor to share React with your app instead of bundling. |
+| Import                        | React / MUI / emotion / xyflow | Size (min / gzip) | Use when                                                                                                           |
+| ----------------------------- | ------------------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `@tumaet/apollon` _(default)_ | **bundled**                    | ~2.4 MB / ~540 KB | Your host is Angular, Vue, Svelte, vanilla JS — anything without React. Zero peer deps to install.                 |
+| `@tumaet/apollon/react`       | **peer deps** (shared)         | ~875 KB / ~170 KB | Your host is React 18.3 and should share its React/MUI instance with the editor instead of bundling a second copy. |
 
-### Standalone build (any framework, no peer deps)
+Sizes are the published entry chunks; gzip is what ships over the wire. The `/react` figure excludes the peers your app already has.
+
+### Standalone build — any framework, no peer deps
 
 ```sh
 npm install @tumaet/apollon
@@ -25,9 +48,9 @@ import { ApollonEditor } from "@tumaet/apollon"
 import "@tumaet/apollon/style.css"
 ```
 
-No further installs needed — React, MUI, emotion, and xyflow are bundled inside the library.
+React, MUI, emotion, and xyflow are bundled inside the library — nothing else to install.
 
-### Peer-dependency build (React hosts)
+### React build — share your host's React
 
 ```sh
 npm install @tumaet/apollon \
@@ -35,14 +58,27 @@ npm install @tumaet/apollon \
   @emotion/react @emotion/styled @mui/material @xyflow/react
 ```
 
-```ts
+```tsx
 import { Apollon } from "@tumaet/apollon/react"
 import "@tumaet/apollon/style.css"
 ```
 
-Peer ranges: `react ^18.3`, `react-dom ^18.3`, `@mui/material ^6.4`, `@emotion/react ^11.11`, `@emotion/styled ^11.11`, `@xyflow/react ^12.3`. The `/react` subpath keeps your final bundle from shipping a second copy of React, and is the only entry that exports the `<Apollon>` React component.
+| Peer            | Range     |     | Peer              | Range      |
+| --------------- | --------- | --- | ----------------- | ---------- |
+| `react`         | `^18.3.0` |     | `@mui/material`   | `^6.4.0`   |
+| `react-dom`     | `^18.3.0` |     | `@emotion/react`  | `^11.11.0` |
+| `@xyflow/react` | `^12.3.0` |     | `@emotion/styled` | `^11.11.0` |
 
-## Usage
+## Which build do I use?
+
+This is the one decision to get right up front:
+
+- **Not a React app?** Use the default `@tumaet/apollon`. It bundles its own React, so there is nothing to install and nothing to configure.
+- **A React app?** Use `@tumaet/apollon/react` and install the peers above. The default build would ship a **second copy of React** that fights your host's — causing "Invalid hook call" errors and a bloated bundle. The `/react` subpath externalizes React, MUI, emotion, and xyflow so the editor shares the single instance your app already has, and it is the **only** entry that exports the `<Apollon>` component, hooks, and provider.
+
+> **⚠️ The container must have an explicit, non-zero height** (`600px`, `80vh`, or a sized flex/grid child) — whichever build you choose. The canvas sizes itself to its parent; without a resolvable height it collapses to zero pixels and renders blank. This is the single most common embedding mistake. See [Troubleshooting](https://ls1intum.github.io/Apollon/library/troubleshooting).
+
+## Quick start
 
 ```ts
 import { ApollonEditor, UMLDiagramType } from "@tumaet/apollon"
@@ -56,22 +92,22 @@ const editor = new ApollonEditor(container, {
 })
 
 const subscriptionId = editor.subscribeToModelChange((model) => {
-  // persist / broadcast
+  // persist / broadcast the latest diagram JSON
 })
 
-const svg = await editor.exportAsSVG({ svgMode: "web" })
+const { svg } = await editor.exportAsSVG()
 
 editor.unsubscribe(subscriptionId)
 editor.destroy()
 ```
 
-The editor is client-only. In SSR frameworks (Next.js, Remix, SvelteKit, Nuxt), construct from a client-side effect — never during render. Always call `editor.destroy()` before re-mounting on the same container.
+The editor is **client-only**. In SSR frameworks (Next.js, Remix, SvelteKit, Nuxt), construct it from a client-side effect — never during render. Always call `editor.destroy()` before re-mounting on the same container.
 
 ## Embedding examples
 
 ### React
 
-Use the `<Apollon>` component from the `@tumaet/apollon/react` subpath. Render a saved diagram and persist edits as the user makes them:
+Use the `<Apollon>` component from the `@tumaet/apollon/react` subpath — it owns the editor's lifecycle (constructs on mount, destroys on unmount):
 
 ```tsx
 import { Apollon } from "@tumaet/apollon/react"
@@ -94,7 +130,7 @@ export function DiagramEditor({ initialModel }: { initialModel?: UMLModel }) {
 }
 ```
 
-The component owns the editor's lifecycle. See the [React embedding guide](https://ls1intum.github.io/Apollon/library/embedding/react) for hooks, ref, and provider.
+Reach the instance via `ref`, the `onMount(editor)` callback, or the `useApollonEditor()` hook. See the [React embedding guide](https://ls1intum.github.io/Apollon/library/embedding/react) for hooks, the provider, and SSR.
 
 ### Angular (17.3+ signal-based)
 
@@ -137,6 +173,8 @@ export class DiagramEditorComponent {
 }
 ```
 
+`afterNextRender` runs only in the browser, so this is SSR-safe by construction.
+
 ### Vanilla JS / CDN
 
 ```html
@@ -157,34 +195,50 @@ export class DiagramEditorComponent {
 </script>
 ```
 
-Pin an exact version; an unpinned CDN URL resolves to `latest` and can break your embed on the next page refresh.
+> **⚠️ Pin an exact version**, as the URLs above do. An unpinned CDN URL resolves to `latest`, so a new major can land on the next page refresh and break your embed.
 
 ## Supported diagrams
 
-Class, Object, Activity, Use Case, Communication, Component, Deployment, Petri Net, Reachability Graph, Syntax Tree, Flowchart, BPMN, SFC. See `UMLDiagramType` in `dist/index.d.ts` for the exact enum.
+Class, Object, Activity, Use Case, Communication, Component, Deployment, Petri Net, Reachability Graph, Syntax Tree, Flowchart, BPMN, SFC. The `UMLDiagramType` enum carries the exact wire literals.
 
 ## Real-time collaboration
 
 Opt-in and transport-agnostic. Set `collaborationEnabled: true`, then wire your transport:
 
 ```ts
+const editor = new ApollonEditor(container, { collaborationEnabled: true })
+
+// Outbound: the editor calls back when it has bytes to send.
 editor.sendBroadcastMessage((base64) => transport.send(base64))
+
+// Inbound: forward every received frame back to the editor.
 transport.onMessage((base64) => editor.receiveBroadcastedMessage(base64))
 ```
 
-Use any Yjs-compatible transport (WebSocket, WebRTC, `y-websocket`, etc.).
+Any Yjs-compatible transport works — `y-websocket`, `y-webrtc`, BroadcastChannel, or your own relay. Cursor/selection awareness rides the same channel automatically. See [Collaboration](https://ls1intum.github.io/Apollon/library/api/collaboration).
 
 ## Export
 
-- `editor.exportAsSVG(options)` resolves to `{ svg, clip }`.
-- PNG and PDF use the same pipeline via `ExportOptions` (`svgMode: "web" | "compat"`); see `dist/index.d.ts`.
-- `editor.model` returns the `UMLModel` as JSON.
+- **SVG** — `await editor.exportAsSVG(options)` resolves to `{ svg, clip }`. `svgMode: "web"` (default) keeps CSS variables for theme-adaptive output; `"compat"` inlines them for PDF/Inkscape.
+- **JSON** — `editor.model` returns the `UMLModel`; assignment is round-trip safe. Use `importDiagram(json)` to normalize older v2/v3 models.
+- **Headless** — `ApollonEditor.exportModelAsSvg(model, options)` renders an arbitrary model with no mounted editor.
+- **PNG / PDF** — produced downstream from the exported SVG. The repo's standalone app and server show reference implementations (`@resvg/resvg-js` for PNG, `pdfmake` for PDF).
+
+See [Export](https://ls1intum.github.io/Apollon/library/api/export) for the full `ExportOptions`.
+
+## Documentation
+
+- [Library overview](https://ls1intum.github.io/Apollon/library/) — install, quickstart, embedding
+- [API reference](https://ls1intum.github.io/Apollon/library/api) — the complete `ApollonEditor` and `<Apollon>` surface
+- [Troubleshooting](https://ls1intum.github.io/Apollon/library/troubleshooting) — blank canvas, SSR, duplicate React, and other embedding gotchas
+
+The server-side wire protocol lives behind the **unstable** `@tumaet/apollon/internals` subpath, which is explicitly **not** covered by SemVer.
 
 ## Related
 
-- Source and issue tracker: <https://github.com/ls1intum/Apollon>
-- Standalone web editor, server, and VS Code extension live in the same monorepo.
-- Developed alongside [Artemis](https://artemis.tum.de/), TUM's interactive learning platform.
+- **Source & issues:** <https://github.com/ls1intum/Apollon>
+- **Live editor:** <https://apollon.aet.cit.tum.de>
+- The standalone web editor, collaboration server, and [VS Code extension](https://marketplace.visualstudio.com/items?itemName=tumaet.apollon-vscode) live in the same monorepo.
 
 ## License
 

--- a/library/README.md
+++ b/library/README.md
@@ -7,7 +7,7 @@
 [![license](https://img.shields.io/npm/l/@tumaet/apollon)](https://github.com/ls1intum/Apollon/blob/main/LICENSE)
 [![types included](https://img.shields.io/npm/types/@tumaet/apollon)](https://www.npmjs.com/package/@tumaet/apollon)
 
-**Embeddable UML modeling editor for the web.** Mounts into any DOM node — works inside Angular, Vue, Svelte, vanilla JS, or React hosts.
+**Embeddable UML modeling editor for the web.** Mounts into any DOM node and works inside Angular, Vue, Svelte, vanilla JS, or React.
 
 [**▶ Live demo**](https://apollon.aet.cit.tum.de) · [Docs](https://ls1intum.github.io/Apollon/library/) · [API reference](https://ls1intum.github.io/Apollon/library/api) · [Examples](https://ls1intum.github.io/Apollon/library/embedding/react) · [GitHub](https://github.com/ls1intum/Apollon)
 
@@ -15,29 +15,29 @@
 
 ---
 
-Apollon is the modeling editor behind [Artemis](https://artemis.tum.de/), TUM's interactive learning platform. Its public API is **imperative** — `new ApollonEditor(container, options)` — so your host code never has to touch React, even though the editor mounts its own React tree inside the node you give it. React hosts get a first-class [`<Apollon>` component](#react) instead.
+Apollon is the modeling editor behind [Artemis](https://artemis.tum.de/), TUM's interactive learning platform. The API is imperative: you call `new ApollonEditor(container, options)` and the editor renders its own React tree inside that node, so your own code never touches React. In a React app, render the [`<Apollon>` component](#react) instead.
 
 ## Features
 
-- **13 diagram types** — class, object, activity, use case, communication, component, deployment, Petri net, reachability graph, syntax tree, flowchart, BPMN, and SFC.
-- **Framework-agnostic** — one imperative API for Angular, Vue, Svelte, and vanilla JS; a dedicated React component, hooks, and provider for React.
-- **Real-time collaboration** — opt-in, transport-agnostic multi-user editing powered by [Yjs](https://yjs.dev/). Bring any WebSocket/WebRTC/BroadcastChannel transport.
-- **Export** — SVG and JSON out of the box; PNG/PDF derive from the SVG pipeline (reference implementations ship in the repo).
-- **Assessment mode** — attach scores and feedback to elements (the grading workflow used by Artemis).
-- **TypeScript-first** — full type definitions ship with the package.
+- **13 diagram types**: class, object, activity, use case, communication, component, deployment, Petri net, reachability graph, syntax tree, flowchart, BPMN, and SFC.
+- **Framework-agnostic**: one imperative API for Angular, Vue, Svelte, and vanilla JS, plus a React component, hooks, and provider.
+- **Real-time collaboration**: opt-in multi-user editing over [Yjs](https://yjs.dev/), with any transport you like (WebSocket, WebRTC, BroadcastChannel).
+- **Export**: SVG and JSON are built in. Generate PNG and PDF from the SVG (see [Export](#export)).
+- **Assessment mode**: attach scores and feedback to elements. This is the grading workflow Artemis uses.
+- **TypeScript**: type definitions are included.
 
 ## Install
 
-The package ships **two builds with an identical API.** Pick by whether your host already uses React:
+The package ships two builds with the same API. Pick one based on whether your host already uses React:
 
-| Import                        | React / MUI / emotion / xyflow | Size (min / gzip) | Use when                                                                                                           |
-| ----------------------------- | ------------------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `@tumaet/apollon` _(default)_ | **bundled**                    | ~2.4 MB / ~540 KB | Your host is Angular, Vue, Svelte, vanilla JS — anything without React. Zero peer deps to install.                 |
-| `@tumaet/apollon/react`       | **peer deps** (shared)         | ~875 KB / ~170 KB | Your host is React 18.3 and should share its React/MUI instance with the editor instead of bundling a second copy. |
+| Import                        | React / MUI / emotion / xyflow | Size (min / gzip) | Use when                                                                                                |
+| ----------------------------- | ------------------------------ | ----------------- | ------------------------------------------------------------------------------------------------------- |
+| `@tumaet/apollon` _(default)_ | **bundled**                    | ~2.4 MB / ~540 KB | Your host is Angular, Vue, Svelte, or vanilla JS. No peer deps to install.                              |
+| `@tumaet/apollon/react`       | **peer deps** (shared)         | ~875 KB / ~170 KB | Your host is React 18.3 and should share its React and MUI with the editor instead of duplicating them. |
 
-Sizes are the published entry chunks; gzip is what ships over the wire. The `/react` figure excludes the peers your app already has.
+Sizes are the published entry chunks. Gzip is the transfer size. The `/react` number excludes the peers your app already ships.
 
-### Standalone build — any framework, no peer deps
+### Standalone build (any framework, no peer deps)
 
 ```sh
 npm install @tumaet/apollon
@@ -48,9 +48,9 @@ import { ApollonEditor } from "@tumaet/apollon"
 import "@tumaet/apollon/style.css"
 ```
 
-React, MUI, emotion, and xyflow are bundled inside the library — nothing else to install.
+React, MUI, emotion, and xyflow are bundled in. Nothing else to install.
 
-### React build — share your host's React
+### React build (share your host's React)
 
 ```sh
 npm install @tumaet/apollon \
@@ -71,12 +71,12 @@ import "@tumaet/apollon/style.css"
 
 ## Which build do I use?
 
-This is the one decision to get right up front:
+It comes down to whether your host already runs React:
 
-- **Not a React app?** Use the default `@tumaet/apollon`. It bundles its own React, so there is nothing to install and nothing to configure.
-- **A React app?** Use `@tumaet/apollon/react` and install the peers above. The default build would ship a **second copy of React** that fights your host's — causing "Invalid hook call" errors and a bloated bundle. The `/react` subpath externalizes React, MUI, emotion, and xyflow so the editor shares the single instance your app already has, and it is the **only** entry that exports the `<Apollon>` component, hooks, and provider.
+- **Not a React app?** Use the default `@tumaet/apollon`. It bundles its own React, so there is nothing extra to install or configure.
+- **A React app?** Use `@tumaet/apollon/react` and install the peers above. The default build bundles its own React, so in a React app you would load two copies. That causes "Invalid hook call" errors and a larger bundle. The `/react` subpath leaves React, MUI, emotion, and xyflow external so the editor shares the copies your app already has. It is also the only entry that exports the `<Apollon>` component, hooks, and provider.
 
-> **⚠️ The container must have an explicit, non-zero height** (`600px`, `80vh`, or a sized flex/grid child) — whichever build you choose. The canvas sizes itself to its parent; without a resolvable height it collapses to zero pixels and renders blank. This is the single most common embedding mistake. See [Troubleshooting](https://ls1intum.github.io/Apollon/library/troubleshooting).
+> **⚠️ Give the container an explicit, non-zero height** (`600px`, `80vh`, or a sized flex/grid child), whichever build you use. The canvas sizes itself to its parent, so with no resolvable height it collapses to zero pixels and renders blank. This is the most common embedding mistake. See [Troubleshooting](https://ls1intum.github.io/Apollon/library/troubleshooting).
 
 ## Quick start
 
@@ -101,13 +101,13 @@ editor.unsubscribe(subscriptionId)
 editor.destroy()
 ```
 
-The editor is **client-only**. In SSR frameworks (Next.js, Remix, SvelteKit, Nuxt), construct it from a client-side effect — never during render. Always call `editor.destroy()` before re-mounting on the same container.
+The editor is client-only. In SSR frameworks (Next.js, Remix, SvelteKit, Nuxt), construct it from a client-side effect, never during render. Always call `editor.destroy()` before re-mounting on the same container.
 
 ## Embedding examples
 
 ### React
 
-Use the `<Apollon>` component from the `@tumaet/apollon/react` subpath — it owns the editor's lifecycle (constructs on mount, destroys on unmount):
+Render the `<Apollon>` component from the `@tumaet/apollon/react` subpath. It owns the editor's lifecycle: it constructs on mount and destroys on unmount.
 
 ```tsx
 import { Apollon } from "@tumaet/apollon/react"
@@ -130,7 +130,7 @@ export function DiagramEditor({ initialModel }: { initialModel?: UMLModel }) {
 }
 ```
 
-Reach the instance via `ref`, the `onMount(editor)` callback, or the `useApollonEditor()` hook. See the [React embedding guide](https://ls1intum.github.io/Apollon/library/embedding/react) for hooks, the provider, and SSR.
+Reach the instance through `ref`, the `onMount(editor)` callback, or the `useApollonEditor()` hook. See the [React embedding guide](https://ls1intum.github.io/Apollon/library/embedding/react) for hooks, the provider, and SSR.
 
 ### Angular (17.3+ signal-based)
 
@@ -173,7 +173,7 @@ export class DiagramEditorComponent {
 }
 ```
 
-`afterNextRender` runs only in the browser, so this is SSR-safe by construction.
+`afterNextRender` runs only in the browser, so this is SSR-safe.
 
 ### Vanilla JS / CDN
 
@@ -199,11 +199,11 @@ export class DiagramEditorComponent {
 
 ## Supported diagrams
 
-Class, Object, Activity, Use Case, Communication, Component, Deployment, Petri Net, Reachability Graph, Syntax Tree, Flowchart, BPMN, SFC. The `UMLDiagramType` enum carries the exact wire literals.
+Class, Object, Activity, Use Case, Communication, Component, Deployment, Petri Net, Reachability Graph, Syntax Tree, Flowchart, BPMN, SFC. The `UMLDiagramType` enum holds the exact string values.
 
 ## Real-time collaboration
 
-Opt-in and transport-agnostic. Set `collaborationEnabled: true`, then wire your transport:
+Collaboration is opt-in and transport-agnostic. Set `collaborationEnabled: true`, then wire up your transport:
 
 ```ts
 const editor = new ApollonEditor(container, { collaborationEnabled: true })
@@ -215,31 +215,31 @@ editor.sendBroadcastMessage((base64) => transport.send(base64))
 transport.onMessage((base64) => editor.receiveBroadcastedMessage(base64))
 ```
 
-Any Yjs-compatible transport works — `y-websocket`, `y-webrtc`, BroadcastChannel, or your own relay. Cursor/selection awareness rides the same channel automatically. See [Collaboration](https://ls1intum.github.io/Apollon/library/api/collaboration).
+Any Yjs-compatible transport works: `y-websocket`, `y-webrtc`, BroadcastChannel, or your own relay. Cursor and selection awareness travel on the same channel. See [Collaboration](https://ls1intum.github.io/Apollon/library/api/collaboration).
 
 ## Export
 
-- **SVG** — `await editor.exportAsSVG(options)` resolves to `{ svg, clip }`. `svgMode: "web"` (default) keeps CSS variables for theme-adaptive output; `"compat"` inlines them for PDF/Inkscape.
-- **JSON** — `editor.model` returns the `UMLModel`; assignment is round-trip safe. Use `importDiagram(json)` to normalize older v2/v3 models.
-- **Headless** — `ApollonEditor.exportModelAsSvg(model, options)` renders an arbitrary model with no mounted editor.
-- **PNG / PDF** — produced downstream from the exported SVG. The repo's standalone app and server show reference implementations (`@resvg/resvg-js` for PNG, `pdfmake` for PDF).
+- **SVG**: `await editor.exportAsSVG(options)` resolves to `{ svg, clip }`. `svgMode: "web"` (the default) keeps CSS variables for theme-adaptive output; `"compat"` inlines them for PDF and Inkscape.
+- **JSON**: `editor.model` returns the `UMLModel`, and assigning it back is round-trip safe. Use `importDiagram(json)` to normalize older v2/v3 models first.
+- **Headless**: `ApollonEditor.exportModelAsSvg(model, options)` renders a model without a mounted editor.
+- **PNG / PDF**: not built in. Generate them from the exported SVG. The standalone webapp and server in this repo do this with `@resvg/resvg-js` (PNG) and `pdfmake` (PDF).
 
 See [Export](https://ls1intum.github.io/Apollon/library/api/export) for the full `ExportOptions`.
 
 ## Documentation
 
-- [Library overview](https://ls1intum.github.io/Apollon/library/) — install, quickstart, embedding
-- [API reference](https://ls1intum.github.io/Apollon/library/api) — the complete `ApollonEditor` and `<Apollon>` surface
-- [Troubleshooting](https://ls1intum.github.io/Apollon/library/troubleshooting) — blank canvas, SSR, duplicate React, and other embedding gotchas
+- [Library overview](https://ls1intum.github.io/Apollon/library/): install, quickstart, embedding
+- [API reference](https://ls1intum.github.io/Apollon/library/api): the full `ApollonEditor` and `<Apollon>` surface
+- [Troubleshooting](https://ls1intum.github.io/Apollon/library/troubleshooting): blank canvas, SSR, duplicate React, and other gotchas
 
-The server-side wire protocol lives behind the **unstable** `@tumaet/apollon/internals` subpath, which is explicitly **not** covered by SemVer.
+The server-side wire protocol is exposed through the `@tumaet/apollon/internals` subpath. It is unstable and not covered by SemVer.
 
 ## Related
 
-- **Source & issues:** <https://github.com/ls1intum/Apollon>
-- **Live editor:** <https://apollon.aet.cit.tum.de>
+- Source and issues: <https://github.com/ls1intum/Apollon>
+- Live editor: <https://apollon.aet.cit.tum.de>
 - The standalone web editor, collaboration server, and [VS Code extension](https://marketplace.visualstudio.com/items?itemName=tumaet.apollon-vscode) live in the same monorepo.
 
 ## License
 
-MIT — see [LICENSE](https://github.com/ls1intum/Apollon/blob/main/LICENSE).
+MIT. See [LICENSE](https://github.com/ls1intum/Apollon/blob/main/LICENSE).

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "format:check": "prettier --ignore-path .prettierignore --check \"**/*.+(js|mjs|cjs|ts|tsx|json|md|mdx|yml|yaml)\"",
     "test": "pnpm --filter @tumaet/apollon run test",
     "test:e2e": "pnpm --filter @tumaet/webapp run test:e2e",
+    "sync:version": "node scripts/sync-library-version.mjs",
+    "sync:version:check": "node scripts/sync-library-version.mjs --check",
     "prepare": "husky || true",
     "capacitor:add:android": "pnpm --filter @tumaet/webapp run capacitor:add:android",
     "capacitor:add:ios": "pnpm --filter @tumaet/webapp run capacitor:add:ios",

--- a/scripts/sync-library-version.mjs
+++ b/scripts/sync-library-version.mjs
@@ -1,0 +1,89 @@
+// @ts-check
+// Rewrites the pinned `@tumaet/apollon@X.Y.Z` esm.sh URLs in the README and
+// docs to match library/package.json. They must name an exact version (an
+// unpinned URL resolves to `latest` and breaks consumers' embeds), and no
+// bundler rewrites them, so the version-bump workflow runs this writer and PR
+// Health Checks run `--check` to block any drift from merging.
+//
+//   node scripts/sync-library-version.mjs           # rewrite to current version
+//   node scripts/sync-library-version.mjs --check    # exit 1 if anything drifts
+
+import { readFileSync, writeFileSync, readdirSync } from "node:fs"
+import { join, relative, extname } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url))
+
+const { version } = JSON.parse(
+  readFileSync(join(repoRoot, "library", "package.json"), "utf8")
+)
+
+const PIN_RE = /(@tumaet\/apollon@)(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)/g
+
+const SCANNED_EXTENSIONS = new Set([".md", ".mdx", ".ts", ".tsx", ".html"])
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  ".git",
+  ".context",
+  ".claude",
+  ".tmp",
+])
+
+/** @param {string} dir @returns {string[]} */
+function collectFiles(dir) {
+  /** @type {string[]} */
+  const files = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue
+      files.push(...collectFiles(join(dir, entry.name)))
+    } else if (SCANNED_EXTENSIONS.has(extname(entry.name))) {
+      files.push(join(dir, entry.name))
+    }
+  }
+  return files
+}
+
+const checkOnly = process.argv.includes("--check")
+
+/** @type {string[]} */
+const drifted = []
+/** @type {string[]} */
+const updated = []
+
+for (const file of collectFiles(repoRoot)) {
+  const original = readFileSync(file, "utf8")
+  if (!original.includes("@tumaet/apollon@")) continue
+
+  const next = original.replace(PIN_RE, `$1${version}`)
+  if (next === original) continue
+
+  const rel = relative(repoRoot, file)
+  if (checkOnly) {
+    drifted.push(rel)
+  } else {
+    writeFileSync(file, next)
+    updated.push(rel)
+  }
+}
+
+if (checkOnly) {
+  if (drifted.length > 0) {
+    console.error(
+      `\n✗ ${drifted.length} file(s) reference a @tumaet/apollon CDN version other than ${version}:\n` +
+        drifted.map((f) => `  - ${f}`).join("\n") +
+        `\n\nRun \`pnpm sync:version\` to fix.\n`
+    )
+    process.exit(1)
+  }
+  console.log(`✓ All @tumaet/apollon CDN references match ${version}`)
+} else if (updated.length > 0) {
+  console.log(
+    `Synced ${updated.length} file(s) to @tumaet/apollon@${version}:\n` +
+      updated.map((f) => `  - ${f}`).join("\n")
+  )
+} else {
+  console.log(`Nothing to sync — already at ${version}`)
+}


### PR DESCRIPTION
## Summary

Two related changes to the published `@tumaet/apollon` package: a best-practice rewrite of the npm README, and tooling so the README/docs version references can never drift from the package version again.

### 1. `docs(library)` — README overhaul

Restructured `library/README.md` to match conventions from established editor libraries (React Flow, tldraw, Excalidraw), validated against the source and Docusaurus docs:

- **Badge row + nav** — version, downloads, license, types badges; a **▶ Live demo** ([apollon.aet.cit.tum.de](https://apollon.aet.cit.tum.de), previously unlinked) + docs/API/examples nav.
- **"Which build do I use?"** — a dedicated section making the standalone-vs-`/react` choice unambiguous (the double-React pitfall, who exports `<Apollon>`).
- **Corrected two inaccuracies:**
  - PNG/PDF were described as native library exports. They aren't — the library emits **SVG and JSON**; PNG/PDF derive downstream from the SVG (`@resvg/resvg-js` / `pdfmake`, per `docs/library/api/export.md`).
  - Bundle sizes were unlabelled raw bytes. Now labelled **min / gzip** (measured from `dist/`: standalone ~2.4 MB / ~540 KB; `/react` ~875 KB / ~170 KB).
- Portable bold-blockquote callouts instead of GitHub-only `[!NOTE]` syntax (npm renders the latter as literal text).

### 2. `ci` — keep the pinned CDN version in sync

The README and docs embed pinned `@tumaet/apollon@X.Y.Z` esm.sh example URLs. Nothing rewrites them, so they silently went stale on every release. New `scripts/sync-library-version.mjs`:

- **Writer** (`pnpm sync:version`) — rewrites every `@tumaet/apollon@X.Y.Z` reference to `library/package.json`'s version, scanning the whole tree so new docs are covered automatically.
- **`--check`** (`pnpm sync:version:check`) — exits non-zero on drift.

Wired into both ends:
- `version-bump.yml` runs the writer and commits the result, so a library bump ships matching examples **automatically** (no-op for the standalone/vscode scopes).
- `pr-health-checks.yml` runs `--check` in the merge gate, so **no out-of-sync version can land** — from a bump or a manual doc edit.

Prose "pin a version" notes were reworded to drop their hardcoded literal, leaving the esm.sh URLs as the single source the script syncs.

## Test plan

- [x] `pnpm sync:version:check` passes at the current version (`4.4.0`)
- [x] Round-tripped a simulated bump (`4.4.0` → `9.9.9` → `4.4.0`): writer updated all 7 references across 3 files, `--check` passed at each version, no stray version left behind
- [x] `prettier --check` clean on all changed files
- [x] README links validated (live demo HTTP 200; docs/npm/marketplace URLs from the Docusaurus config)
- [ ] CI green (lint/build/tests + new `version-sync-check` gate job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)