### PR TITLE
feat(library): add edge-type preview icons to edge popovers

### DIFF
--- a/.changeset/eight-frogs-love.md
+++ b/.changeset/eight-frogs-love.md
@@ -2,4 +2,4 @@
 "@tumaet/apollon": patch
 ---
 
-Class diagram edge type options now show matching edge icon previews.
+The edge-type dropdown now previews how each option renders, for class, component, deployment, use case, and BPMN diagrams.

--- a/.changeset/eight-frogs-love.md
+++ b/.changeset/eight-frogs-love.md
@@ -1,5 +1,5 @@
 ---
-"@tumaet/apollon": patch
+"@tumaet/apollon": minor
 ---
 
-The edge-type dropdown now previews how each option renders, for class, component, deployment, use case, and BPMN diagrams.
+The edge-type dropdown now shows a small preview of how each option renders — its real line style and arrowheads — so you can pick the right relationship at a glance, across class, component, deployment, use case, and BPMN diagrams.

--- a/.changeset/eight-frogs-love.md
+++ b/.changeset/eight-frogs-love.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Class diagram edge type options now show matching edge icon previews.

--- a/library/lib/components/popovers/edgePopovers/BPMNDiagramEdgeEditPopover.tsx
+++ b/library/lib/components/popovers/edgePopovers/BPMNDiagramEdgeEditPopover.tsx
@@ -1,10 +1,18 @@
-import { Box, FormControl, InputLabel, Select, MenuItem } from "@mui/material"
+import { Box } from "@mui/material"
 import { CustomEdgeProps } from "@/edges/EdgeProps"
 import { useReactFlow } from "@xyflow/react"
 import { useEdgePopOver } from "@/hooks"
 import { PopoverProps } from "../types"
 import { SwapHorizIcon } from "@/components/Icon"
 import { EdgeStyleEditor, TextField, Typography } from "@/components/ui"
