### PR TITLE
chore(release): backfill changesets for merges since v4.4.1

### DIFF
--- a/.changeset/capacitor-cors-allowlist-server.md
+++ b/.changeset/capacitor-cors-allowlist-server.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/server": patch
+---
+
+`CORS_ORIGIN` now accepts a comma-separated allowlist, so a deployment can permit the mobile app origins (`capacitor://localhost`, `ionic://localhost`) alongside the web app without weakening CORS (no wildcard, credentials preserved). Operators: add the mobile origins to `CORS_ORIGIN` when shipping the app.

--- a/.changeset/capacitor-cors-allowlist-server.md
+++ b/.changeset/capacitor-cors-allowlist-server.md
@@ -2,4 +2,4 @@
 "@tumaet/server": patch
 ---
 
-`CORS_ORIGIN` now accepts a comma-separated allowlist, so a deployment can permit the mobile app origins (`capacitor://localhost`, `ionic://localhost`) alongside the web app without weakening CORS (no wildcard, credentials preserved). Operators: add the mobile origins to `CORS_ORIGIN` when shipping the app.
+`CORS_ORIGIN` now accepts a comma-separated allowlist, so you can permit the mobile app origins (`capacitor://localhost`, `ionic://localhost`) alongside the web app without loosening CORS to a wildcard. Operators: add the mobile origins to `CORS_ORIGIN` when shipping the apps.

--- a/.changeset/capacitor-pptx-export.md
+++ b/.changeset/capacitor-pptx-export.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/webapp": minor
+---
+
+The mobile app can now export diagrams as PowerPoint (PPTX), matching the web app.

--- a/.changeset/capacitor-shell-webapp.md
+++ b/.changeset/capacitor-shell-webapp.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/webapp": minor
+---
+
+Run Apollon as a native iOS/Android app: a Capacitor shell with native copy-to-clipboard (and a browser fallback), and share/collaboration links that point at the deployed web app so they open anywhere.

--- a/.changeset/capacitor-shell-webapp.md
+++ b/.changeset/capacitor-shell-webapp.md
@@ -2,4 +2,4 @@
 "@tumaet/webapp": minor
 ---
 
-Run Apollon as a native iOS/Android app: a Capacitor shell with native copy-to-clipboard (and a browser fallback), and share/collaboration links that point at the deployed web app so they open anywhere.
+Apollon now runs as a native iOS and Android app, with native copy-to-clipboard and share links that always point at the web app so they open anywhere.

--- a/.changeset/collaboration-option.md
+++ b/.changeset/collaboration-option.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": minor
+---
+
+The editor can now render live cursors, a presence bar, and remote selection highlights itself: pass a `collaboration` option with the local `user` instead of building that overlay in your host app. Also exports the `collabColorFromName` and `randomCollabName` helpers.

--- a/.changeset/edge-line-jump.md
+++ b/.changeset/edge-line-jump.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": minor
+---
+
+Crossing edges now hop over one another (line jumps) instead of overlapping, keeping relationships legible in dense diagrams.

--- a/.changeset/edge-line-jump.md
+++ b/.changeset/edge-line-jump.md
@@ -2,4 +2,4 @@
 "@tumaet/apollon": minor
 ---
 
-Crossing edges now hop over one another (line jumps) instead of overlapping, keeping relationships legible in dense diagrams.
+Crossing edges now hop over one another (line jumps) instead of overlapping, keeping relationships readable in dense diagrams.

--- a/.changeset/edge-routing-library.md
+++ b/.changeset/edge-routing-library.md
@@ -2,4 +2,4 @@
 "@tumaet/apollon": minor
 ---
 
-Reworked edge routing and interaction: step-edge bends are predictable and grid-snapped, manually placed waypoints survive endpoint reconnection, endpoint reconnection follows React Flow's native behaviour, and only an edge's inputs (endpoints, waypoints, handles) are synced through Yjs — never computed geometry — so collaborators no longer thrash shared state.
+Edge editing overhaul: bend handles move a single segment and snap to the grid, manually placed waypoints now survive endpoint reconnection (they were discarded before), the path updates live as you drag, and connection handles no longer overlap on short node sides or when zoomed out. Grid snapping is also finer (5px).

--- a/.changeset/edge-routing-library.md
+++ b/.changeset/edge-routing-library.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": minor
+---
+
+Reworked edge routing and interaction: step-edge bends are predictable and grid-snapped, manually placed waypoints survive endpoint reconnection, endpoint reconnection follows React Flow's native behaviour, and only an edge's inputs (endpoints, waypoints, handles) are synced through Yjs — never computed geometry — so collaborators no longer thrash shared state.

