### PR TITLE
fix(ci): drop duplicate ghcr.io prefix from image names

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -62,14 +62,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # image must be bare (no registry prefix) — the reusable workflow below prepends it.
         include:
           - name: Webapp
             dockerfile: ./standalone/webapp/Dockerfile
-            image: ghcr.io/ls1intum/apollon/webapp
+            image: ls1intum/apollon/webapp
             context: .
           - name: Server
             dockerfile: ./standalone/server/Dockerfile
-            image: ghcr.io/ls1intum/apollon/server
+            image: ls1intum/apollon/server
             context: .
     uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@c8ede985ff7999c28d7538cb32ae52bfb83f51b9 # main
     with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -51,7 +51,7 @@ jobs:
     with:
       environment: Production
       docker-compose-file: "./docker/compose.db.yml"
-      main-image-name: ghcr.io/ls1intum/apollon/server
+      main-image-name: ls1intum/apollon/server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/db"
     secrets: inherit
@@ -62,7 +62,7 @@ jobs:
     with:
       environment: Production
       docker-compose-file: "./docker/compose.proxy.yml"
-      main-image-name: ghcr.io/ls1intum/apollon/server
+      main-image-name: ls1intum/apollon/server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/proxy"
     secrets: inherit
@@ -73,7 +73,7 @@ jobs:
     with:
       environment: Production
       docker-compose-file: "./docker/compose.app.yml"
-      main-image-name: ghcr.io/ls1intum/apollon/server
+      main-image-name: ls1intum/apollon/server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/app"
     secrets: inherit

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -51,7 +51,7 @@ jobs:
     with:
       environment: Staging
       docker-compose-file: "./docker/compose.db.yml"
-      main-image-name: ghcr.io/ls1intum/apollon/server
+      main-image-name: ls1intum/apollon/server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/db"
     secrets: inherit
@@ -62,7 +62,7 @@ jobs:
     with:
       environment: Staging
       docker-compose-file: "./docker/compose.proxy.yml"
-      main-image-name: ghcr.io/ls1intum/apollon/server
+      main-image-name: ls1intum/apollon/server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/proxy"
     secrets: inherit
@@ -73,7 +73,7 @@ jobs:
     with:
       environment: Staging
       docker-compose-file: "./docker/compose.app.yml"
-      main-image-name: ghcr.io/ls1intum/apollon/server
+      main-image-name: ls1intum/apollon/server
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/apollon/app"
     secrets: inherit


### PR DESCRIPTION
## Problem

Two CI failures on `main` traced to the same root cause:

1. **[Deploy to Staging / prepare-deploy](https://github.com/ls1intum/Apollon/actions/runs/26742841670/job/78812263573)** — `Check if image exists` exited non-zero (image not found).
2. **[Build and Push Docker Image](https://github.com/ls1intum/Apollon/actions/runs/26748718778)** — builds producing a malformed image ref.

The build log is the smoking gun — the image ref is **doubled**:

```
--tag ghcr.io/ghcr.io/ls1intum/apollon/server
```

## Root cause

Both reusable workflows (pinned at `ls1intum/.github@c8ede985`) prepend the registry to the image name themselves:

- `build-and-push-docker-image.yml`: `images: ${{ inputs.registry }}/${{ inputs.image-name }}` (registry defaults to `ghcr.io`)
- `deploy-docker-compose.yml`: `https://ghcr.io/v2/${{ inputs.main-image-name }}/manifests/...`

We were passing `ghcr.io/ls1intum/apollon/{webapp,server}` *with* the prefix, producing `ghcr.io/ghcr.io/ls1intum/apollon/...`. So builds emitted an invalid ref, and the staging deploy's existence check probed a malformed GHCR v2 path → 404.

## Fix

Strip the `ghcr.io/` prefix from:
- `image-name` in `build-and-push.yml`
- `main-image-name` in `deploy-staging.yml` and `deploy-prod.yml`

`docker/compose.app.yml` and `release-standalone.yml` keep the fully-qualified `ghcr.io/...` names — they feed `docker pull` / `docker buildx imagetools` / `cosign` directly and were already correct (and will now resolve, since the build pushes to the right place).

## Verification

- All three workflow files pass `yaml.safe_load`.
- Tag formats verified to line up end-to-end: build passes `tags: "type=sha,format=long"` → `sha-<40hex>`; both `deploy-staging` (`image-tag: sha-${{ github.sha }}`) and `release-standalone` (`$IMAGE:sha-$COMMIT_SHA`) consume exactly that.
- **Caveat:** this PR's CI exercises the *build* push (confirm the build log now shows a single-prefix `--tag ghcr.io/ls1intum/apollon/...`). The `deploy-staging` existence-check only runs on push-to-main, so it is validated post-merge — confirm `Check if image exists` returns HTTP 200.

## Scope (deliberate)

- The true root cause — non-idempotent `${registry}/${image-name}` concat — lives in `ls1intum/.github`, another repo. Out of scope here, and arguably it *should* reject registry-qualified names rather than silently accept both forms.
- Did not add an explicit `registry: ghcr.io` input at the call sites: it is redundant with the reusable workflow's default and isn't passed anywhere else, so it would add surface, not safety. The ref is SHA-pinned, so the default can't drift unexpectedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)