+import { EdgeTypeSelect, EdgeTypeOption } from "./EdgeTypeSelect"
+
+const BPMN_EDGE_TYPE_OPTIONS: ReadonlyArray<EdgeTypeOption> = [
+  { value: "BPMNSequenceFlow", label: "Sequence Flow" },
+  { value: "BPMNMessageFlow", label: "Message Flow" },
+  { value: "BPMNAssociationFlow", label: "Association Flow" },
+  { value: "BPMNDataAssociationFlow", label: "Data Association Flow" },
+]
 
 export const BPMNDiagramEdgeEditPopover: React.FC<PopoverProps> = ({
   elementId,
@@ -23,13 +31,6 @@ export const BPMNDiagramEdgeEditPopover: React.FC<PopoverProps> = ({
   const targetNode = getNode(edge.target)
   const sourceName = (sourceNode?.data?.name as string) ?? "Source"
   const targetName = (targetNode?.data?.name as string) ?? "Target"
-
-  const bpmnEdgeTypeOptions = [
-    { value: "BPMNSequenceFlow", label: "Sequence Flow" },
-    { value: "BPMNMessageFlow", label: "Message Flow" },
-    { value: "BPMNAssociationFlow", label: "Association Flow" },
-    { value: "BPMNDataAssociationFlow", label: "Data Association Flow" },
-  ]
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
@@ -50,22 +51,11 @@ export const BPMNDiagramEdgeEditPopover: React.FC<PopoverProps> = ({
           ),
         ]}
       />
-      <FormControl fullWidth size="small">
-        <InputLabel id="edge-type-label">Edge Type</InputLabel>
-        <Select
-          labelId="edge-type-label"
-          id="edge-type-select"
-          value={edge.type}
-          label="Edge Type"
-          onChange={(e) => handleEdgeTypeChange(e.target.value)}
-        >
-          {bpmnEdgeTypeOptions.map((option) => (
-            <MenuItem key={option.value} value={option.value}>
-              {option.label}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+      <EdgeTypeSelect
+        value={edge.type}
+        options={BPMN_EDGE_TYPE_OPTIONS}
+        onChange={handleEdgeTypeChange}
+      />
 
       <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
         {sourceName} → {targetName}

--- a/library/lib/components/popovers/edgePopovers/ClassDiagramEdgeEditPopover.tsx
+++ b/library/lib/components/popovers/edgePopovers/ClassDiagramEdgeEditPopover.tsx
@@ -1,131 +1,21 @@
-import { Box, FormControl, InputLabel, Select, MenuItem } from "@mui/material"
+import { Box } from "@mui/material"
 import { EdgeStyleEditor, TextField, Typography } from "@/components/ui"
 import { useReactFlow } from "@xyflow/react"
 import { CustomEdgeProps } from "@/edges/EdgeProps"
 import { SwapHorizIcon } from "@/components/Icon"
 import { useEdgePopOver } from "@/hooks"
 import { PopoverProps } from "../types"
+import { EdgeTypeSelect, EdgeTypeOption } from "./EdgeTypeSelect"
 
-const EDGE_TYPE_ICON_FILL = "var(--apollon-background-variant, transparent)"
-
-type ClassEdgeTypeIconMarker =
-  | { type: "none" }
-  | { type: "arrow" }
-  | { type: "triangle" }
-  | { type: "rhombus"; filled: boolean }
-
-type ClassEdgeTypeIconConfig = {
-  dashed: boolean
-  lineEndX: number
-  marker: ClassEdgeTypeIconMarker
-}
-
-const CLASS_EDGE_TYPE_OPTIONS = [
-  {
-    value: "ClassBidirectional",
-    label: "Bi-Association",
-    icon: { dashed: false, lineEndX: 52, marker: { type: "none" } },
-  },
-  {
-    value: "ClassUnidirectional",
-    label: "Uni-Association",
-    icon: { dashed: false, lineEndX: 40, marker: { type: "arrow" } },
-  },
-  {
-    value: "ClassAggregation",
-    label: "Aggregation",
-    icon: {
-      dashed: false,
-      lineEndX: 38,
-      marker: { type: "rhombus", filled: false },
-    },
-  },
-  {
-    value: "ClassComposition",
-    label: "Composition",
-    icon: {
-      dashed: false,
-      lineEndX: 38,
-      marker: { type: "rhombus", filled: true },
-    },
-  },
-  {
-    value: "ClassInheritance",
-    label: "Inheritance",
-    icon: { dashed: false, lineEndX: 40, marker: { type: "triangle" } },
-  },
-  {
-    value: "ClassDependency",
-    label: "Dependency",
-    icon: { dashed: true, lineEndX: 40, marker: { type: "arrow" } },
-  },
-  {
-    value: "ClassRealization",
-    label: "Realization",
-    icon: { dashed: true, lineEndX: 40, marker: { type: "triangle" } },
-  },
-] as const satisfies ReadonlyArray<{
-  value: string
-  label: string
-  icon: ClassEdgeTypeIconConfig
-}>
-
-const ClassEdgeTypeIcon = ({ icon }: { icon: ClassEdgeTypeIconConfig }) => {
-  return (
-    <Box
-      component="svg"
-      aria-hidden
-      focusable="false"
-      viewBox="0 0 56 20"
-      sx={{
-        width: 56,
-        height: 20,
-        color: "inherit",
-        flex: "0 0 auto",
-      }}
-    >
-      <line
-        x1="4"
-        y1="10"
-        x2={icon.lineEndX}
-        y2="10"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeDasharray={icon.dashed ? "5 4" : undefined}
-      />
-
-      {icon.marker.type === "arrow" && (
-        <path
-          d="M42 5 L52 10 L42 15"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.8"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      )}
-      {icon.marker.type === "triangle" && (
-        <path
-          d="M52 10 L40 4 L40 16 Z"
-          fill={EDGE_TYPE_ICON_FILL}
-          stroke="currentColor"
-          strokeWidth="1.6"
-          strokeLinejoin="round"
-        />
-      )}
-      {icon.marker.type === "rhombus" && (
-        <path
-          d="M52 10 L45 5 L38 10 L45 15 Z"
-          fill={icon.marker.filled ? "currentColor" : EDGE_TYPE_ICON_FILL}
-          stroke="currentColor"
-          strokeWidth="1.6"
-          strokeLinejoin="round"
-        />
-      )}
-    </Box>
-  )
-}
+const CLASS_EDGE_TYPE_OPTIONS: ReadonlyArray<EdgeTypeOption> = [
+  { value: "ClassBidirectional", label: "Bi-Association" },
+  { value: "ClassUnidirectional", label: "Uni-Association" },
+  { value: "ClassAggregation", label: "Aggregation" },
+  { value: "ClassComposition", label: "Composition" },
+  { value: "ClassInheritance", label: "Inheritance" },
+  { value: "ClassDependency", label: "Dependency" },
+  { value: "ClassRealization", label: "Realization" },
+]
 
 export const EdgeEditPopover: React.FC<PopoverProps> = ({ elementId }) => {
   const { getEdge, getNode, updateEdgeData } = useReactFlow()
@@ -160,10 +50,7 @@ export const EdgeEditPopover: React.FC<PopoverProps> = ({ elementId }) => {
         label="Edge Type"
         sideElements={[
           handleSwap && (
-            <Box
-              key="swap-edge-direction"
-              sx={{ display: "flex", justifyContent: "flex-end" }}
-            >
+            <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
               <SwapHorizIcon
                 style={{ cursor: "pointer" }}
                 onClick={handleSwap}
@@ -173,42 +60,11 @@ export const EdgeEditPopover: React.FC<PopoverProps> = ({ elementId }) => {
         ]}
       />
 
-      <FormControl fullWidth size="small">
-        <InputLabel id="edge-type-label">Edge Type</InputLabel>
-        <Select
-          labelId="edge-type-label"
-          id="edge-type-select"
-          value={edge.type}
-          label="Edge Type"
-          onChange={(e) => handleEdgeTypeChange(e.target.value)}
-          MenuProps={{
-            disablePortal: true,
-            PaperProps: {
-              sx: {
-                backgroundColor: "var(--apollon-background-variant, #f8f9fa)",
-                color: "var(--apollon-primary-contrast, #000000)",
-              },
-            },
-          }}
-        >
-          {CLASS_EDGE_TYPE_OPTIONS.map((option) => (
-            <MenuItem key={option.value} value={option.value}>
-              <Box
-                sx={{
-                  alignItems: "center",
-                  display: "flex",
-                  gap: 2,
-                  justifyContent: "space-between",
-                  width: "100%",
-                }}
-              >
-                <Box component="span">{option.label}</Box>
-                <ClassEdgeTypeIcon icon={option.icon} />
-              </Box>
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+      <EdgeTypeSelect
+        value={edge.type}
+        options={CLASS_EDGE_TYPE_OPTIONS}
+        onChange={handleEdgeTypeChange}
+      />
 
       {
         <>

--- a/library/lib/components/popovers/edgePopovers/ClassDiagramEdgeEditPopover.tsx
+++ b/library/lib/components/popovers/edgePopovers/ClassDiagramEdgeEditPopover.tsx
@@ -6,6 +6,127 @@ import { SwapHorizIcon } from "@/components/Icon"
 import { useEdgePopOver } from "@/hooks"
 import { PopoverProps } from "../types"
 
+const EDGE_TYPE_ICON_FILL = "var(--apollon-background-variant, transparent)"
+
+type ClassEdgeTypeIconMarker =
+  | { type: "none" }
+  | { type: "arrow" }
+  | { type: "triangle" }
+  | { type: "rhombus"; filled: boolean }
+
+type ClassEdgeTypeIconConfig = {
+  dashed: boolean
+  lineEndX: number
+  marker: ClassEdgeTypeIconMarker
+}
+
+const CLASS_EDGE_TYPE_OPTIONS = [
+  {
+    value: "ClassBidirectional",
+    label: "Bi-Association",
+    icon: { dashed: false, lineEndX: 52, marker: { type: "none" } },
+  },
+  {
+    value: "ClassUnidirectional",
+    label: "Uni-Association",
+    icon: { dashed: false, lineEndX: 40, marker: { type: "arrow" } },
+  },
+  {
+    value: "ClassAggregation",
+    label: "Aggregation",
+    icon: {
+      dashed: false,
+      lineEndX: 38,
+      marker: { type: "rhombus", filled: false },
+    },
+  },
+  {
+    value: "ClassComposition",
+    label: "Composition",
+    icon: {
+      dashed: false,
+      lineEndX: 38,
+      marker: { type: "rhombus", filled: true },
+    },
+  },
+  {
+    value: "ClassInheritance",
+    label: "Inheritance",
+    icon: { dashed: false, lineEndX: 40, marker: { type: "triangle" } },
+  },
+  {
+    value: "ClassDependency",
+    label: "Dependency",
+    icon: { dashed: true, lineEndX: 40, marker: { type: "arrow" } },
+  },
+  {
+    value: "ClassRealization",
+    label: "Realization",
+    icon: { dashed: true, lineEndX: 40, marker: { type: "triangle" } },
+  },
+] as const satisfies ReadonlyArray<{
+  value: string
+  label: string
+  icon: ClassEdgeTypeIconConfig
+}>
+
+const ClassEdgeTypeIcon = ({ icon }: { icon: ClassEdgeTypeIconConfig }) => {
+  return (
+    <Box
+      component="svg"
+      aria-hidden
+      focusable="false"
+      viewBox="0 0 56 20"
+      sx={{
+        width: 56,
+        height: 20,
+        color: "inherit",
+        flex: "0 0 auto",
+      }}
+    >
+      <line
+        x1="4"
+        y1="10"
+        x2={icon.lineEndX}
+        y2="10"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeDasharray={icon.dashed ? "5 4" : undefined}
+      />
+
+      {icon.marker.type === "arrow" && (
+        <path
+          d="M42 5 L52 10 L42 15"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      )}
+      {icon.marker.type === "triangle" && (
+        <path
+          d="M52 10 L40 4 L40 16 Z"
+          fill={EDGE_TYPE_ICON_FILL}
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinejoin="round"
+        />
+      )}
+      {icon.marker.type === "rhombus" && (
+        <path
+          d="M52 10 L45 5 L38 10 L45 15 Z"
+          fill={icon.marker.filled ? "currentColor" : EDGE_TYPE_ICON_FILL}
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinejoin="round"
+        />
+      )}
+    </Box>
+  )
+}
+
 export const EdgeEditPopover: React.FC<PopoverProps> = ({ elementId }) => {
   const { getEdge, getNode, updateEdgeData } = useReactFlow()
 
@@ -29,20 +150,6 @@ export const EdgeEditPopover: React.FC<PopoverProps> = ({ elementId }) => {
   const sourceName = (sourceNode?.data?.name as string) ?? "Source"
   const targetName = (targetNode?.data?.name as string) ?? "Target"
 
-  const getEdgeTypeOptions = () => {
-    return [
-      { value: "ClassBidirectional", label: "Bi-Association" },
-      { value: "ClassUnidirectional", label: "Uni-Association" },
-      { value: "ClassAggregation", label: "Aggregation" },
-      { value: "ClassComposition", label: "Composition" },
-      { value: "ClassInheritance", label: "Inheritance" },
-      { value: "ClassDependency", label: "Dependency" },
-      { value: "ClassRealization", label: "Realization" },
-    ]
-  }
-
-  const edgeTypeOptions = getEdgeTypeOptions()
-
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
       <EdgeStyleEditor
@@ -53,7 +160,10 @@ export const EdgeEditPopover: React.FC<PopoverProps> = ({ elementId }) => {
         label="Edge Type"
         sideElements={[
           handleSwap && (
-            <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+            <Box
+              key="swap-edge-direction"
+              sx={{ display: "flex", justifyContent: "flex-end" }}
+            >
               <SwapHorizIcon
                 style={{ cursor: "pointer" }}
                 onClick={handleSwap}
@@ -71,10 +181,30 @@ export const EdgeEditPopover: React.FC<PopoverProps> = ({ elementId }) => {
           value={edge.type}
           label="Edge Type"
           onChange={(e) => handleEdgeTypeChange(e.target.value)}
+          MenuProps={{
+            disablePortal: true,
+            PaperProps: {
+              sx: {
+                backgroundColor: "var(--apollon-background-variant, #f8f9fa)",
+                color: "var(--apollon-primary-contrast, #000000)",
+              },
+            },
+          }}
         >
-          {edgeTypeOptions.map((option) => (
+          {CLASS_EDGE_TYPE_OPTIONS.map((option) => (
             <MenuItem key={option.value} value={option.value}>
-              {option.label}
+              <Box
+                sx={{
+                  alignItems: "center",
+                  display: "flex",
+                  gap: 2,
+                  justifyContent: "space-between",
+                  width: "100%",
+                }}
+              >
+                <Box component="span">{option.label}</Box>
+                <ClassEdgeTypeIcon icon={option.icon} />
+              </Box>
             </MenuItem>
           ))}
         </Select>

--- a/library/lib/components/popovers/edgePopovers/ComponentDiagramEdgeEditPopover.tsx
+++ b/library/lib/components/popovers/edgePopovers/ComponentDiagramEdgeEditPopover.tsx
@@ -1,10 +1,17 @@
-import { Box, FormControl, Select, MenuItem, InputLabel } from "@mui/material"
+import { Box } from "@mui/material"
 import { EdgeStyleEditor, Typography } from "@/components/ui"
 import { useReactFlow } from "@xyflow/react"
 import { SwapHorizIcon } from "@/components/Icon"
 import { useEdgePopOver } from "@/hooks"
 import { PopoverProps } from "../types"
 import { CustomEdgeProps } from "@/edges"
+import { EdgeTypeSelect, EdgeTypeOption } from "./EdgeTypeSelect"
+
+const COMPONENT_EDGE_TYPE_OPTIONS: ReadonlyArray<EdgeTypeOption> = [
+  { value: "ComponentDependency", label: "Dependency" },
+  { value: "ComponentProvidedInterface", label: "Provided Interface" },
+  { value: "ComponentRequiredInterface", label: "Required Interface" },
+]
 
 export const ComponentEdgeEditPopover: React.FC<PopoverProps> = ({
   elementId,
@@ -22,12 +29,6 @@ export const ComponentEdgeEditPopover: React.FC<PopoverProps> = ({
   const targetNode = getNode(edge.target)
   const sourceName = (sourceNode?.data?.name as string) ?? "Source"
   const targetName = (targetNode?.data?.name as string) ?? "Target"
-
-  const componentEdgeTypeOptions = [
-    { value: "ComponentDependency", label: "Dependency" },
-    { value: "ComponentProvidedInterface", label: "Provided Interface" },
-    { value: "ComponentRequiredInterface", label: "Required Interface" },
-  ]
 
   const edgeData = edge.data as CustomEdgeProps | undefined
 
@@ -51,22 +52,11 @@ export const ComponentEdgeEditPopover: React.FC<PopoverProps> = ({
         ]}
       />
 
-      <FormControl fullWidth size="small">
-        <InputLabel id="edge-type-label">Edge Type</InputLabel>
-        <Select
-          labelId="edge-type-label"
-          id="edge-type-select"
-          value={edge.type}
-          label="Edge Type"
-          onChange={(e) => handleEdgeTypeChange(e.target.value)}
-        >
-          {componentEdgeTypeOptions.map((option) => (
-            <MenuItem key={option.value} value={option.value}>
-              {option.label}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+      <EdgeTypeSelect
+        value={edge.type}
+        options={COMPONENT_EDGE_TYPE_OPTIONS}
+        onChange={handleEdgeTypeChange}
+      />
 
       <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
         {sourceName} → {targetName}

--- a/library/lib/components/popovers/edgePopovers/DeploymentDiagramEdgeEditPopover.tsx
+++ b/library/lib/components/popovers/edgePopovers/DeploymentDiagramEdgeEditPopover.tsx
@@ -1,10 +1,18 @@
-import { Box, FormControl, Select, MenuItem, InputLabel } from "@mui/material"
+import { Box } from "@mui/material"
 import { EdgeStyleEditor, TextField, Typography } from "@/components/ui"
 import { SwapHorizIcon } from "@/components/Icon"
 import { useReactFlow } from "@xyflow/react"
 import { CustomEdgeProps } from "@/edges/EdgeProps"
 import { useEdgePopOver } from "@/hooks"
 import { PopoverProps } from "../types"
+import { EdgeTypeSelect, EdgeTypeOption } from "./EdgeTypeSelect"
+
+const DEPLOYMENT_EDGE_TYPE_OPTIONS: ReadonlyArray<EdgeTypeOption> = [
+  { value: "DeploymentAssociation", label: "Deployment Association" },
+  { value: "DeploymentDependency", label: "Deployment Dependency" },
+  { value: "DeploymentProvidedInterface", label: "Provided Interface" },
+  { value: "DeploymentRequiredInterface", label: "Required Interface" },
+]
 
 export const DeploymentEdgeEditPopover: React.FC<PopoverProps> = ({
   elementId,
@@ -25,13 +33,6 @@ export const DeploymentEdgeEditPopover: React.FC<PopoverProps> = ({
   const sourceName = (sourceNode?.data?.name as string) ?? "Source"
   const targetName = (targetNode?.data?.name as string) ?? "Target"
 
-  const deploymentEdgeTypeOptions = [
-    { value: "DeploymentAssociation", label: "Deployment Association" },
-    { value: "DeploymentDependency", label: "Deployment Dependency" },
-    { value: "DeploymentProvidedInterface", label: "Provided Interface" },
-    { value: "DeploymentRequiredInterface", label: "Required Interface" },
-  ]
-
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
       <EdgeStyleEditor
@@ -51,23 +52,11 @@ export const DeploymentEdgeEditPopover: React.FC<PopoverProps> = ({
           ),
         ]}
       />
-      {/* Edge type selection */}
-      <FormControl fullWidth size="small">
-        <InputLabel id="edge-type-label">Edge Type</InputLabel>
-        <Select
-          labelId="edge-type-label"
-          id="edge-type-select"
-          value={edge.type}
-          label="Edge Type"
-          onChange={(e) => handleEdgeTypeChange(e.target.value)}
-        >
-          {deploymentEdgeTypeOptions.map((option) => (
-            <MenuItem key={option.value} value={option.value}>
-              {option.label}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+      <EdgeTypeSelect
+        value={edge.type}
+        options={DEPLOYMENT_EDGE_TYPE_OPTIONS}
+        onChange={handleEdgeTypeChange}
+      />
 
       {/* Connection info */}
       <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>

--- a/library/lib/components/popovers/edgePopovers/EdgeTypePreviewIcon.tsx
+++ b/library/lib/components/popovers/edgePopovers/EdgeTypePreviewIcon.tsx
@@ -1,0 +1,106 @@
+import { Box } from "@mui/material"
+import {
+  extractMarkerId,
+  getMarkerHalfHeight,
+  InlineMarker,
+} from "@/components/svgs/edges"
+import { MARKER_CONFIGS, type MarkerId } from "@/constants"
+import { getEdgeMarkerStyles } from "@/utils/edgeUtils"
+
+// A miniature of how an edge type renders on the canvas, shown next to each
+// option in the edge-type dropdown. Markers reuse the canvas's own
+// `getEdgeMarkerStyles` + `InlineMarker`, so the glyphs can't drift from real
+// edges. The line only signals solid vs dashed — its dash pattern is sized for
+// the preview, not the canvas's pixel length.
+
+const VIEW_W = 56
+const VIEW_H = 28
+const MID_Y = VIEW_H / 2
+// Marker tips sit at END_X; arrow/triangle/rhombus grow leftward, the interface
+// socket rightward, so END_X leaves room both ways.
+const START_X = 6
+const END_X = 44
+// Largest marker half-height that fits the row with a little breathing room.
+const MAX_MARKER_HALF_HEIGHT = MID_Y - 3
+
+// Markers are sized for the canvas (the interface socket especially is
+// node-scale), so anything taller than the row is scaled down to fit.
+const fitScale = (markerId: MarkerId): number =>
+  Math.min(1, MAX_MARKER_HALF_HEIGHT / getMarkerHalfHeight(markerId))
+
+const toMarkerId = (raw: string | null): MarkerId | null =>
+  raw !== null && raw in MARKER_CONFIGS ? (raw as MarkerId) : null
+
+// Renders a marker at the given anchor, shrunk to fit the row. Scaling about
+// the anchor keeps the tip on the line.
+const FittedMarker = ({
+  markerId,
+  anchorX,
+  direction,
+}: {
+  markerId: MarkerId
+  anchorX: number
+  direction: number
+}) => {
+  const scale = fitScale(markerId)
+  const marker = (
+    <InlineMarker
+      endPoint={{ x: anchorX, y: MID_Y }}
+      direction={direction}
+      markerId={markerId}
+      strokeColor="currentColor"
+    />
+  )
+  if (scale === 1) return marker
+  return (
+    <g
+      transform={`translate(${anchorX} ${MID_Y}) scale(${scale}) translate(${-anchorX} ${-MID_Y})`}
+    >
+      {marker}
+    </g>
+  )
+}
+
+export const EdgeTypePreviewIcon = ({ edgeType }: { edgeType: string }) => {
+  const { markerEnd, markerStart, strokeDashArray } =
+    getEdgeMarkerStyles(edgeType)
+  const dashed = strokeDashArray !== undefined && strokeDashArray !== "0"
+  const endMarkerId = toMarkerId(extractMarkerId(markerEnd))
+  const startMarkerId = toMarkerId(extractMarkerId(markerStart))
+
+  return (
+    <Box
+      component="svg"
+      aria-hidden
+      focusable="false"
+      viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+      sx={{
+        width: VIEW_W,
+        height: VIEW_H,
+        flex: "0 0 auto",
+        overflow: "visible",
+      }}
+    >
+      <line
+        x1={START_X}
+        y1={MID_Y}
+        x2={END_X}
+        y2={MID_Y}
+        stroke="currentColor"
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeDasharray={dashed ? "4 3" : undefined}
+      />
+      {endMarkerId && (
+        <FittedMarker markerId={endMarkerId} anchorX={END_X} direction={0} />
+      )}
+      {startMarkerId && (
+        <FittedMarker
+          markerId={startMarkerId}
+          anchorX={START_X}
+          direction={Math.PI}
+        />
+      )}
+    </Box>
+  )
+}

--- a/library/lib/components/popovers/edgePopovers/EdgeTypeSelect.tsx
+++ b/library/lib/components/popovers/edgePopovers/EdgeTypeSelect.tsx
@@ -1,0 +1,58 @@
+import { useId } from "react"
+import { Box, FormControl, InputLabel, MenuItem, Select } from "@mui/material"
+import { EdgeTypePreviewIcon } from "./EdgeTypePreviewIcon"
+
+export interface EdgeTypeOption {
+  value: string
+  label: string
+}
+
+// Shared "Edge Type" dropdown; each option (and the collapsed selection)
+// previews how that type renders — see EdgeTypePreviewIcon.
+export const EdgeTypeSelect = ({
+  value,
+  options,
+  onChange,
+}: {
+  value?: string
+  options: ReadonlyArray<EdgeTypeOption>
+  onChange: (value: string) => void
+}) => {
+  const labelId = useId()
+  const selectedLabel = options.find((o) => o.value === value)?.label
+
+  return (
+    <FormControl fullWidth size="small">
+      <InputLabel id={labelId}>Edge Type</InputLabel>
+      <Select
+        labelId={labelId}
+        value={value ?? ""}
+        label="Edge Type"
+        onChange={(e) => onChange(e.target.value)}
+        renderValue={() => (
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <Box component="span">{selectedLabel}</Box>
+            {value && <EdgeTypePreviewIcon edgeType={value} />}
+          </Box>
+        )}
+      >
+        {options.map((option) => (
+          <MenuItem key={option.value} value={option.value}>
+            <Box
+              sx={{
+                alignItems: "center",
+                display: "flex",
+                gap: 2,
+                justifyContent: "space-between",
+                width: "100%",
+              }}
+            >
+              <Box component="span">{option.label}</Box>
+              <EdgeTypePreviewIcon edgeType={option.value} />
+            </Box>
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  )
+}

--- a/library/lib/components/popovers/edgePopovers/UseCaseDiagramEdgeEditPopover.tsx
+++ b/library/lib/components/popovers/edgePopovers/UseCaseDiagramEdgeEditPopover.tsx
@@ -1,10 +1,18 @@
-import { Box, FormControl, Select, MenuItem, InputLabel } from "@mui/material"
+import { Box } from "@mui/material"
 import { EdgeStyleEditor, TextField, Typography } from "@/components/ui"
 import { SwapHorizIcon } from "@/components/Icon"
 import { useReactFlow } from "@xyflow/react"
 import { CustomEdgeProps } from "@/edges/EdgeProps"
 import { useEdgePopOver } from "@/hooks"
 import { PopoverProps } from "../types"
+import { EdgeTypeSelect, EdgeTypeOption } from "./EdgeTypeSelect"
+
+const USE_CASE_EDGE_TYPE_OPTIONS: ReadonlyArray<EdgeTypeOption> = [
+  { value: "UseCaseAssociation", label: "Association" },
+  { value: "UseCaseInclude", label: "Include" },
+  { value: "UseCaseExtend", label: "Extend" },
+  { value: "UseCaseGeneralization", label: "Generalization" },
+]
 
 export const UseCaseEdgeEditPopover: React.FC<PopoverProps> = ({
   elementId,
@@ -24,13 +32,6 @@ export const UseCaseEdgeEditPopover: React.FC<PopoverProps> = ({
   const targetNode = getNode(edge.target)
   const sourceName = (sourceNode?.data?.name as string) ?? "Source"
   const targetName = (targetNode?.data?.name as string) ?? "Target"
-
-  const useCaseEdgeTypeOptions = [
-    { value: "UseCaseAssociation", label: "Association" },
-    { value: "UseCaseInclude", label: "Include" },
-    { value: "UseCaseExtend", label: "Extend" },
-    { value: "UseCaseGeneralization", label: "Generalization" },
-  ]
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
@@ -52,22 +53,11 @@ export const UseCaseEdgeEditPopover: React.FC<PopoverProps> = ({
         ]}
       />
 
-      <FormControl fullWidth size="small">
-        <InputLabel id="edge-type-label">Edge Type</InputLabel>
-        <Select
-          labelId="edge-type-label"
-          id="edge-type-select"
-          value={edge.type}
-          label="Edge Type"
-          onChange={(e) => handleEdgeTypeChange(e.target.value)}
-        >
-          {useCaseEdgeTypeOptions.map((option) => (
-            <MenuItem key={option.value} value={option.value}>
-              {option.label}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+      <EdgeTypeSelect
+        value={edge.type}
+        options={USE_CASE_EDGE_TYPE_OPTIONS}
+        onChange={handleEdgeTypeChange}
+      />
 
       {/* Connection info */}
       <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>

--- a/library/lib/components/svgs/edges/InlineMarker.tsx
+++ b/library/lib/components/svgs/edges/InlineMarker.tsx
@@ -36,6 +36,25 @@ const isMarkerId = (id: string): id is keyof typeof MARKER_CONFIGS =>
 const THEME_BACKGROUND_COLOR = "var(--apollon-background, #ffffff)"
 
 /**
+ * Native (canvas-scale) half-height of a marker's bounding box. The single
+ * place marker vertical extent is derived from MARKER_CONFIGS, so callers that
+ * place or scale a marker (e.g. inline dropdown previews) stay in sync with how
+ * `InlineMarker` actually draws it.
+ */
+export function getMarkerHalfHeight(markerId: keyof typeof MARKER_CONFIGS) {
+  const config = MARKER_CONFIGS[markerId]
+  if (config.type === "semicircle") {
+    const radius = INTERFACE.RADIUS + INTERFACE.SOCKET_GAP
+    // Once the arc spans past ±90° its extent is the full radius; clamp so a
+    // >180° arc (e.g. the three-quarter socket) isn't under-measured.
+    const span = Math.min(config.arcSpanDegrees ?? 180, 180)
+    return radius * Math.sin((span / 2) * (Math.PI / 180))
+  }
+  if (config.type === "circle") return config.size / 2
+  return (config.size * config.heightFactor) / 2
+}
+
+/**
  * Extract marker ID from a url() reference.
  * e.g., "url(#black-arrow)" -> "black-arrow"
  *

--- a/library/lib/components/ui/StyleEditor/EdgeStyleEditor.tsx
+++ b/library/lib/components/ui/StyleEditor/EdgeStyleEditor.tsx
@@ -108,7 +108,9 @@ export const EdgeStyleEditor: React.FC<EdgeStyleEditorProps> = ({
             aria-label="Toggle color settings"
           />
           {sideElements.map((element, index) => (
-            <React.Fragment key={index}>{element}</React.Fragment>
+            <React.Fragment key={`side-element-${index}`}>
+              {element}
+            </React.Fragment>
           ))}
         </div>
       </div>
@@ -117,7 +119,7 @@ export const EdgeStyleEditor: React.FC<EdgeStyleEditorProps> = ({
         <div style={styles.colorPanel}>
           {!activeColorField ? (
             colorFields.map(({ key, label }) => (
-              <React.Fragment key={`${edgeData?.label}-${key}`}>
+              <React.Fragment key={key}>
                 <ColorOption
                   label={label}
                   color={edgeData ? edgeData[key] : undefined}

--- a/library/lib/components/ui/StyleEditor/EdgeStyleEditor.tsx
+++ b/library/lib/components/ui/StyleEditor/EdgeStyleEditor.tsx
@@ -107,7 +107,9 @@ export const EdgeStyleEditor: React.FC<EdgeStyleEditorProps> = ({
             onClick={() => setPaintOpen(!paintOpen)}
             aria-label="Toggle color settings"
           />
-          {sideElements}
+          {sideElements.map((element, index) => (
+            <React.Fragment key={index}>{element}</React.Fragment>
+          ))}
         </div>
       </div>
 
@@ -115,9 +117,8 @@ export const EdgeStyleEditor: React.FC<EdgeStyleEditorProps> = ({
         <div style={styles.colorPanel}>
           {!activeColorField ? (
             colorFields.map(({ key, label }) => (
-              <>
+              <React.Fragment key={`${edgeData?.label}-${key}`}>
                 <ColorOption
-                  key={`${edgeData?.label}-${key}-option`}
                   label={label}
                   color={edgeData ? edgeData[key] : undefined}
                   onSelect={() => toggleColorField(key)}
@@ -125,7 +126,7 @@ export const EdgeStyleEditor: React.FC<EdgeStyleEditorProps> = ({
                 {key !== colorFields[colorFields.length - 1].key && (
                   <DividerLine backgroundColor="var(--apollon-gray, #e9ecef)" />
                 )}
-              </>
+              </React.Fragment>
             ))
           ) : (
             <div

--- a/library/tests/unit/EdgeTypePreviewIcon.test.tsx
+++ b/library/tests/unit/EdgeTypePreviewIcon.test.tsx
@@ -1,0 +1,56 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { EdgeTypePreviewIcon } from "@/components/popovers/edgePopovers/EdgeTypePreviewIcon"
+
+// The type -> marker/dash mapping is covered by edgeUtils.test.ts. These tests
+// cover the rendering layer it adds: dash-attribute translation, marker
+// presence, that hollow vs filled markers stay visually distinct, and that the
+// oversized interface socket is scaled down to fit.
+
+const renderIcon = (edgeType: string) => {
+  const { container } = render(<EdgeTypePreviewIcon edgeType={edgeType} />)
+  return container.querySelector("svg") as SVGSVGElement
+}
+
+describe("EdgeTypePreviewIcon", () => {
+  it("draws a solid line for solid edge types", () => {
+    const line = renderIcon("ClassBidirectional").querySelector("line")
+    expect(line?.getAttribute("stroke-dasharray")).toBeNull()
+  })
+
+  it("draws a dashed line for dashed edge types", () => {
+    const line = renderIcon("ClassDependency").querySelector("line")
+    expect(line?.getAttribute("stroke-dasharray")).toBe("4 3")
+  })
+
+  it("renders an end marker only when the type has one", () => {
+    expect(
+      renderIcon("ClassBidirectional").querySelectorAll("path")
+    ).toHaveLength(0)
+    expect(
+      renderIcon("ClassInheritance").querySelectorAll("path").length
+    ).toBeGreaterThan(0)
+  })
+
+  it("renders both start and end markers (BPMN message flow)", () => {
+    const svg = renderIcon("BPMNMessageFlow")
+    expect(svg.querySelector("circle")).not.toBeNull()
+    expect(svg.querySelector("path")).not.toBeNull()
+  })
+
+  it("keeps hollow and filled markers distinct (aggregation vs composition)", () => {
+    // The hollow/filled diamond is the only thing telling these two apart.
+    const hollow = renderIcon("ClassAggregation").querySelector("path")
+    const filled = renderIcon("ClassComposition").querySelector("path")
+    expect(hollow?.getAttribute("fill")).not.toBe(filled?.getAttribute("fill"))
+  })
+
+  it("scales the oversized interface socket down to fit, but not small markers", () => {
+    expect(
+      renderIcon("ComponentRequiredInterface").querySelector("g[transform]")
+    ).not.toBeNull()
+    expect(
+      renderIcon("ClassUnidirectional").querySelector("g[transform]")
+    ).toBeNull()
+  })
+})

--- a/standalone/webapp/src/webapp.css
+++ b/standalone/webapp/src/webapp.css
@@ -42,7 +42,6 @@ body {
   flex-grow: 1;
   /* background-color: var(--apollon-background); */
   height: 100%;
-
 }
 
 .apollon-editor {
@@ -70,4 +69,10 @@ body {
 
 .MuiMenu-list .MuiMenuItem-root.Mui-selected:hover {
   background-color: var(--apollon-gray) !important;
+}
+
+/* Keep notifications above Apollon's collaboration presence/cursor overlays. */
+.Toastify__toast-container {
+  --toastify-z-index: 10005;
+  z-index: 10005;
 }

--- a/standalone/webapp/src/webapp.css
+++ b/standalone/webapp/src/webapp.css
@@ -42,6 +42,7 @@ body {
   flex-grow: 1;
   /* background-color: var(--apollon-background); */
   height: 100%;
+
 }
 
 .apollon-editor {
@@ -69,10 +70,4 @@ body {
 
 .MuiMenu-list .MuiMenuItem-root.Mui-selected:hover {
   background-color: var(--apollon-gray) !important;
-}
-
-/* Keep notifications above Apollon's collaboration presence/cursor overlays. */
-.Toastify__toast-container {
-  --toastify-z-index: 10005;
-  z-index: 10005;
 }


### PR DESCRIPTION
### Summary

The "Edge Type" dropdown in the edge-edit popover now shows a small preview of how each option actually renders — the real line style (solid/dashed) and end/start markers — so you can pick the right relationship by sight instead of decoding names. The selected type is also previewed in the collapsed dropdown.

This started as class-diagram-only; it now covers every edge popover that offers a type choice: **class, component, deployment, use case, and BPMN**.

| Before | After |
| --- | --- |
| Type names only | Each option shows its authentic edge preview |

### Implementation notes

- **Single source of truth — previews can't drift from edges.** Each preview derives its line dash and markers from `getEdgeMarkerStyles(edgeType)` (the same mapping the canvas uses) and draws them with the real `InlineMarker` component, rather than hand-drawing SVG paths. So the dropdown glyph is the same shape/fill the canvas paints.
- **Shared component.** A new `EdgeTypeSelect` replaces the duplicated `FormControl`/`Select` boilerplate that previously lived in all five popovers; `EdgeTypePreviewIcon` renders the preview.
- **Fit-to-row scaling.** Node-scale markers (the interface socket) are scaled down to fit the menu row, anchored at the tip so they stay on the line. Marker vertical extent is computed once, next to the renderer (`getMarkerHalfHeight`), so it can't desync.
- **Authentic by design.** Provided-interface previews render as a plain line because the lollipop ball is a separate node, not an edge marker — the preview reflects what the edge itself draws. Use case include/extend share a glyph because they differ only by stereotype text on the canvas too; the label disambiguates.
- **Scope cleanup.** The unrelated toast `z-index` change in `standalone/webapp/src/webapp.css` was reverted out of this PR. That removes the Codacy failure on that file **and** keeps the changeset correctly scoped to `@tumaet/apollon` only. The toast fix can land as its own focused PR.
- Also fixes the React key warnings in `EdgeStyleEditor` (keyed fragments for `sideElements`/`colorFields`), matching `NodeStyleEditor`.

### Steps for testing

1. Open a **Class** diagram, connect two classes, and edit the edge — the "Edge Type" dropdown shows a preview next to each option (hollow vs filled diamond, hollow triangle, dashed dependency/realization, …).
2. Repeat in **Component**, **Deployment**, **Use Case**, and **BPMN** diagrams.
3. Toggle dark mode — markers use `currentColor` and stay legible.

### Screenshots / screencasts

<img width="229" height="384" alt="Class diagram edge type previews" src="https://github.com/user-attachments/assets/290e1b47-f53d-450f-a1fa-ffcfa7145d36" />

### Checklist

- [ ] Linked to a related issue (if applicable)
- [x] Added a changeset (`pnpm changeset`, [how](https://ls1intum.github.io/Apollon/contributor/development/release-notes/))
- [x] Tests added or updated
- [ ] Documentation updated (if applicable)
- [x] Screenshots or screencasts attached (if a UI change)
