### PR TITLE
chore(release): downgrade #691 React API changeset to minor

### DIFF
--- a/.changeset/react-apollon-api.md
+++ b/.changeset/react-apollon-api.md
@@ -1,5 +1,5 @@
 ---
-"@tumaet/apollon": major
+"@tumaet/apollon": minor
 ---
 
 Add a first-class React API and split the package into two entry points.
@@ -7,7 +7,7 @@ Add a first-class React API and split the package into two entry points.
 - `@tumaet/apollon/react` exports an `<Apollon>` component plus `ApollonProvider`, `useApollonEditor`, `useApollonEditorOrThrow`, and `useApollonSubscription`. It treats `react`, `react-dom`, `@mui/material`, `@emotion/react`, `@emotion/styled`, and `@xyflow/react` as peer dependencies so a React host resolves a single shared copy.
 - The default `@tumaet/apollon` entry stays framework-agnostic and bundles those dependencies, so non-React hosts install with zero peers.
 
-**Breaking changes — migrating from 4.x:**
+**When upgrading:**
 
 - React hosts: import from `@tumaet/apollon/react` and add the six peers above to your own dependencies.
 - Minimum Node is now 22 (was 20).


### PR DESCRIPTION
Corrects the `@tumaet/apollon` bump in the backfilled `react-apollon-api` changeset from `major` to `minor` (maintainer decision). The pending **Version Packages** PR (#733) will recompute the library at **4.5.0** instead of 5.0.0 once this lands. Reframed the note from "Breaking changes" to "When upgrading" for consistency with a minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)