--- a/.changeset/edge-routing-webapp.md
+++ b/.changeset/edge-routing-webapp.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/webapp": minor
+---
+
+Edges are easier to shape: drag a bend handle to move one segment at a time and see the path update live, reconnect an endpoint without losing the waypoints you placed, and connection handles no longer overlap on small elements.

--- a/.changeset/edge-routing-webapp.md
+++ b/.changeset/edge-routing-webapp.md
@@ -2,4 +2,4 @@
 "@tumaet/webapp": minor
 ---
 
-Edges are easier to shape: drag a bend handle to move one segment at a time and see the path update live, reconnect an endpoint without losing the waypoints you placed, and connection handles no longer overlap on small elements.
+Editing edges feels better: drag a bend handle to move one segment and watch the path update live, reconnect an endpoint without losing the waypoints you placed, and connection handles no longer crowd or overlap on small shapes.

--- a/.changeset/follow-viewport-library.md
+++ b/.changeset/follow-viewport-library.md
@@ -2,4 +2,4 @@
 "@tumaet/apollon": minor
 ---
 
-Follow a collaborator's viewport during a live session — track and recenter the editor on another participant's pan and zoom, built on the awareness layer.
+Follow another participant's viewport during a live session — the editor recenters and tracks their pan and zoom. Exposed through the `collaboration` option (`showFollow`, `followingClientId`) and a new `CollaborationViewport` type.

--- a/.changeset/follow-viewport-library.md
+++ b/.changeset/follow-viewport-library.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": minor
+---
+
+Follow a collaborator's viewport during a live session — track and recenter the editor on another participant's pan and zoom, built on the awareness layer.

--- a/.changeset/follow-viewport-webapp.md
+++ b/.changeset/follow-viewport-webapp.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/webapp": minor
+---
+
+Follow a collaborator while editing together: select their avatar in the presence bar to snap your view to theirs and keep tracking it as they move around the canvas.

--- a/.changeset/follow-viewport-webapp.md
+++ b/.changeset/follow-viewport-webapp.md
@@ -2,4 +2,4 @@
 "@tumaet/webapp": minor
 ---
 
-Follow a collaborator while editing together: select their avatar in the presence bar to snap your view to theirs and keep tracking it as they move around the canvas.
+Follow a collaborator while editing together: click their avatar to snap your view to theirs and keep tracking it as they move around the canvas.

--- a/.changeset/helper-lines-nested.md
+++ b/.changeset/helper-lines-nested.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Alignment helper lines now prioritise the parent when dragging near nested elements, while children still align within their parent.

--- a/.changeset/helper-lines-nested.md
+++ b/.changeset/helper-lines-nested.md
@@ -2,4 +2,4 @@
 "@tumaet/apollon": patch
 ---
 
-Alignment helper lines now prioritise the parent when dragging near nested elements, while children still align within their parent.
+Alignment guides now favour the parent container when you drag near a nested element, instead of fighting with the children inside it — children still align among themselves.

--- a/.changeset/nodetoolbar-canvas-pan.md
+++ b/.changeset/nodetoolbar-canvas-pan.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Pressing and dragging on a node toolbar button (Edit, Delete, …) no longer pans the canvas, so the toolbar is usable on touch devices.

--- a/.changeset/nodetoolbar-canvas-pan.md
+++ b/.changeset/nodetoolbar-canvas-pan.md
@@ -2,4 +2,4 @@
 "@tumaet/apollon": patch
 ---
 
-Pressing and dragging on a node toolbar button (Edit, Delete, …) no longer pans the canvas, so the toolbar is usable on touch devices.
+Pressing a node's toolbar button (Edit, Delete, …) no longer drags the canvas, so the toolbar works reliably on touch screens.

--- a/.changeset/react-apollon-api.md
+++ b/.changeset/react-apollon-api.md
@@ -1,5 +1,15 @@
 ---
-"@tumaet/apollon": minor
+"@tumaet/apollon": major
 ---
 
