### PR TITLE
fix(ci): bump ls1intum/.github to repair GHCR image existence check

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -72,7 +72,7 @@ jobs:
             dockerfile: ./standalone/server/Dockerfile
             image: ls1intum/apollon/server
             context: .
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@c8ede985ff7999c28d7538cb32ae52bfb83f51b9 # main
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@5f645f96873d8b8b3a9b2e52d06626c71377f7ac # main as of 2026-05-28
     with:
       image-name: ${{ matrix.image }}
       docker-file: ${{ matrix.dockerfile }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -47,7 +47,7 @@ permissions: {}
 jobs:
   deploy-db:
     if: ${{ inputs.deploy-db }}
-    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@c8ede985ff7999c28d7538cb32ae52bfb83f51b9 # main as of 2026-05-19
+    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@5f645f96873d8b8b3a9b2e52d06626c71377f7ac # main as of 2026-05-28 (GHCR existence-check fix)
     with:
       environment: Production
       docker-compose-file: "./docker/compose.db.yml"
@@ -58,7 +58,7 @@ jobs:
 
   deploy-proxy:
     if: ${{ inputs.deploy-proxy }}
-    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@c8ede985ff7999c28d7538cb32ae52bfb83f51b9 # main as of 2026-05-19
+    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@5f645f96873d8b8b3a9b2e52d06626c71377f7ac # main as of 2026-05-28 (GHCR existence-check fix)
     with:
       environment: Production
       docker-compose-file: "./docker/compose.proxy.yml"
@@ -69,7 +69,7 @@ jobs:
 
   deploy-app:
     if: ${{ inputs.deploy-app }}
-    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@c8ede985ff7999c28d7538cb32ae52bfb83f51b9 # main as of 2026-05-19
+    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@5f645f96873d8b8b3a9b2e52d06626c71377f7ac # main as of 2026-05-28 (GHCR existence-check fix)
     with:
       environment: Production
       docker-compose-file: "./docker/compose.app.yml"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -47,7 +47,7 @@ permissions: {}
 jobs:
   deploy-db:
     if: ${{ inputs.deploy-db }}
-    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@c8ede985ff7999c28d7538cb32ae52bfb83f51b9 # main as of 2026-05-19
+    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@5f645f96873d8b8b3a9b2e52d06626c71377f7ac # main as of 2026-05-28 (GHCR existence-check fix)
     with:
       environment: Staging
       docker-compose-file: "./docker/compose.db.yml"
@@ -58,7 +58,7 @@ jobs:
 
   deploy-proxy:
     if: ${{ inputs.deploy-proxy }}
-    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@c8ede985ff7999c28d7538cb32ae52bfb83f51b9 # main as of 2026-05-19
+    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@5f645f96873d8b8b3a9b2e52d06626c71377f7ac # main as of 2026-05-28 (GHCR existence-check fix)
     with:
       environment: Staging
       docker-compose-file: "./docker/compose.proxy.yml"
@@ -69,7 +69,7 @@ jobs:
 
   deploy-app:
     if: ${{ inputs.deploy-app }}
-    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@c8ede985ff7999c28d7538cb32ae52bfb83f51b9 # main as of 2026-05-19
+    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@5f645f96873d8b8b3a9b2e52d06626c71377f7ac # main as of 2026-05-28 (GHCR existence-check fix)
     with:
       environment: Staging
       docker-compose-file: "./docker/compose.app.yml"


### PR DESCRIPTION
## Problem

Every push to `main` fails at **Deploy to Staging / deploy-app / prepare-deploy** → *Check if image exists* with `Process completed with exit code 43`, even though the server/webapp images are built and pushed successfully (e.g. [run 26882678084](https://github.com/ls1intum/Apollon/actions/runs/26882678084/job/79288119449)).

## Root cause

We pin the reusable deploy workflow at `c8ede985` (main as of 2026-05-19). Its image-existence check did:

```bash
ENCODED_TOKEN=$(echo -n "${{ secrets.GITHUB_TOKEN }}" | base64)
curl ... -H "Authorization: Bearer ${ENCODED_TOKEN}" "https://ghcr.io/v2/.../manifests/..."
```

`base64` wraps output at 76 columns, so the long `GITHUB_TOKEN` became a **multi-line** value. The embedded newline produced a malformed `Authorization` header, and curl aborted with exit code 43 (`CURLE_BAD_FUNCTION_ARGUMENT`) before the status was ever read — failing the gate regardless of whether the image exists (it did).

## Fix

Upstream repaired this on 2026-05-28 in [ls1intum/.github#67](https://github.com/ls1intum/.github/pull/67) by replacing the hand-rolled curl/base64 auth with `docker login` + `docker buildx imagetools inspect`.

This PR bumps all pinned reusable-workflow references from `c8ede985` → `5f645f9`. The only change between those two SHAs is that single fix; `build-and-push-docker-image.yml` is untouched, so the build path is unaffected.

- `deploy-staging.yml` ×3
- `deploy-prod.yml` ×3
- `build-and-push.yml` ×1 (kept in sync; same SHA)

No changeset — CI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)