### PR TITLE
chore: use native issue types in templates, add feature request form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,51 +1,72 @@
 name: 🐛 Bug report
-description: Something on Apollon is not working as expected? Create a report to help us improve.
+description: Something in Apollon is not working as expected? Let us know so we can fix it.
 type: Bug
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. A clear, reproducible report helps us fix it much faster.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched the existing issues and discussions and did not find a duplicate.
+          required: true
+        - label: I can reproduce this on the live demo (https://apollon.aet.cit.tum.de) or the latest `@tumaet/apollon`.
+          required: false
+
   - type: textarea
     id: description
     attributes:
       label: Describe the bug
       description: A clear and concise description of what the bug is.
-      placeholder: Describe the issue here...
+      placeholder: When I ..., Apollon ...
     validations:
       required: true
 
   - type: textarea
     id: steps
     attributes:
-      label: To Reproduce
-      description: Steps to reproduce the behavior.
+      label: Steps to reproduce
+      description: Steps for us to reproduce the behaviour. A sample diagram (File → Export → JSON) is very helpful.
       placeholder: |
         1. Go to '...'
         2. Click on '...'
-        3. Scroll to '...'
-        4. See error
+        3. See the error
     validations:
       required: true
 
   - type: textarea
     id: expected
     attributes:
-      label: Expected behavior
-      description: A clear and concise description of what you expected to happen.
-      placeholder: What should have happened?
+      label: Expected behaviour
+      description: What did you expect to happen instead?
     validations:
       required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of Apollon is affected? (We will confirm during triage.)
+      options:
+        - Editor library
+        - Standalone web app
+        - VS Code extension
+        - Documentation
+        - Realtime collaboration
+        - Mobile
+        - Not sure
+    validations:
+      required: false
 
   - type: textarea
     id: screenshots
     attributes:
-      label: Screenshots
-      description: If applicable, add screenshots to help explain your problem.
-      placeholder: Drag & drop or paste images here.
-
-  - type: input
-    id: os
-    attributes:
-      label: OS
-      description: Operating System
-      placeholder: e.g. iOS, macOS, Windows
+      label: Screenshots or recording
+      description: If it helps explain the problem, drag and drop images or a short screen recording here.
     validations:
       required: false
 
@@ -53,27 +74,32 @@ body:
     id: browser
     attributes:
       label: Browser
-      placeholder: e.g. Chrome, Safari, Firefox
+      placeholder: e.g. Chrome 126, Safari 17, Firefox 127
+    validations:
+      required: false
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: e.g. macOS 14, Windows 11, iOS 17
     validations:
       required: false
 
   - type: input
     id: version
     attributes:
-      label: Version
-      placeholder: e.g. 22
+      label: Apollon version
+      description: If you embed the `@tumaet/apollon` library, which version? (Skip if you used the live demo.)
+      placeholder: e.g. 4.6.0
     validations:
       required: false
 
   - type: textarea
-    id: context
-    attributes:
-      label: Additional context
-      description: Add any other context about the problem here.
-
-  - type: textarea
     id: console
     attributes:
-      label: Web Console Output
-      description: If applicable, copy output from the Web Console.
+      label: Browser console output
+      description: If there are errors, copy them from the browser dev tools console.
       render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,6 @@
 name: 🐛 Bug report
 description: Something on Apollon is not working as expected? Create a report to help us improve.
-title: "[BUG] "
-labels: ["bug"]
+type: Bug
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Questions & ideas
+    url: https://github.com/ls1intum/Apollon/discussions
+    about: Have a question or an idea to discuss? Start a discussion here.
+  - name: ▶ Try the live demo
+    url: https://apollon.aet.cit.tum.de
+    about: Try Apollon in your browser.
+  - name: 📖 Documentation
+    url: https://ls1intum.github.io/Apollon/
+    about: Guides, API reference, and embedding examples.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,14 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
-  - name: 💬 Questions & ideas
+  - name: 💬 Questions & ideas (Discussions)
     url: https://github.com/ls1intum/Apollon/discussions
-    about: Have a question or an idea to discuss? Start a discussion here.
+    about: Have a question or want to discuss an idea before filing? Start here.
   - name: ▶ Try the live demo
     url: https://apollon.aet.cit.tum.de
-    about: Try Apollon in your browser.
+    about: Reproduce or explore the editor in your browser.
   - name: 📖 Documentation
     url: https://ls1intum.github.io/Apollon/
     about: Guides, API reference, and embedding examples.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/ls1intum/Apollon/security/advisories/new
+    about: Please report security issues privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,19 @@ name: 💡 Feature request
 description: Suggest an idea or new capability for Apollon.
 type: Feature
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing an idea. Tell us about the problem first and the solution second — it helps us understand the need even if we end up solving it differently.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched the existing issues and discussions and did not find a duplicate.
+          required: true
+
   - type: textarea
     id: problem
     attributes:
@@ -15,7 +28,7 @@ body:
     id: proposal
     attributes:
       label: Proposed solution
-      description: What would you like to see? Describe the behaviour or feature you have in mind.
+      description: What would you like to see? Describe the behaviour or capability you have in mind.
       placeholder: It would help if Apollon could ...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: 💡 Feature request
+description: Suggest an idea or new capability for Apollon.
+type: Feature
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: What are you trying to do, and where does Apollon get in the way today?
+      placeholder: I'm trying to ... but ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? Describe the behaviour or feature you have in mind.
+      placeholder: It would help if Apollon could ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or other approaches you have thought about.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of Apollon does this relate to? (We will confirm during triage.)
+      options:
+        - Editor library
+        - Standalone web app
+        - VS Code extension
+        - Documentation
+        - Realtime collaboration
+        - Mobile
+        - Not sure
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, links, or anything else that helps explain the idea.
+    validations:
+      required: false


### PR DESCRIPTION
## What

Moves the issue templates onto GitHub's native **Issue Types** and adds a feature-request form.

- **`bug-report.yml`**: drops the `[BUG] ` title prefix and the `bug` label, and sets `type: Bug` instead.
- **`feature_request.yml`**: new form, sets `type: Feature`, with fields for the problem, proposal, alternatives, area, and context.
- **`config.yml`**: routes questions and ideas to Discussions, and links the live demo and docs from the new-issue chooser.

## Why

We retired the `bug` and `enhancement` labels in favour of native Issue Types (Bug / Feature / Task), so type now lives in one place. The `[BUG] ` prefix is redundant once the type is set, and a bit noisy in titles. This keeps new issues consistent with that.

## Note

The open issues have already been given their types and area labels directly. This PR only updates the templates so new issues follow the same convention.