-New React API for embedding the editor: an `<Apollon>` component with `ApollonProvider`, `useApollonEditor`, `useApollonEditorOrThrow`, and `useApollonSubscription`. A `/react` subpath externalises React, MUI, and emotion so React hosts can dedupe them, while the default entry still bundles them for non-React hosts.
+Add a first-class React API and split the package into two entry points.
+
+- `@tumaet/apollon/react` exports an `<Apollon>` component plus `ApollonProvider`, `useApollonEditor`, `useApollonEditorOrThrow`, and `useApollonSubscription`. It treats `react`, `react-dom`, `@mui/material`, `@emotion/react`, and `@xyflow/react` as peer dependencies so a React host resolves a single shared copy.
+- The default `@tumaet/apollon` entry stays framework-agnostic and bundles those dependencies, so non-React hosts install with zero peers.
+
+**Migrating from 4.x:**
+
+- React hosts: import from `@tumaet/apollon/react` and add the five peers above to your own dependencies.
+- Minimum Node is now 22 (was 20).
+- Removed the `ApollonOptions` fields `theme`, `copyPasteToClipboard`, `colorEnabled`, and `scale`, and the `theme` argument of `exportModelAsSvg`.
+- Low-level sync internals (`YjsSync`, format converters) moved to `@tumaet/apollon/internals` and are not covered by semver.

--- a/.changeset/react-apollon-api.md
+++ b/.changeset/react-apollon-api.md
@@ -1,5 +1,5 @@
 ---
-"@tumaet/apollon": major
+"@tumaet/apollon": minor
 ---
 
 Add a first-class React API and split the package into two entry points.
@@ -7,7 +7,7 @@ Add a first-class React API and split the package into two entry points.
 - `@tumaet/apollon/react` exports an `<Apollon>` component plus `ApollonProvider`, `useApollonEditor`, `useApollonEditorOrThrow`, and `useApollonSubscription`. It treats `react`, `react-dom`, `@mui/material`, `@emotion/react`, and `@xyflow/react` as peer dependencies so a React host resolves a single shared copy.
 - The default `@tumaet/apollon` entry stays framework-agnostic and bundles those dependencies, so non-React hosts install with zero peers.
 
-**Migrating from 4.x:**
+**When upgrading:**
 
 - React hosts: import from `@tumaet/apollon/react` and add the five peers above to your own dependencies.
 - Minimum Node is now 22 (was 20).

--- a/.changeset/react-apollon-api.md
+++ b/.changeset/react-apollon-api.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": minor
+---
+
+New React API for embedding the editor: an `<Apollon>` component with `ApollonProvider`, `useApollonEditor`, `useApollonEditorOrThrow`, and `useApollonSubscription`. A `/react` subpath externalises React, MUI, and emotion so React hosts can dedupe them, while the default entry still bundles them for non-React hosts.

--- a/.changeset/react-apollon-api.md
+++ b/.changeset/react-apollon-api.md
@@ -4,12 +4,12 @@
 
 Add a first-class React API and split the package into two entry points.
 
-- `@tumaet/apollon/react` exports an `<Apollon>` component plus `ApollonProvider`, `useApollonEditor`, `useApollonEditorOrThrow`, and `useApollonSubscription`. It treats `react`, `react-dom`, `@mui/material`, `@emotion/react`, and `@xyflow/react` as peer dependencies so a React host resolves a single shared copy.
+- `@tumaet/apollon/react` exports an `<Apollon>` component plus `ApollonProvider`, `useApollonEditor`, `useApollonEditorOrThrow`, and `useApollonSubscription`. It treats `react`, `react-dom`, `@mui/material`, `@emotion/react`, `@emotion/styled`, and `@xyflow/react` as peer dependencies so a React host resolves a single shared copy.
 - The default `@tumaet/apollon` entry stays framework-agnostic and bundles those dependencies, so non-React hosts install with zero peers.
 
 **Breaking changes — migrating from 4.x:**
 
-- React hosts: import from `@tumaet/apollon/react` and add the five peers above to your own dependencies.
+- React hosts: import from `@tumaet/apollon/react` and add the six peers above to your own dependencies.
 - Minimum Node is now 22 (was 20).
 - Removed the `ApollonOptions` fields `theme`, `copyPasteToClipboard`, `colorEnabled`, and `scale`, and the `theme` argument of `exportModelAsSvg`.
 - Low-level sync internals (`YjsSync`, format converters) moved to `@tumaet/apollon/internals` and are not covered by semver.

--- a/.changeset/react-apollon-api.md
+++ b/.changeset/react-apollon-api.md
@@ -1,5 +1,5 @@
 ---
-"@tumaet/apollon": minor
+"@tumaet/apollon": major
 ---
 
 Add a first-class React API and split the package into two entry points.
@@ -7,7 +7,7 @@ Add a first-class React API and split the package into two entry points.
 - `@tumaet/apollon/react` exports an `<Apollon>` component plus `ApollonProvider`, `useApollonEditor`, `useApollonEditorOrThrow`, and `useApollonSubscription`. It treats `react`, `react-dom`, `@mui/material`, `@emotion/react`, and `@xyflow/react` as peer dependencies so a React host resolves a single shared copy.
 - The default `@tumaet/apollon` entry stays framework-agnostic and bundles those dependencies, so non-React hosts install with zero peers.
 
