### PR TITLE
ci(release): automate versioning with a Changesets Version Packages PR

### DIFF
--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -131,7 +131,7 @@ jobs:
           # plus an install footer. Fall back to GitHub's --generate-notes only
           # when there is no changelog section for this version (e.g. a release
           # that carried no changeset).
-          CHANGELOG=$(node scripts/extract-changelog.mjs library "$VERSION" || true)
+          CHANGELOG=$(node scripts/extract-changelog.mjs "$VERSION" library || true)
           {
             if [ -n "$CHANGELOG" ]; then printf '%s\n\n' "$CHANGELOG"; fi
             cat <<EOF

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -124,17 +124,34 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.check.outputs.version }}
         run: |
+          set -euo pipefail
           TAG="@tumaet/apollon@${VERSION}"
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --target "$GITHUB_SHA" \
-            --verify-tag \
-            --latest=false \
-            --generate-notes \
-            --notes "Install:
+
+          # Body = the Changesets-owned CHANGELOG section (curated per-PR voice)
+          # plus an install footer. Fall back to GitHub's --generate-notes only
+          # when there is no changelog section for this version (e.g. a release
+          # that carried no changeset).
+          CHANGELOG=$(node scripts/extract-changelog.mjs library "$VERSION" || true)
+          {
+            if [ -n "$CHANGELOG" ]; then printf '%s\n\n' "$CHANGELOG"; fi
+            cat <<EOF
+          Install:
 
           \`\`\`sh
           npm install @tumaet/apollon@${VERSION}
           \`\`\`
 
-          Published to npm with [provenance](https://docs.npmjs.com/generating-provenance-statements) via OIDC trusted publishing: [\`@tumaet/apollon@${VERSION}\`](https://www.npmjs.com/package/@tumaet/apollon/v/${VERSION})."
+          Published to npm with [provenance](https://docs.npmjs.com/generating-provenance-statements) via OIDC trusted publishing: [\`@tumaet/apollon@${VERSION}\`](https://www.npmjs.com/package/@tumaet/apollon/v/${VERSION}).
+          EOF
+          } > release-notes.md
+
+          GENERATE=()
+          [ -z "$CHANGELOG" ] && GENERATE=(--generate-notes)
+
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --target "$GITHUB_SHA" \
+            --verify-tag \
+            --latest=false \
+            "${GENERATE[@]}" \
+            --notes-file release-notes.md

--- a/.github/workflows/release-standalone.yml
+++ b/.github/workflows/release-standalone.yml
@@ -65,6 +65,12 @@ jobs:
         with:
           ref: ${{ needs.check.outputs.sha }}
 
+      # Pin Node for the changelog-extraction step in "Create GitHub Release"
+      # rather than relying on the runner's ambient version.
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: ".nvmrc"
+
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io

--- a/.github/workflows/release-standalone.yml
+++ b/.github/workflows/release-standalone.yml
@@ -115,13 +115,17 @@ jobs:
           VERSION: ${{ needs.check.outputs.version }}
           COMMIT_SHA: ${{ needs.check.outputs.sha }}
         run: |
-          gh release create "v${VERSION}" \
-            --title "v${VERSION}" \
-            --target "$COMMIT_SHA" \
-            --verify-tag \
-            --latest \
-            --generate-notes \
-            --notes "## Docker images
+          set -euo pipefail
+
+          # Body = the Changesets-owned CHANGELOG section (the webapp + server
+          # are paired, so they share one entry) plus the Docker + cosign
+          # footer. Fall back to GitHub's --generate-notes only when there is no
+          # changelog section for this version.
+          CHANGELOG=$(node scripts/extract-changelog.mjs standalone/webapp "$VERSION" || true)
+          {
+            if [ -n "$CHANGELOG" ]; then printf '%s\n\n' "$CHANGELOG"; fi
+            cat <<EOF
+          ## Docker images
 
           - \`ghcr.io/ls1intum/apollon/webapp:${VERSION}\`
           - \`ghcr.io/ls1intum/apollon/server:${VERSION}\`
@@ -132,4 +136,17 @@ jobs:
           cosign verify ghcr.io/ls1intum/apollon/webapp:${VERSION} \\
             --certificate-identity-regexp='^https://github\\.com/ls1intum/Apollon/\\.github/workflows/release-standalone\\.yml@refs/heads/main\$' \\
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com
-          \`\`\`"
+          \`\`\`
+          EOF
+          } > release-notes.md
+
+          GENERATE=()
+          [ -z "$CHANGELOG" ] && GENERATE=(--generate-notes)
+
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --target "$COMMIT_SHA" \
+            --verify-tag \
+            --latest \
+            "${GENERATE[@]}" \
+            --notes-file release-notes.md

--- a/.github/workflows/release-standalone.yml
+++ b/.github/workflows/release-standalone.yml
@@ -123,11 +123,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Body = the Changesets-owned CHANGELOG section (the webapp + server
-          # are paired, so they share one entry) plus the Docker + cosign
-          # footer. Fall back to GitHub's --generate-notes only when there is no
-          # changelog section for this version.
-          CHANGELOG=$(node scripts/extract-changelog.mjs standalone/webapp "$VERSION" || true)
+          # Body = the Changesets-owned CHANGELOG sections for the paired webapp
+          # + server, merged (a server-only changeset lands only in the server
+          # file; dupes from a library cascade collapse to one), plus the Docker
+          # + cosign footer. Fall back to GitHub's --generate-notes only when
+          # neither package has a section for this version.
+          CHANGELOG=$(node scripts/extract-changelog.mjs "$VERSION" standalone/webapp standalone/server || true)
           {
             if [ -n "$CHANGELOG" ]; then printf '%s\n\n' "$CHANGELOG"; fi
             cat <<EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+# Canonical Changesets pipeline. On every push to main this opens (or updates)
+# a "Version Packages" PR that runs `changeset version` — consuming the
+# .changeset/*.md files, bumping @tumaet/apollon and the paired
+# @tumaet/webapp + @tumaet/server from the bump types declared in those files
+# (the library bump cascades a patch to the standalone packages via their
+# workspace:* dependency, per .changeset/config.json#updateInternalDependencies),
+# and regenerating every CHANGELOG.md. Merging that PR is the single manual
+# release step: the version bumps it lands then trigger the existing
+# release-library.yml / release-standalone.yml publish jobs.
+#
+# Version-only mode: there is no `publish` input, so this workflow never
+# publishes. The bespoke release-*.yml workflows own publishing (npm OIDC +
+# provenance, GHCR retag + cosign). The VS Code extension is excluded in
+# .changeset/config.json#ignore and keeps its own manual Version Bump dispatch.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  version:
+    name: Version Packages PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write # commit the version bump to the PR branch
+      pull-requests: write # open / update the Version Packages PR
+    steps:
+      # Optional GitHub App token. When the RELEASE_BOT_APP_ID repository
+      # variable is set, the Version Packages PR is opened by the app so its
+      # push events trigger the normal PR checks (lint, build, e2e). Without it
+      # the PR is opened with GITHUB_TOKEN, which by design does not trigger
+      # other workflows — the PR then carries no CI, acceptable for a
+      # version-and-changelog-only change. See npm-publishing.md for setup.
+      - name: Generate GitHub App token
+        id: app-token
+        if: ${{ vars.RELEASE_BOT_APP_ID != '' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6.0.8
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Create or update the Version Packages PR
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        with:
+          # changeset:version also syncs the pinned CDN URLs and regenerates the
+          # lockfile so the PR is mergeable as-is. No `publish` input — see header.
+          version: pnpm run changeset:version
+          title: "chore: version packages"
+          commit: "chore: version packages"
+          setupGitUser: true
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,14 @@
 name: Release
 
-# Canonical Changesets pipeline. On every push to main this opens (or updates)
-# a "Version Packages" PR that runs `changeset version` — consuming the
-# .changeset/*.md files, bumping @tumaet/apollon and the paired
-# @tumaet/webapp + @tumaet/server from the bump types declared in those files
-# (the library bump cascades a patch to the standalone packages via their
-# workspace:* dependency, per .changeset/config.json#updateInternalDependencies),
-# and regenerating every CHANGELOG.md. Merging that PR is the single manual
-# release step: the version bumps it lands then trigger the existing
+# Opens or updates the "Version Packages" PR on every push to main, via
+# changesets/action in version-only mode (no `publish` input): this never
+# publishes or tags — merging the PR bumps versions, which triggers the bespoke
 # release-library.yml / release-standalone.yml publish jobs.
 #
-# Version-only mode: there is no `publish` input, so this workflow never
-# publishes. The bespoke release-*.yml workflows own publishing (npm OIDC +
-# provenance, GHCR retag + cosign). The VS Code extension is excluded in
-# .changeset/config.json#ignore and keeps its own manual Version Bump dispatch.
+# The PR is opened with GITHUB_TOKEN, so it carries no CI (token-created events
+# don't trigger workflows) — acceptable for a version-and-changelog-only change.
+# TODO: for pre-merge CI on the PR, open it with a GitHub App token (provision
+# and test the App in that change).
 
 on:
   push:
@@ -34,24 +29,9 @@ jobs:
       contents: write # commit the version bump to the PR branch
       pull-requests: write # open / update the Version Packages PR
     steps:
-      # Optional GitHub App token. When the RELEASE_BOT_APP_ID repository
-      # variable is set, the Version Packages PR is opened by the app so its
-      # push events trigger the normal PR checks (lint, build, e2e). Without it
-      # the PR is opened with GITHUB_TOKEN, which by design does not trigger
-      # other workflows — the PR then carries no CI, acceptable for a
-      # version-and-changelog-only change. See npm-publishing.md for setup.
-      - name: Generate GitHub App token
-        id: app-token
-        if: ${{ vars.RELEASE_BOT_APP_ID != '' }}
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6.0.8
@@ -66,11 +46,10 @@ jobs:
       - name: Create or update the Version Packages PR
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          # changeset:version also syncs the pinned CDN URLs and regenerates the
-          # lockfile so the PR is mergeable as-is. No `publish` input — see header.
+          # changeset:version is a custom script — it chains `changeset version`
+          # with the CDN-URL sync and a lockfile refresh so the PR merges as-is.
           version: pnpm run changeset:version
           title: "chore: version packages"
           commit: "chore: version packages"
-          setupGitUser: true
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,11 +1,9 @@
 name: Version Bump (VS Code extension)
 
-# Manual version bump for the VS Code extension only. The library and the
-# paired standalone webapp+server are versioned by Changesets — see release.yml,
-# which opens a "Version Packages" PR automatically from the per-PR changesets.
-# The extension is excluded from Changesets (.changeset/config.json#ignore: it
-# ships to the VS Marketplace + Open VSX on its own cadence), so it keeps this
-# manual dispatch. Merging the PR this opens triggers `Release VS Code Extension`.
+# Manual version bump for the VS Code extension only. The library + standalone
+# moved to Changesets (see release.yml); the extension is deliberately excluded
+# (.changeset/config.json#ignore — separate marketplace + cadence), so it keeps
+# this dispatch. Merging the PR this opens triggers `Release VS Code Extension`.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,16 +1,15 @@
-name: Version Bump
+name: Version Bump (VS Code extension)
+
+# Manual version bump for the VS Code extension only. The library and the
+# paired standalone webapp+server are versioned by Changesets — see release.yml,
+# which opens a "Version Packages" PR automatically from the per-PR changesets.
+# The extension is excluded from Changesets (.changeset/config.json#ignore: it
+# ships to the VS Marketplace + Open VSX on its own cadence), so it keeps this
+# manual dispatch. Merging the PR this opens triggers `Release VS Code Extension`.
 
 on:
   workflow_dispatch:
     inputs:
-      scope:
-        type: choice
-        description: Which track to bump
-        required: true
-        options:
-          - library
-          - standalone
-          - vscode-extension
       bump:
         type: choice
         description: Version bump type
@@ -46,169 +45,53 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "pnpm"
 
-      - name: Require changes in the scoped path since the last scoped tag
-        env:
-          SCOPE: ${{ inputs.scope }}
+      - name: Require changes in vscode-extension since the last tag
         run: |
           set -euo pipefail
           git fetch --tags --quiet
-          case "$SCOPE" in
-            library)
-              LAST=$(git tag --list '@tumaet/apollon@*' --sort=-v:refname | head -n1)
-              PATH_PATTERN=library/
-              ;;
-            standalone)
-              LAST=$(git tag --list 'v*' --sort=-v:refname | head -n1)
-              PATH_PATTERN=standalone/
-              ;;
-            vscode-extension)
-              LAST=$(git tag --list 'apollon-vscode@*' --sort=-v:refname | head -n1)
-              PATH_PATTERN=vscode-extension/
-              ;;
-          esac
-          if [ -n "$LAST" ] && git diff --quiet "$LAST"..HEAD -- "$PATH_PATTERN"; then
-            echo "::error::No changes under $PATH_PATTERN since $LAST. Refusing to cut an empty $SCOPE release."
+          LAST=$(git tag --list 'apollon-vscode@*' --sort=-v:refname | head -n1)
+          if [ -n "$LAST" ] && git diff --quiet "$LAST"..HEAD -- vscode-extension/; then
+            echo "::error::No changes under vscode-extension/ since $LAST. Refusing to cut an empty release."
             exit 1
           fi
 
-      - name: Align local versions with what's already published
-        env:
-          SCOPE: ${{ inputs.scope }}
-        run: |
-          set -euo pipefail
-          # If a long-lived branch was rebased before a release-bump
-          # commit landed on main, the merge can regress the local
-          # version below what's already published. Bumping from a
-          # stale local would then collide with an existing npm/Docker
-          # tag. Roll the local up to max(local, published) before the
-          # bump so the result is always strictly greater than what
-          # consumers can already pull.
-          align_to_max() {
-            pkg="$1"
-            published="$2"
-            local=$(jq -r '.version' "$pkg/package.json")
-            if [ -z "$published" ]; then
-              echo "$pkg: no published version found, keeping local=$local"
-              return
-            fi
-            higher=$(printf '%s\n%s\n' "$local" "$published" | sort -V | tail -n1)
-            if [ "$higher" != "$local" ]; then
-              echo "::warning::$pkg local=$local but registry has $published — aligning to $higher before bump"
-              jq --arg v "$higher" '.version = $v' "$pkg/package.json" > "$pkg/package.json.tmp"
-              mv "$pkg/package.json.tmp" "$pkg/package.json"
-            else
-              echo "$pkg: local=$local ≥ published=$published ✓"
-            fi
-          }
-
-          if [ "$SCOPE" = "library" ]; then
-            LIB_PUBLISHED=$(npm view @tumaet/apollon version 2>/dev/null || echo "")
-            align_to_max library "$LIB_PUBLISHED"
-          fi
-
-          # Standalone tracks GHCR tags, not npm. The release-standalone
-          # workflow tags Docker images `vX.Y.Z`; pull the highest one
-          # we've seen and align local against it.
-          if [ "$SCOPE" = "standalone" ] || [ "$SCOPE" = "library" ]; then
-            STANDALONE_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n1)
-            if [ -n "$STANDALONE_TAG" ]; then
-              align_to_max standalone/webapp "${STANDALONE_TAG#v}"
-              align_to_max standalone/server "${STANDALONE_TAG#v}"
-            fi
-          fi
-
-      - name: Bump versions
+      - name: Bump version
         id: bump
         env:
-          SCOPE: ${{ inputs.scope }}
           BUMP: ${{ inputs.bump }}
         run: |
           set -euo pipefail
-          bump_pkg() {
-            local pkg="$1"
-            BUMP="$BUMP" PKG="$pkg" node -e '
-              const fs = require("fs");
-              const pkgPath = process.env.PKG + "/package.json";
-              const data = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
-              const [maj, min, pat] = data.version.split(".").map(Number);
-              let next;
-              switch (process.env.BUMP) {
-                case "patch": next = [maj, min, pat + 1].join("."); break;
-                case "minor": next = [maj, min + 1, 0].join("."); break;
-                case "major": next = [maj + 1, 0, 0].join("."); break;
-                default: throw new Error("invalid bump: " + process.env.BUMP);
-              }
-              data.version = next;
-              fs.writeFileSync(pkgPath, JSON.stringify(data, null, 2) + "\n");
-              console.log(pkgPath + ": " + next);
-            '
-          }
-
-          # scope=library mirrors the bump to standalone too — a library
-          # release ships new code to standalone consumers via Docker.
-          LIB_VERSION=""
-          STANDALONE_VERSION=""
-          VSCODE_VERSION=""
-          case "$SCOPE" in
-            library)
-              bump_pkg library
-              LIB_VERSION=$(node -p "require('./library/package.json').version")
-              bump_pkg standalone/webapp
-              bump_pkg standalone/server
-              STANDALONE_VERSION=$(node -p "require('./standalone/webapp/package.json').version")
-              ;;
-            standalone)
-              bump_pkg standalone/webapp
-              bump_pkg standalone/server
-              STANDALONE_VERSION=$(node -p "require('./standalone/webapp/package.json').version")
-              ;;
-            vscode-extension)
-              bump_pkg vscode-extension
-              VSCODE_VERSION=$(node -p "require('./vscode-extension/package.json').version")
-              ;;
-          esac
-
-          echo "library_version=${LIB_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "standalone_version=${STANDALONE_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "vscode_version=${VSCODE_VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Sync pinned library version in README + docs
-        # No-op for the standalone/vscode scopes — library version unchanged.
-        run: node scripts/sync-library-version.mjs
+          BUMP="$BUMP" node -e '
+            const fs = require("fs");
+            const pkgPath = "vscode-extension/package.json";
+            const data = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+            const [maj, min, pat] = data.version.split(".").map(Number);
+            let next;
+            switch (process.env.BUMP) {
+              case "patch": next = [maj, min, pat + 1].join("."); break;
+              case "minor": next = [maj, min + 1, 0].join("."); break;
+              case "major": next = [maj + 1, 0, 0].join("."); break;
+              default: throw new Error("invalid bump: " + process.env.BUMP);
+            }
+            data.version = next;
+            fs.writeFileSync(pkgPath, JSON.stringify(data, null, 2) + "\n");
+            console.log(pkgPath + ": " + next);
+          '
+          VERSION=$(node -p "require('./vscode-extension/package.json').version")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Regenerate pnpm-lock.yaml
         run: pnpm install --lockfile-only --ignore-scripts
 
-      - name: Commit bump
-        id: commit
+      - name: Commit and open pull request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LIB_VERSION: ${{ steps.bump.outputs.library_version }}
-          STANDALONE_VERSION: ${{ steps.bump.outputs.standalone_version }}
-          VSCODE_VERSION: ${{ steps.bump.outputs.vscode_version }}
-          SCOPE: ${{ inputs.scope }}
+          VERSION: ${{ steps.bump.outputs.version }}
           BUMP: ${{ inputs.bump }}
         run: |
           set -euo pipefail
-          case "$SCOPE" in
-            library)
-              BRANCH="chore/library-v${LIB_VERSION}"
-              COMMIT_TITLE="chore: release @tumaet/apollon@${LIB_VERSION} + standalone v${STANDALONE_VERSION}"
-              FILES=(library/package.json standalone/webapp/package.json standalone/server/package.json pnpm-lock.yaml library/README.md docs/library/embedding/vanilla.md docs/src/pages/index.tsx)
-              ;;
-            standalone)
-              BRANCH="chore/standalone-v${STANDALONE_VERSION}"
-              COMMIT_TITLE="chore: release standalone v${STANDALONE_VERSION}"
-              FILES=(standalone/webapp/package.json standalone/server/package.json pnpm-lock.yaml)
-              ;;
-            vscode-extension)
-              BRANCH="chore/vscode-v${VSCODE_VERSION}"
-              COMMIT_TITLE="chore: release apollon-vscode@${VSCODE_VERSION}"
-              FILES=(vscode-extension/package.json pnpm-lock.yaml)
-              ;;
-          esac
-          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
-          echo "title=${COMMIT_TITLE}" >> "$GITHUB_OUTPUT"
+          BRANCH="chore/vscode-v${VERSION}"
+          TITLE="chore: release apollon-vscode@${VERSION}"
 
           # Refuse to overwrite a branch that already backs an open PR —
           # would otherwise force-push through reviewer-visible work.
@@ -220,38 +103,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add "${FILES[@]}"
-
-          git commit -m "${COMMIT_TITLE}" -m "Scope: ${SCOPE} ${BUMP}"
-
+          git add vscode-extension/package.json pnpm-lock.yaml
+          git commit -m "$TITLE" -m "Scope: vscode-extension ${BUMP}"
           git push --force-with-lease origin "$BRANCH"
-
-      - name: Open pull request
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SCOPE: ${{ inputs.scope }}
-          BUMP: ${{ inputs.bump }}
-          LIB_VERSION: ${{ steps.bump.outputs.library_version }}
-          STANDALONE_VERSION: ${{ steps.bump.outputs.standalone_version }}
-          VSCODE_VERSION: ${{ steps.bump.outputs.vscode_version }}
-          BRANCH: ${{ steps.commit.outputs.branch }}
-          TITLE: ${{ steps.commit.outputs.title }}
-        run: |
-          set -euo pipefail
-          case "$SCOPE" in
-            library)
-              BODY=$'**Scope:** `library` (`'"${BUMP}"$'`)\n\nMerging this PR publishes **both** artifacts automatically:\n\n- `@tumaet/apollon@'"${LIB_VERSION}"$'` to npm (via `Release Library`)\n- `v'"${STANDALONE_VERSION}"$'` — Docker images tagged `'"${STANDALONE_VERSION}"$'` (via `Release Standalone`, mirrored so the new library code ships as a Docker release)'
-              ;;
-            standalone)
-              BODY=$'**Scope:** `standalone` (`'"${BUMP}"$'`)\n\nMerging this PR cuts `v'"${STANDALONE_VERSION}"$'` automatically — `Release Standalone` retags Docker images as `'"${STANDALONE_VERSION}"$'` and creates the GitHub Release. The library is untouched.'
-              ;;
-            vscode-extension)
-              BODY=$'**Scope:** `vscode-extension` (`'"${BUMP}"$'`)\n\nMerging this PR publishes `tumaet.apollon-vscode@'"${VSCODE_VERSION}"$'` to the VS Marketplace and Open VSX automatically (via `Release VS Code Extension`). Tag prefix: `apollon-vscode@*`.'
-              ;;
-          esac
 
           gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "$TITLE" \
-            --body "$BODY"
+            --body $'**Scope:** `vscode-extension` (`'"${BUMP}"$'`)\n\nMerging this PR publishes `tumaet.apollon-vscode@'"${VERSION}"$'` to the VS Marketplace and Open VSX automatically (via `Release VS Code Extension`). Tag prefix: `apollon-vscode@*`.'

--- a/docs/contributor/deployment/npm-publishing.md
+++ b/docs/contributor/deployment/npm-publishing.md
@@ -46,16 +46,6 @@ cosign verify \
 
 ## One-time setup
 
-### Version Packages PR CI (recommended)
-
-By default the **Version Packages** PR is opened with `GITHUB_TOKEN`, which — by GitHub design — does **not** trigger other workflows, so that PR carries no lint/build/e2e checks. Acceptable for a version-and-changelog-only change, but to run the full PR checks on it, give `release.yml` a GitHub App token:
-
-- Create (or reuse) a GitHub App in the org with **Contents: write** and **Pull requests: write**, installed on this repo. Generate a private key.
-- Repository **variable** `RELEASE_BOT_APP_ID` = the App's ID (its presence is what switches `release.yml` to the app token).
-- Repository **secret** `RELEASE_BOT_PRIVATE_KEY` = the App's private key (PEM).
-
-Leave both unset to keep the `GITHUB_TOKEN` behaviour.
-
 ### npm (library)
 
 - npm trusted publisher on npmjs.com: `ls1intum/Apollon` → `.github/workflows/release-library.yml` → environment `npm-publish` (no `NPM_TOKEN` needed).

--- a/docs/contributor/deployment/npm-publishing.md
+++ b/docs/contributor/deployment/npm-publishing.md
@@ -16,18 +16,19 @@ Three independently versioned artifacts, each with its own release workflow:
 
 Standalone starts at `4.2.18` (the library version at the time of the release-pipeline switchover). Future `vX.Y.Z` tags advance from there and do not collide with legacy tags.
 
-All three workflows trigger automatically when their version changes on `main`. There is **one** manual step per release: merge the bump PR.
+The library and standalone tracks are versioned by [Changesets](https://github.com/changesets/changesets); the VS Code extension is bumped manually (it is excluded in `.changeset/config.json#ignore`). All three publish workflows trigger automatically when their version changes on `main`. There is **one** manual step per release: merge the version PR.
 
-The per-PR side of this is [Changesets](https://github.com/changesets/changesets): authors run `pnpm changeset` on every user-visible PR to record a changelog entry (see [Release notes](/contributor/development/release-notes)). Those entries are what the changelog automation will consume when it replaces the manual version bump.
+The per-PR side is Changesets: authors run `pnpm changeset` on every user-visible PR to record a changelog entry with its bump type (see [Release notes](/contributor/development/release-notes)). On every push to `main`, `release.yml` runs [`changesets/action`](https://github.com/changesets/action) in **version-only** mode (no `publish` input — the bespoke `release-*.yml` workflows own publishing) and opens or updates a single **Version Packages** PR. That PR runs `pnpm changeset:version`, which:
 
-The `library` bump also rewrites the pinned `@tumaet/apollon@X.Y.Z` CDN URLs in the README and docs (via `scripts/sync-library-version.mjs`) so the published examples never lag the package version. PR Health Checks run the same script with `--check`, so a drift can never merge — run `pnpm sync:version` locally to fix one.
+- consumes the accumulated `.changeset/*.md` files and bumps `@tumaet/apollon` and the paired `@tumaet/webapp` + `@tumaet/server` from the **declared** bump types — no human picks a bump;
+- cascades a **patch** to the standalone packages whenever the library bumps, because they depend on `@tumaet/apollon` via `workspace:*` (`updateInternalDependencies: patch`), so a library change still ships to npm **and** as a new Docker release from the same merge;
+- regenerates every `CHANGELOG.md`, rewrites the pinned `@tumaet/apollon@X.Y.Z` CDN URLs (via `scripts/sync-library-version.mjs`), and refreshes the lockfile.
+
+The GitHub Release body for each track is taken from that `CHANGELOG.md` section (via `scripts/extract-changelog.mjs`); it falls back to GitHub's auto-generated notes only when a version carried no changeset. PR Health Checks also run `sync-library-version.mjs --check`, so a CDN-URL drift can never merge — run `pnpm sync:version` locally to fix one.
 
 ## Cut a release
 
-1. Actions → **Version Bump** → pick `scope` and bump type. Merge the PR that opens.
-   - **`library`** bumps `library/package.json` **and** `standalone/{webapp,server}/package.json` by the same bump type, so a library change ships to npm **and** as a new Docker release from the same PR merge.
-   - **`standalone`** bumps only `standalone/{webapp,server}/package.json`; the library is untouched.
-   - **`vscode-extension`** bumps only `vscode-extension/package.json`; library and standalone are untouched.
+1. Let the **Version Packages** PR (titled `chore: version packages`, opened by `release.yml`) accumulate as changesets land, then **merge it** when you want to cut a release. The library and the paired standalone packages bump together; merging is the only manual step. _The VS Code extension is separate: Actions → **Version Bump (VS Code extension)** → pick a bump type, then merge the PR it opens._
 2. On merge:
    - `release-library.yml` fires when `library/package.json` changes: builds with pnpm, packs the tarball with `pnpm pack`, publishes with `npm publish` for OIDC trusted publishing + provenance (pnpm does not yet support OIDC trusted publishing natively — tracked in [pnpm#9812](https://github.com/pnpm/pnpm/issues/9812)). Tags `@tumaet/apollon@X.Y.Z` → GitHub Release. Skipped if the version is already on npm.
    - `release-standalone.yml` fires after the push-to-main Docker build succeeds: retag `sha-<commit>` → `X.Y.Z` → cosign-sign → tag `vX.Y.Z` → GitHub Release. Staging is already running the same digest under the `sha-<commit>` tag from the push-to-main deploy, so no second deploy is needed. Skipped if a release for that version already exists.
@@ -44,6 +45,16 @@ cosign verify \
 ```
 
 ## One-time setup
+
+### Version Packages PR CI (recommended)
+
+By default the **Version Packages** PR is opened with `GITHUB_TOKEN`, which — by GitHub design — does **not** trigger other workflows, so that PR carries no lint/build/e2e checks. Acceptable for a version-and-changelog-only change, but to run the full PR checks on it, give `release.yml` a GitHub App token:
+
+- Create (or reuse) a GitHub App in the org with **Contents: write** and **Pull requests: write**, installed on this repo. Generate a private key.
+- Repository **variable** `RELEASE_BOT_APP_ID` = the App's ID (its presence is what switches `release.yml` to the app token).
+- Repository **secret** `RELEASE_BOT_PRIVATE_KEY` = the App's private key (PEM).
+
+Leave both unset to keep the `GITHUB_TOKEN` behaviour.
 
 ### npm (library)
 

--- a/docs/contributor/development/release-notes.md
+++ b/docs/contributor/development/release-notes.md
@@ -11,7 +11,7 @@ User-facing release notes come from [Changesets](https://github.com/changesets/c
 Three release lines carry changesets: `@tumaet/apollon` on npm, and `@tumaet/webapp` + `@tumaet/server` as paired `ghcr.io` Docker images. The VS Code extension, the docs site, and the webview sub-packages are excluded in `.changeset/config.json#ignore` — they have their own (or no) release flow, and without the exclusion a routine library bump would version them too, since every package depends on `@tumaet/apollon` via `workspace:*`.
 
 :::note
-Changesets are the per-PR convention now; the pipeline that consumes them (`changeset version` → `CHANGELOG.md` → release) lands in a follow-up. Until then, write the changeset so the backlog is ready — and note that the existing `CHANGELOG.md` files are hand-maintained, since the tool does not yet regenerate them. See [Releases](/contributor/deployment/npm-publishing).
+The pipeline that consumes changesets is live: `release.yml` opens a **Version Packages** PR that runs `changeset version` → regenerates `CHANGELOG.md` → triggers the release on merge. Write the changeset and the rest is automatic — don't hand-edit `CHANGELOG.md`. See [Releases](/contributor/deployment/npm-publishing).
 :::
 
 ## When do you need one?
@@ -80,6 +80,6 @@ A change that spans the webapp and the library lands as two changesets in the sa
 
 ## CHANGELOG.md and the GitHub Release body
 
-`CHANGELOG.md` is the per-version bullet log Changesets writes; once the consuming pipeline lands it is tool-owned, not edited by hand. The **GitHub Release body** carries the human-curated lede and highlights (screenshots, video).
+`CHANGELOG.md` is the per-version bullet log Changesets writes — tool-owned, not edited by hand. The **GitHub Release body** is generated from that same `CHANGELOG.md` section (via `scripts/extract-changelog.mjs`) plus a per-track install/verify footer, so the Release reads in the voice you wrote. A maintainer can still edit the published Release afterward to add a lede, screenshots, or video.
 
 You write only the changeset body (the markdown after the frontmatter). At `changeset version` time, `@changesets/changelog-github` prepends the PR link, commit link, and `Thanks @author!` automatically. The backfilled v4.4.0 / v4.4.1 entries omit the commit-SHA link — those commits predate Changesets; new releases include it.

--- a/docs/contributor/development/scripts.md
+++ b/docs/contributor/development/scripts.md
@@ -119,8 +119,10 @@ Mobile shell scaffolding for the webapp. Run these once per platform; see
 ## Release and packaging
 
 Releases run on GitHub Actions — there are no local publish scripts. Cut a
-release by dispatching the **Version Bump** workflow and merging the PR it
-opens; see [npm publishing](/contributor/deployment/npm-publishing).
+library/standalone release by merging the **Version Packages** PR that
+`release.yml` opens from the accumulated changesets; the VS Code extension uses
+the **Version Bump (VS Code extension)** workflow. See
+[npm publishing](/contributor/deployment/npm-publishing).
 `pnpm package:vscode` builds a local `.vsix` for the VS Code extension.
 
 | Script           | Does                                           |

--- a/docs/contributor/overview.md
+++ b/docs/contributor/overview.md
@@ -31,7 +31,7 @@ pnpm dev
 - **[Troubleshooting](/contributor/troubleshooting)** — common local-setup and self-host issues
 - **[Release notes](/contributor/development/release-notes)** — when to add a changeset and how to write it
 - **[Release pipeline → GitHub Actions](/contributor/deployment/github-actions)** — required-status-checks setup
-- **[Release pipeline → npm publishing](/contributor/deployment/npm-publishing)** — `version-bump.yml` + per-artifact release workflows
+- **[Release pipeline → npm publishing](/contributor/deployment/npm-publishing)** — `release.yml` (Changesets Version Packages PR) + per-artifact release workflows
 
 ## Pull-request checklist
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "sync:version": "node scripts/sync-library-version.mjs",
     "sync:version:check": "node scripts/sync-library-version.mjs --check",
     "changeset": "changeset",
+    "changeset:version": "changeset version && node scripts/sync-library-version.mjs && pnpm install --lockfile-only --ignore-scripts",
     "prepare": "husky || true",
     "capacitor:add:android": "pnpm --filter @tumaet/webapp run capacitor:add:android",
     "capacitor:add:ios": "pnpm --filter @tumaet/webapp run capacitor:add:ios",

--- a/scripts/extract-changelog.mjs
+++ b/scripts/extract-changelog.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Extract the changelog section for a specific version from a package's
+// CHANGELOG.md. The release workflows use it to set the GitHub Release body
+// from the Changesets-owned changelog instead of GitHub's --generate-notes,
+// so the Release reads in the curated voice authors wrote per PR.
+//
+// Usage: node scripts/extract-changelog.mjs <package-dir> <version>
+//   e.g. node scripts/extract-changelog.mjs library 4.5.0
+//
+// Prints the section body (without the "## x.y.z" heading) to stdout. Prints
+// nothing and exits 0 when the file or the section is absent, so callers can
+// fall back to generated notes (e.g. a manual bump that carried no changeset).
+
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const [, , pkgDir, version] = process.argv
+if (!pkgDir || !version) {
+  console.error("usage: extract-changelog.mjs <package-dir> <version>")
+  process.exit(2)
+}
+
+let text
+try {
+  text = readFileSync(join(pkgDir, "CHANGELOG.md"), "utf8")
+} catch {
+  process.exit(0) // no changelog yet — caller falls back to generated notes
+}
+
+// Changesets writes one "## X.Y.Z" heading per release. Capture everything
+// from the matching heading up to the next "## " heading.
+const lines = text.split("\n")
+const start = lines.findIndex((line) => line.trim() === `## ${version}`)
+if (start === -1) process.exit(0)
+
+const rest = lines.slice(start + 1)
+const end = rest.findIndex((line) => /^## /.test(line))
+const body = (end === -1 ? rest : rest.slice(0, end)).join("\n").trim()
+
+process.stdout.write(body)

--- a/scripts/extract-changelog.mjs
+++ b/scripts/extract-changelog.mjs
@@ -1,39 +1,49 @@
 #!/usr/bin/env node
-// Extract one version's section from a package's CHANGELOG.md, for the release
-// workflows to use as the GitHub Release body instead of GitHub's
-// auto-generated notes. Prints the section to stdout; prints nothing and exits
-// 0 when the file or section is absent, so callers fall back to --generate-notes
-// (e.g. a release that carried no changeset).
+// Extract one version's section from one or more CHANGELOG.md files, for the
+// release workflows to use as the GitHub Release body instead of GitHub's
+// auto-generated notes. With several packages (the fixed webapp+server pair) it
+// merges the non-empty sections and drops exact duplicates — so a server-only
+// changeset still surfaces, and a library-cascade patch (identical in both)
+// shows once. Prints nothing and exits 0 when no package has a section, so
+// callers fall back to --generate-notes (e.g. a release with no changeset).
 
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
 
-const [, , pkgDir, version] = process.argv
-if (!pkgDir || !version) {
-  console.error("usage: extract-changelog.mjs <package-dir> <version>")
+const [, , version, ...pkgDirs] = process.argv
+if (!version || pkgDirs.length === 0) {
+  console.error("usage: extract-changelog.mjs <version> <package-dir>...")
   process.exit(2)
 }
 
-let text
-try {
-  text = readFileSync(join(pkgDir, "CHANGELOG.md"), "utf8")
-} catch {
-  process.exit(0) // no changelog yet — caller falls back to generated notes
+function sectionFor(pkgDir) {
+  let text
+  try {
+    text = readFileSync(join(pkgDir, "CHANGELOG.md"), "utf8")
+  } catch {
+    return "" // no changelog yet
+  }
+  // Changesets writes one "## X.Y.Z" heading per release. Capture from the
+  // matching heading to the next one — ignoring "## " lines inside fenced code
+  // blocks (backtick or tilde) so a changeset documenting markdown can't
+  // truncate the section.
+  const lines = text.replace(/\r\n/g, "\n").split("\n")
+  const start = lines.findIndex((line) => line.trim() === `## ${version}`)
+  if (start === -1) return ""
+  let inFence = false
+  const body = []
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s*(```|~~~)/.test(line)) inFence = !inFence
+    if (!inFence && /^## /.test(line)) break
+    body.push(line)
+  }
+  return body.join("\n").trim()
 }
 
-// Changesets writes one "## X.Y.Z" heading per release. Capture from the
-// matching heading to the next one — ignoring "## " lines inside fenced code
-// blocks so a changeset that documents markdown can't truncate the section.
-const lines = text.replace(/\r\n/g, "\n").split("\n")
-const start = lines.findIndex((line) => line.trim() === `## ${version}`)
-if (start === -1) process.exit(0)
-
-let inFence = false
-const body = []
-for (const line of lines.slice(start + 1)) {
-  if (/^\s*(```|~~~)/.test(line)) inFence = !inFence
-  if (!inFence && /^## /.test(line)) break
-  body.push(line)
+const sections = []
+for (const dir of pkgDirs) {
+  const section = sectionFor(dir)
+  if (section && !sections.includes(section)) sections.push(section)
 }
 
-process.stdout.write(body.join("\n").trim())
+process.stdout.write(sections.join("\n\n"))

--- a/scripts/extract-changelog.mjs
+++ b/scripts/extract-changelog.mjs
@@ -1,15 +1,9 @@
 #!/usr/bin/env node
-// Extract the changelog section for a specific version from a package's
-// CHANGELOG.md. The release workflows use it to set the GitHub Release body
-// from the Changesets-owned changelog instead of GitHub's --generate-notes,
-// so the Release reads in the curated voice authors wrote per PR.
-//
-// Usage: node scripts/extract-changelog.mjs <package-dir> <version>
-//   e.g. node scripts/extract-changelog.mjs library 4.5.0
-//
-// Prints the section body (without the "## x.y.z" heading) to stdout. Prints
-// nothing and exits 0 when the file or the section is absent, so callers can
-// fall back to generated notes (e.g. a manual bump that carried no changeset).
+// Extract one version's section from a package's CHANGELOG.md, for the release
+// workflows to use as the GitHub Release body instead of GitHub's
+// auto-generated notes. Prints the section to stdout; prints nothing and exits
+// 0 when the file or section is absent, so callers fall back to --generate-notes
+// (e.g. a release that carried no changeset).
 
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
@@ -27,14 +21,19 @@ try {
   process.exit(0) // no changelog yet — caller falls back to generated notes
 }
 
-// Changesets writes one "## X.Y.Z" heading per release. Capture everything
-// from the matching heading up to the next "## " heading.
-const lines = text.split("\n")
+// Changesets writes one "## X.Y.Z" heading per release. Capture from the
+// matching heading to the next one — ignoring "## " lines inside fenced code
+// blocks so a changeset that documents markdown can't truncate the section.
+const lines = text.replace(/\r\n/g, "\n").split("\n")
 const start = lines.findIndex((line) => line.trim() === `## ${version}`)
 if (start === -1) process.exit(0)
 
-const rest = lines.slice(start + 1)
-const end = rest.findIndex((line) => /^## /.test(line))
-const body = (end === -1 ? rest : rest.slice(0, end)).join("\n").trim()
+let inFence = false
+const body = []
+for (const line of lines.slice(start + 1)) {
+  if (/^\s*(```|~~~)/.test(line)) inFence = !inFence
+  if (!inFence && /^## /.test(line)) break
+  body.push(line)
+}
 
-process.stdout.write(body)
+process.stdout.write(body.join("\n").trim())

--- a/scripts/sync-library-version.mjs
+++ b/scripts/sync-library-version.mjs
@@ -2,8 +2,8 @@
 // Rewrites the pinned `@tumaet/apollon@X.Y.Z` esm.sh URLs in the README and
 // docs to match library/package.json. They must name an exact version (an
 // unpinned URL resolves to `latest` and breaks consumers' embeds), and no
-// bundler rewrites them, so the version-bump workflow runs this writer and PR
-// Health Checks run `--check` to block any drift from merging.
+// bundler rewrites them, so the `changeset:version` script runs this writer and
+// PR Health Checks run `--check` to block any drift from merging.
 //
 //   node scripts/sync-library-version.mjs           # rewrite to current version
 //   node scripts/sync-library-version.mjs --check    # exit 1 if anything drifts

--- a/vscode-extension/README.dev.md
+++ b/vscode-extension/README.dev.md
@@ -34,4 +34,4 @@ Then press <kbd>F5</kbd> in VS Code (or <kbd>Cmd/Ctrl+Shift+P</kbd> → **Debug:
 
 ## Release
 
-Bumps and publishes go through `Version Bump` → `Release VS Code Extension` workflows. See [`docs/deployment/npm-publishing.md`](../docs/deployment/npm-publishing.md) for the full pipeline.
+Bumps and publishes go through the `Version Bump (VS Code extension)` → `Release VS Code Extension` workflows. See [`docs/deployment/npm-publishing.md`](../docs/deployment/npm-publishing.md) for the full pipeline.


### PR DESCRIPTION
## Summary

Turns on the canonical Changesets pipeline that #690 left *plumbed but not wired*. Today contributors declare a bump type per PR via `pnpm changeset`, but releases **discard** it — a maintainer hand-picks the bump from the `Version Bump` dropdown and a hand-rolled script applies it. This makes the declared bump types authoritative and answers the question #690 raised ("is a release PR created automatically?") with **yes**.

## What changes

- **`release.yml` (new)** — on push to `main`, [`changesets/action`](https://github.com/changesets/action) runs in **version-only** mode (no `publish` input) and opens/updates a single **Version Packages** PR. That PR runs the new root `changeset:version` script (`changeset version` + `sync-library-version.mjs` + lockfile regen). Merging it triggers the **existing** `release-library.yml` / `release-standalone.yml` publish jobs — those stay in charge of publishing, so the blast radius is "how package.json gets bumped", not "how we publish".
- **Native library→standalone cascade** — a library bump patches the paired `@tumaet/webapp` + `@tumaet/server` automatically via their `workspace:*` dependency (`updateInternalDependencies: patch`), replacing the hand-coded mirror in `version-bump.yml`.
- **`version-bump.yml` slimmed to the VS Code extension only** — it stays in `.changeset/config.json#ignore` (separate marketplace + cadence), so it keeps a manual dispatch.
- **GitHub Release body from the changelog** — new `scripts/extract-changelog.mjs` sources each Release body from the Changesets-owned `CHANGELOG.md` section, falling back to `--generate-notes` when a version carried no changeset. CRLF-normalized and fenced-code-block-aware so a changeset documenting markdown can't truncate the body.
- **Docs** — `npm-publishing.md`, `release-notes.md`, `scripts.md`, `overview.md`, and the vscode dev README updated to the live flow.

## Multi-agent audit (this branch was graded, not vibes)

Ran 5 web-validated principal-engineer reviewers + an adversarial round-2 gate. Acted on every confirmed finding:

- **Cut** an over-engineered optional GitHub-App-token path (unset var, untested dead conditional arm — YAGNI). Left a `TODO` for if/when pre-merge CI on the version PR is actually wanted.
- **Swept** stale "Version Bump" references the slimming left behind (4 files).
- **Pinned Node** (`setup-node`) in the standalone release job so the changelog step doesn't ride the runner's ambient Node.
- **Hardened** `extract-changelog.mjs` (CRLF + fence boundary) and trimmed comment bloat.
- Both new action SHAs were independently verified against the GitHub API (`changesets/action` v1.9.0, `create-github-app-token` removed).

## Verification

Pipeline run end-to-end with a throwaway `@tumaet/apollon: minor` changeset, then reverted: library 4.4.0 → **4.5.0**, webapp/server 4.4.1 → **4.4.2** (cascaded patch), both `CHANGELOG.md` regenerated, CDN URLs synced. `extract-changelog.mjs` exercised against real changelogs plus fence/CRLF/last-section/missing fixtures. `prettier --check`, `lint:lib`, and workflow YAML parse all pass.

## Reviewer notes

- **No changeset** on this PR — it's CI/docs-only (exempt per `CLAUDE.md`).
- **Declined as YAGNI** (stated, not silently dropped): prerelease-mode contract and the "Updated dependencies" cascade Release body — both speculative/marginal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)