### PR TITLE
chore(deps): stop Mend Bolt from opening per-vulnerability issues

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -8,7 +8,7 @@
     "useMendCheckNames": true
   },
   "issueSettings": {
-    "minSeverityLevel": "LOW",
+    "minSeverityLevel": "NONE",
     "issueType": "DEPENDENCY"
   }
 }


### PR DESCRIPTION
## What

Sets `issueSettings.minSeverityLevel` to `NONE` in `.whitesource`, which stops Mend Bolt from opening a GitHub issue per vulnerable dependency.

## Why

We already run Renovate (`renovate.json`) in dashboard mode, and it handles security updates through `vulnerabilityAlerts`. Running Mend Bolt alongside it means two tools doing the same job, with Mend only adding issue noise. As of now that is 13 open Mend issues (#573, #589, #635, #636, #638, #641, #644, #664, #684, #696, #698, #746, #747).

The recommended way to disable Mend's issue creation is to set `minSeverityLevel` to `NONE` ([Mend docs](https://docs.mend.io/integrations/latest/mend-bolt-for-github)). The change only takes effect once it is on the default branch.

## Notes

- Renovate keeps surfacing and fixing vulnerable dependencies, so nothing is lost on the security side.
- For a full removal (including Mend's PR check-runs), the Mend Bolt GitHub App can also be uninstalled from the repo settings. This PR is the in-repo fix that works regardless.
- I will close the existing Mend issues once this is reviewed.