-**When upgrading:**
+**Breaking changes — migrating from 4.x:**
 
 - React hosts: import from `@tumaet/apollon/react` and add the five peers above to your own dependencies.
 - Minimum Node is now 22 (was 20).

--- a/.changeset/redis-data-dir.md
+++ b/.changeset/redis-data-dir.md
@@ -2,4 +2,4 @@
 "@tumaet/server": patch
 ---
 
-Redis Stack is now pinned to persist into the `/data` volume (`--dir /data`). Previously it defaulted to `/var/lib/redis-stack`, writing into the container's ephemeral layer, so diagram writes between deploys could be silently lost. Operators: redeploy the database so the container picks up the corrected data directory.
+The Redis Stack container now persists to the `/data` volume (`--dir /data`). It previously defaulted to `/var/lib/redis-stack` — the container's ephemeral layer — so diagrams written between deploys could be silently lost. Operators: redeploy the database so it picks up the corrected data directory.

--- a/.changeset/redis-data-dir.md
+++ b/.changeset/redis-data-dir.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/server": patch
+---
+
+Redis Stack is now pinned to persist into the `/data` volume (`--dir /data`). Previously it defaulted to `/var/lib/redis-stack`, writing into the container's ephemeral layer, so diagram writes between deploys could be silently lost. Operators: redeploy the database so the container picks up the corrected data directory.


### PR DESCRIPTION
## Summary

The Changesets pipeline (#728) went live **after** a backlog of user-facing PRs had already merged, so those unreleased changes carry no changeset. This backfills them — one changeset **per affected audience**, in that audience's voice (embedder / end-user / operator).

Bumps and inclusion were decided from the **actual diffs**, not the PR titles/labels:

- **#691 is a `major`.** `@tumaet/apollon` is a public npm package and this PR carries documented breaking changes — removed `ApollonOptions` fields and the `exportModelAsSvg` theme arg (a compile break for TS consumers), `YjsSyncClass` dropped from the root export, and the Node floor raised 20 → 22. Under SemVer those require a major; a minor would silently break downstream `^4` consumers on update. The changeset carries a "Breaking changes — migrating from 4.x" block.
- **#709 was un-skipped.** Despite its `refactor:` label it adds public surface (`collaboration` option, `CollaborationViewport` / `ApollonCollaborationOptions` types, `collabColorFromName` / `randomCollabName` exports) → library minor.
- **#710 is minor**, not major: no persisted-schema change and it's collaboration-safe across versions; notes rewritten to the real behaviours.

**Result** (verified via `changeset status` + a token-backed `changeset version` render): `@tumaet/apollon` **4.4.0 → 5.0.0**, standalone **4.4.1 → 4.5.0**. The two version lines diverge correctly — the library has a breaking API change; the app gets new features.

## Backfilled (10 PRs → 13 changesets)

| PR | Change | Bump |
| --- | --- | --- |
| #691 | React `<Apollon>` API + dual entry points (breaking) | `apollon` **major** |
| #709 | Library renders collaboration UI (presence, cursors) | `apollon` minor |
| #681 | Follow a collaborator's viewport | `apollon` minor + `webapp` minor |
| #710 | Edge bending / waypoint / reconnection overhaul | `apollon` minor + `webapp` minor |
| #706 | Line-jump on edge collision | `apollon` minor |
| #708 | Node toolbar no longer pans the canvas | `apollon` patch |
| #680 | Helper lines for nested elements | `apollon` patch |
| #713 | PPTX export on the mobile app | `webapp` minor |
| #701 | Native iOS/Android app + CORS allowlist | `webapp` minor + `server` patch |
| #689 | Pin Redis Stack data dir to `/data` | `server` patch |

## Skipped (per `CLAUDE.md`)

- **#721** `docs:` README + `ci:` version sync · **#690, #716–#720, #726, #728** — ci / chore / release-tooling.

## Notes

- **Attribution:** entries are attributed to this curated release PR by `changelog-github` (the idiomatic changesets outcome); original authorship is preserved on the linked source PRs in the table above.
- The changeset bodies are written for humans, leading with the user/embedder/operator benefit and avoiding internal implementation detail.

## On merge

Lands the changesets on `main` → `release.yml` opens the **Version Packages** PR automatically (computing 5.0.0 / 4.5.0). Review the generated `CHANGELOG.md` there, then merge it to publish (npm + Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)