### PR TITLE
feat(library): restore per-element highlighting via setElementHighlights

### DIFF
--- a/.changeset/highlight-elements-api.md
+++ b/.changeset/highlight-elements-api.md
@@ -1,0 +1,21 @@
+---
+"@tumaet/apollon": minor
+---
+
+feat: add `ApollonEditor.setElementHighlights()` for host-driven element highlighting
+
+Restores the per-element highlight capability that v3 exposed via the
+`UMLModelElement.highlight` field and `ApollonEditor.select()`, both of which
+were dropped in the v4 rewrite. Hosting apps (e.g. Artemis marking elements
+that are missing assessment feedback, or Athena marking elements that have
+automatic-feedback suggestions) can now call:
+
+```ts
+editor.setElementHighlights(new Map([["element-id", "rgba(23,162,184,0.3)"]]))
+editor.setElementHighlights(null) // clear
+```
+
+The highlight is a translucent overlay painted over each given node, edge, or
+class member id. It is an ephemeral view concern: it is not written into the
+model, not serialized by `get model`, and not shared with collaborators. A
+companion `getElementHighlights()` returns the current highlight record.

--- a/docs/library/api.md
+++ b/docs/library/api.md
@@ -162,10 +162,12 @@ Every field is optional.
 
 ### Assessment
 
-| Member                              | Type                               | Purpose                                                     |
-| ----------------------------------- | ---------------------------------- | ----------------------------------------------------------- |
-| `addOrUpdateAssessment(assessment)` | `(Assessment) => void`             | Attach or update a score/feedback assessment on an element. |
-| `getInteractiveForSerialization()`  | `InteractiveElements \| undefined` | Interactive-element flags for inclusion in a saved model.   |
+| Member                              | Type                                                              | Purpose                                                                                                                                                                                                                                                                                                                         |
+| ----------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `addOrUpdateAssessment(assessment)` | `(Assessment) => void`                                            | Attach or update a score/feedback assessment on an element.                                                                                                                                                                                                                                                                     |
+| `setElementHighlights(highlights)`  | `(Map<string, string> \| Record<string, string> \| null) => void` | Paint a translucent highlight overlay over the given element ids (id → CSS color) — e.g. to flag elements missing feedback or carrying suggestions. Host-driven and ephemeral: never written to the model, serialized, or shared with collaborators. Each call replaces the previous set; pass `null` or an empty map to clear. |
+| `getElementHighlights()`            | `() => Record<string, string>`                                    | The current highlight map (element id → CSS color).                                                                                                                                                                                                                                                                             |
+| `getInteractiveForSerialization()`  | `InteractiveElements \| undefined`                                | Interactive-element flags for inclusion in a saved model.                                                                                                                                                                                                                                                                       |
 
 ## Subscriptions
 

--- a/library/lib/apollon-editor.tsx
+++ b/library/lib/apollon-editor.tsx
@@ -687,6 +687,40 @@ export class ApollonEditor {
       .updateMetaData(model.title, parseDiagramType(model.type))
   }
 
+  /**
+   * Host-driven element highlighting. Paints a translucent overlay over each
+   * given node / edge / class-member id in the supplied CSS color — the v4
+   * replacement for v3's `UMLModelElement.highlight` field and
+   * `ApollonEditor.select()`. Typical hosts: an assessment editor marking
+   * elements that are missing feedback, or Athena marking elements that have
+   * automatic-feedback suggestions.
+   *
+   * The highlight is an ephemeral view overlay: it is NOT written into the
+   * model, NOT serialized by `get model`, and NOT shared with collaborators.
+   * Each call replaces the previous highlight set; pass `null` (or an empty
+   * map) to clear all highlights. Passing `undefined` is a no-op.
+   *
+   * @param highlights map / record of element id -> CSS color (any valid CSS
+   *   color string, e.g. `"rgba(23,162,184,0.3)"`), or `null` to clear.
+   */
+  public setElementHighlights(
+    highlights: Map<string, string> | Record<string, string> | null | undefined
+  ): void {
+    if (highlights === undefined) return
+    const record =
+      highlights === null
+        ? {}
+        : Object.fromEntries(
+            highlights instanceof Map ? highlights : Object.entries(highlights)
+          )
+    this.assessmentSelectionStore.getState().setElementHighlights(record)
+  }
+
+  /** Returns a copy of the current highlight record (id -> CSS color). */
+  public getElementHighlights(): Record<string, string> {
+    return { ...this.assessmentSelectionStore.getState().highlightedElements }
+  }
+
   public getSelectedElements(): string[] {
     const { mode, readonly } = this.metadataStore.getState()
     if (mode === Apollon.ApollonMode.Assessment && readonly) {

--- a/library/lib/components/AssessmentSelectableElement.tsx
+++ b/library/lib/components/AssessmentSelectableElement.tsx
@@ -1,6 +1,10 @@
 import { INTERACTIVE_SELECTION_COLOR } from "@/constants"
 import { useAssessmentSelection } from "@/hooks"
-import { useDiagramStore, useMetadataStore } from "@/store"
+import {
+  useAssessmentSelectionStore,
+  useDiagramStore,
+  useMetadataStore,
+} from "@/store"
 import { ApollonMode, ApollonView } from "@/typings"
 import { FC } from "react"
 import { useShallow } from "zustand/shallow"
@@ -41,6 +45,25 @@ export const AssessmentSelectableElement: FC<
     handleElementMouseEnter,
     handleElementMouseLeave,
   } = useAssessmentSelection(elementId)
+
+  // Host-driven highlight overlay rect (see `highlightedElements` in the store).
+  const highlightColor = useAssessmentSelectionStore(
+    (state) => state.highlightedElements[elementId]
+  )
+  const highlightRect = highlightColor ? (
+    <rect
+      aria-hidden
+      x={0}
+      y={yOffset}
+      width={width}
+      height={itemHeight}
+      fill={highlightColor}
+      stroke={highlightColor}
+      strokeWidth={1}
+      rx={2}
+      pointerEvents="none"
+    />
+  ) : null
 
   const showInteractiveInteraction =
     mode === ApollonMode.Modelling &&
@@ -83,7 +106,12 @@ export const AssessmentSelectableElement: FC<
   }
 
   if (!showAssessmentInteraction) {
-    return <g data-apollon-element-id={elementId}>{children}</g>
+    return (
+      <g data-apollon-element-id={elementId}>
+        {children}
+        {highlightRect}
+      </g>
+    )
   }
 
   const handleSVGClick = (e: React.PointerEvent<SVGGElement>) => {
@@ -118,6 +146,9 @@ export const AssessmentSelectableElement: FC<
           pointerEvents="none"
         />
       )}
+      {/* Host highlight paints last, over the selection rect, matching the
+          div wrapper's layering invariant (host overlay on top). */}
+      {highlightRect}
     </g>
   )
 }

--- a/library/lib/components/wrapper/AssessmentSelectableWrapper.tsx
+++ b/library/lib/components/wrapper/AssessmentSelectableWrapper.tsx
@@ -4,7 +4,11 @@ import {
   INTERACTIVE_SELECTION_FILL,
 } from "@/constants"
 import { useAssessmentSelection } from "@/hooks/useAssessmentSelection"
-import { useDiagramStore, useMetadataStore } from "@/store"
+import {
+  useAssessmentSelectionStore,
+  useDiagramStore,
+  useMetadataStore,
+} from "@/store"
 import { ApollonMode, ApollonView } from "@/typings"
 import { useShallow } from "zustand/shallow"
 
@@ -49,6 +53,31 @@ export const AssessmentSelectableWrapper: React.FC<
     mode === ApollonMode.Modelling &&
     view === ApollonView.Highlight &&
     !readonly
+
+  // Host-driven highlight (assessment "missing feedback" / Athena suggestions):
+  // a translucent tint + ring over div-wrapped nodes, a stroke glow over
+  // g-wrapped edges. Rendered wherever elements are displayed or assessed — not
+  // in the quiz interactive-element picker (ApollonView.Highlight), which the
+  // assessment hosts never enter.
+  const highlightColor = useAssessmentSelectionStore(
+    (state) => state.highlightedElements[elementId]
+  )
+  const highlightDivOverlay = highlightColor ? (
+    <div
+      aria-hidden
+      style={{
+        position: "absolute",
+        inset: 0,
+        backgroundColor: highlightColor,
+        boxShadow: `0 0 0 2px ${highlightColor}`,
+        borderRadius: 2,
+        pointerEvents: "none",
+      }}
+    />
+  ) : null
+  const highlightEdgeFilter = highlightColor
+    ? `drop-shadow(0 0 2px ${highlightColor}) drop-shadow(0 0 2px ${highlightColor})`
+    : undefined
 
   if (showInteractiveInteraction) {
     const handleInteractiveClick = (event: React.PointerEvent) => {
@@ -103,11 +132,33 @@ export const AssessmentSelectableWrapper: React.FC<
   }
 
   if (!showAssessmentInteraction) {
-    return <>{children}</>
+    // No host highlight is the hot path (99% of renders): return a zero-box
+    // Fragment so ordinary modelling/editing pays no extra DOM/layout cost.
+    if (!highlightColor) return <>{children}</>
+    if (asElement == "g") {
+      return (
+        <g
+          data-apollon-element-id={elementId}
+          style={{ filter: highlightEdgeFilter }}
+        >
+          {children}
+        </g>
+      )
+    }
+    // A bare relative box is layout-neutral but gives the absolutely-positioned
+    // overlay a containing block anchored to the node content box (like every
+    // other branch).
+    return (
+      <div data-apollon-element-id={elementId} style={{ position: "relative" }}>
+        {children}
+        {highlightDivOverlay}
+      </div>
+    )
   }
 
   const combinedStyle: React.CSSProperties = {
     cursor: "pointer",
+    ...(highlightColor && { position: "relative" }),
     ...(isSelected && {
       backgroundColor: "rgba(25, 118, 210, 0.2)",
       border: "2px solid #1976d2",
@@ -122,6 +173,7 @@ export const AssessmentSelectableWrapper: React.FC<
   if (asElement == "g") {
     const gStyle = {
       cursor: "pointer",
+      ...(highlightColor && { filter: highlightEdgeFilter }),
       ...(isSelected && {
         stroke: "rgba(25, 118, 210, 0.2)",
       }),
@@ -154,6 +206,7 @@ export const AssessmentSelectableWrapper: React.FC<
       onMouseLeave={handleElementMouseLeave}
     >
       {children}
+      {highlightDivOverlay}
     </div>
   )
 }

--- a/library/lib/store/assessmentSelectionStore.ts
+++ b/library/lib/store/assessmentSelectionStore.ts
@@ -8,6 +8,13 @@ export type AssessmentSelectionStore = {
   highlightedElementId: string | null
   // Whether assessment selection mode is active
   isAssessmentSelectionMode: boolean
+  // Host-driven highlight overlays: element id -> CSS color. Used by hosting
+  // apps (e.g. assessment "missing feedback" or Athena suggestion overlays)
+  // to tint specific nodes / edges / class members. This is an ephemeral view
+  // concern — it is NOT part of the model, never serialized, and never shared
+  // with collaborators. It is the v4 replacement for the v3
+  // `UMLModelElement.highlight` field + `ApollonEditor.select()` API.
+  highlightedElements: Record<string, string>
 
   // Actions
   setAssessmentSelectionMode: (isActive: boolean) => void
@@ -15,6 +22,7 @@ export type AssessmentSelectionStore = {
   selectMultipleElements: (elementIds: string[]) => void
   clearSelection: () => void
   setHighlightedElement: (elementId: string | null) => void
+  setElementHighlights: (highlights: Record<string, string>) => void
   isElementSelected: (elementId: string) => boolean
   isElementHighlighted: (elementId: string) => boolean
   reset: () => void
@@ -24,12 +32,14 @@ type InitialAssessmentSelectionState = {
   selectedElementIds: string[]
   highlightedElementId: string | null
   isAssessmentSelectionMode: boolean
+  highlightedElements: Record<string, string>
 }
 
 const initialAssessmentSelectionState: InitialAssessmentSelectionState = {
   selectedElementIds: [],
   highlightedElementId: null,
   isAssessmentSelectionMode: false,
+  highlightedElements: {},
 }
 
 export const createAssessmentSelectionStore = (): UseBoundStore<
@@ -77,6 +87,14 @@ export const createAssessmentSelectionStore = (): UseBoundStore<
             { highlightedElementId: elementId },
             undefined,
             "setHighlightedElement"
+          )
+        },
+
+        setElementHighlights: (highlights: Record<string, string>) => {
+          set(
+            { highlightedElements: highlights },
+            undefined,
+            "setElementHighlights"
           )
         },
 

--- a/library/tests/unit/assessmentSelectionStore.test.ts
+++ b/library/tests/unit/assessmentSelectionStore.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { createAssessmentSelectionStore } from "@/store/assessmentSelectionStore"
+import { ApollonEditor } from "@/apollon-editor"
+
+describe("assessmentSelectionStore host-driven highlights", () => {
+  let store: ReturnType<typeof createAssessmentSelectionStore>
+
+  beforeEach(() => {
+    store = createAssessmentSelectionStore()
+  })
+
+  it("starts with an empty highlight map", () => {
+    expect(store.getState().highlightedElements).toEqual({})
+  })
+
+  it("setElementHighlights replaces the whole map", () => {
+    store.getState().setElementHighlights({
+      "node-1": "rgba(23,162,184,0.3)",
+      "edge-2": "rgba(219,53,69,0.6)",
+    })
+    expect(store.getState().highlightedElements).toEqual({
+      "node-1": "rgba(23,162,184,0.3)",
+      "edge-2": "rgba(219,53,69,0.6)",
+    })
+
+    // A subsequent call replaces rather than merges.
+    store.getState().setElementHighlights({ "node-3": "#ff0000" })
+    expect(store.getState().highlightedElements).toEqual({
+      "node-3": "#ff0000",
+    })
+
+    // An empty map clears all highlights.
+    store.getState().setElementHighlights({})
+    expect(store.getState().highlightedElements).toEqual({})
+  })
+
+  it("host highlights are independent of selection state", () => {
+    store.getState().setElementHighlights({ "node-1": "#ff0000" })
+    store.getState().selectMultipleElements(["node-1", "node-2"])
+    store.getState().setHighlightedElement("node-2")
+
+    // Toggling assessment-selection mode off clears the interactive selection
+    // and hover, but must NOT wipe the host-driven highlight overlay.
+    store.getState().setAssessmentSelectionMode(false)
+
+    const state = store.getState()
+    expect(state.selectedElementIds).toEqual([])
+    expect(state.highlightedElementId).toBeNull()
+    expect(state.highlightedElements).toEqual({ "node-1": "#ff0000" })
+  })
+
+  it("reset clears host highlights along with the rest of the state", () => {
+    store.getState().setElementHighlights({ "node-1": "#ff0000" })
+    store.getState().reset()
+    expect(store.getState().highlightedElements).toEqual({})
+  })
+})
+
+describe("ApollonEditor host-driven highlight API", () => {
+  let container: HTMLElement
+  let editor: ApollonEditor
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    editor = new ApollonEditor(container)
+  })
+
+  afterEach(() => {
+    editor.destroy()
+    container.remove()
+  })
+
+  it("normalizes a Map input to a Record", () => {
+    const map = new Map([
+      ["node-1", "#ff0000"],
+      ["edge-2", "#00ff00"],
+    ])
+    editor.setElementHighlights(map)
+    expect(editor.getElementHighlights()).toEqual({
+      "node-1": "#ff0000",
+      "edge-2": "#00ff00",
+    })
+  })
+
+  it("isolates stored highlights from the caller's input and returned snapshot", () => {
+    // Map and Record inputs share one normalization path, so a single input
+    // type exercises the defensive copy on the way in...
+    const input = new Map([["node-1", "#ff0000"]])
+    editor.setElementHighlights(input)
+    input.set("node-1", "tampered")
+    expect(editor.getElementHighlights()).toEqual({ "node-1": "#ff0000" })
+
+    // ...and the getter must hand back an independent copy on the way out.
+    const snapshot = editor.getElementHighlights()
+    snapshot["node-1"] = "tampered"
+    expect(editor.getElementHighlights()).toEqual({ "node-1": "#ff0000" })
+  })
+
+  it("clears on null but treats undefined as a no-op", () => {
+    editor.setElementHighlights({ "node-1": "#ff0000" })
+    editor.setElementHighlights(null)
+    expect(editor.getElementHighlights()).toEqual({})
+
+    editor.setElementHighlights({ "node-1": "#ff0000" })
+    editor.setElementHighlights(undefined)
+    expect(editor.getElementHighlights()).toEqual({ "node-1": "#ff0000" })
+  })
+})

--- a/standalone/webapp/src/pages/ApollonLocal.tsx
+++ b/standalone/webapp/src/pages/ApollonLocal.tsx
@@ -77,9 +77,22 @@ export const ApollonLocal: React.FC = () => {
 
     setEditor(instance)
 
+    // E2E seam (dev builds only — `import.meta.env.DEV` is statically false in
+    // production, so this is dead-code-eliminated from the shipped bundle).
+    // Exposes the imperative editor so Playwright can drive API surfaces that
+    // have no UI affordance, e.g. `setElementHighlights`.
+    if (import.meta.env.DEV) {
+      ;(window as Window & { apollonEditor?: ApollonEditor }).apollonEditor =
+        instance
+    }
+
     return () => {
       isThumbnailExportCanceledRef.current = true
       thumbnailExportSequenceRef.current += 1
+      if (import.meta.env.DEV) {
+        delete (window as Window & { apollonEditor?: ApollonEditor })
+          .apollonEditor
+      }
       if (thumbnailExportTimeoutRef.current) {
         clearTimeout(thumbnailExportTimeoutRef.current)
         thumbnailExportTimeoutRef.current = null

--- a/standalone/webapp/tests/e2e/highlight.spec.ts
+++ b/standalone/webapp/tests/e2e/highlight.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+import { openFixtureInLocalEditor, waitForCanvasReady } from "../helpers/canvas"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+/**
+ * E2E coverage for the host-driven highlight API
+ * (`ApollonEditor.setElementHighlights`). The v4 rewrite dropped v3's
+ * per-element `highlight` field, so this asserts the real-browser behaviour
+ * the unit test can't: that a highlight actually paints an overlay onto a
+ * rendered node and a class member, and that clearing it removes the overlay.
+ *
+ * The editor instance is reached through the dev-only `window.apollonEditor`
+ * seam set in ApollonLocal; the API itself has no UI affordance to click.
+ */
+
+function loadFixture(name: string) {
+  return JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "fixtures", name), "utf-8")
+  ) as Record<string, unknown>
+}
+
+const fixture = loadFixture("two-class-close.json")
+const edgeFixture = loadFixture("two-class-fresh-edge.json")
+
+// Stable ids from the fixture: a whole class node and one of its attributes.
+const NODE_ID = "95aac2b6-3e6b-4e6d-9201-52a498e6ea20"
+const ATTRIBUTE_ID = "3ff22a38-2fb9-4009-8d62-1027d24581f7"
+// Stable id from the edge fixture: the single relationship/edge.
+const EDGE_ID = "231f7ef5-b43d-4187-8996-f7726ed6e919"
+const COLOR = "rgba(23, 162, 184, 0.3)"
+
+function setHighlights(record: Record<string, string> | null) {
+  const editor = (
+    window as Window & {
+      apollonEditor?: { setElementHighlights: (h: unknown) => void }
+    }
+  ).apollonEditor
+  editor?.setElementHighlights(record)
+}
+
+test.describe("host-driven element highlighting", () => {
+  test.beforeEach(async ({ page }) => {
+    await openFixtureInLocalEditor(page, fixture)
+    await waitForCanvasReady(page)
+    await page.waitForFunction(() =>
+      Boolean((window as unknown as { apollonEditor?: unknown }).apollonEditor)
+    )
+  })
+
+  test("paints a node overlay and removes it when cleared", async ({
+    page,
+  }) => {
+    const overlay = page.locator(
+      `[data-apollon-element-id="${NODE_ID}"] > div[aria-hidden="true"]`
+    )
+    await expect(overlay).toHaveCount(0)
+
+    await page.evaluate(setHighlights, { [NODE_ID]: COLOR })
+    await expect(overlay).toHaveCount(1)
+    await expect(overlay).toHaveCSS("background-color", COLOR)
+
+    await page.evaluate(setHighlights, null)
+    await expect(overlay).toHaveCount(0)
+  })
+
+  test("paints a class-member (attribute) overlay rect", async ({ page }) => {
+    const highlightRect = page.locator(
+      `g[data-apollon-element-id="${ATTRIBUTE_ID}"] rect[stroke="${COLOR}"]`
+    )
+    await expect(highlightRect).toHaveCount(0)
+
+    await page.evaluate(setHighlights, { [ATTRIBUTE_ID]: COLOR })
+    await expect(highlightRect).toHaveCount(1)
+    await expect(highlightRect).toHaveAttribute("fill", COLOR)
+
+    await page.evaluate(setHighlights, null)
+    await expect(highlightRect).toHaveCount(0)
+  })
+})
+
+test.describe("host-driven element highlighting (edges)", () => {
+  test.beforeEach(async ({ page }) => {
+    await openFixtureInLocalEditor(page, edgeFixture)
+    await waitForCanvasReady(page)
+    await page.waitForFunction(() =>
+      Boolean((window as unknown as { apollonEditor?: unknown }).apollonEditor)
+    )
+  })
+
+  test("glows an edge with a drop-shadow filter and removes it when cleared", async ({
+    page,
+  }) => {
+    // Edges are g-wrapped thin paths: the highlight is a drop-shadow glow on
+    // the stroke, a distinct rendering strategy from the node div overlay. Like
+    // the node wrapper, the g only exists while a highlight is set.
+    const edge = page.locator(`g[data-apollon-element-id="${EDGE_ID}"]`)
+    await expect(edge).toHaveCount(0)
+
+    await page.evaluate(setHighlights, { [EDGE_ID]: COLOR })
+    await expect(edge).toHaveCount(1)
+    const filter = await edge.evaluate((el) => getComputedStyle(el).filter)
+    expect(filter).toMatch(/drop-shadow/)
+
+    await page.evaluate(setHighlights, null)
+    await expect(edge).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
### Summary

Apollon v4 dropped two v3 capabilities that assessment hosts relied on to highlight specific diagram elements: the per-element `highlight` color field on the model, and `ApollonEditor.select()`. After the v3→v4 migration those calls became silent no-ops, so downstream apps lost the ability to visually flag elements — most visibly **Artemis** ("missing feedback" markers) and **Athena** (automatic-suggestion markers).

This PR adds a first-class, non-destructive replacement:

- **`editor.setElementHighlights(map)`** — paint a translucent overlay over the given element ids (`id → CSS color`).
- **`editor.getElementHighlights()`** — read the current map back.

The highlight is purely a view overlay: it is never written into `model`, never serialized by `get model`, and never shared with collaborators. (User-facing release wording lives in the changeset.)

### Implementation notes

**Where it lives.** Highlights are stored in the existing local `assessmentSelectionStore` — _not_ the Yjs-backed diagram store — so they never enter the collaborative document, undo history, or serialization. Rendering reuses the two shared element wrappers, so every diagram type and class sub-element is covered through existing injection points (no per-node-type changes):

- `AssessmentSelectableWrapper` — a translucent tint + ring over div-wrapped **nodes**, and a `drop-shadow` glow over g-wrapped **edges** (thin paths).
- `AssessmentSelectableElement` — an overlay `<rect>` over **class members** (attributes/methods).

**Why an overlay, not `data.fillColor`.** A host could already tint elements by overwriting `data.fillColor`, but that clobbers the author's own colors and needs save/restore bookkeeping. A dedicated overlay is non-destructive and unambiguous.

**API shape / trade-offs.**

- Accepts a `Map` (matches the host's existing data shape) or a plain `Record` (ergonomic), normalized at a single boundary; stored/returned as defensive copies so caller mutation can't leak in.
- `null` (or an empty map) clears; `undefined` is a no-op — matching the codebase's "absence = leave untouched" convention.
- Renders in display/assessment views, **not** the quiz interactive-element picker (`ApollonView.Highlight`), which assessment hosts never enter — no speculative code paths.
- Hot-path guard: an element with no highlight returns the same zero-box Fragment as before, so ordinary modelling/editing pays no extra DOM cost.

**Naming.** `setElementHighlights` (plural, host overlay) is deliberately distinct from the pre-existing `setHighlightedElement` (singular, hover state) to avoid an autocomplete footgun.

**Follow-up (out of scope here).** The Artemis consumer change is a one-liner that swaps its now-dead `node.data.highlight` writes for `editor.setElementHighlights(map)`; it ships separately once this releases.

### Steps for testing

1. **Unit** — from the repo root: `pnpm --filter @tumaet/apollon test`. Covers the store plus the `ApollonEditor` highlight contract (Map/Record normalization, defensive copy, `null` clears / `undefined` no-op).
2. **E2E (real browser)** — build the library, then from `standalone/webapp` run `npx playwright test tests/e2e/highlight.spec.ts`. Asserts a node overlay, a class-member rect, and an edge glow each paint on highlight and disappear on clear.
3. **Manual** — open any class diagram in the local editor and, in the devtools console (the `window.apollonEditor` handle exists in dev builds only), run:
   ```js
   window.apollonEditor.setElementHighlights(
     new Map([["<elementId>", "rgba(23, 162, 184, 0.35)"]]),
   )
   ```
   Confirm the element is tinted; `setElementHighlights(null)` clears it.

### Screenshots / screencasts

The highlight is host-driven (no Apollon UI surface changed), so these demos drive it through the API:

**Whole node + edge** — the left class is highlighted **cyan** (Athena-suggestion style) and the relationship edge glows **red** (missing-feedback style); the right-hand class is the unhighlighted control.

![Node and edge highlights](https://raw.githubusercontent.com/ls1intum/Apollon/pr-762-assets/highlight-demo.png)

**Per-member precision** — a single class attribute highlighted, leaving the rest of the class untouched.

![Class-member highlight](https://raw.githubusercontent.com/ls1intum/Apollon/pr-762-assets/highlight-demo-member.png)

> These images are hosted on the `pr-762-assets` branch, so they render here without being part of this PR's diff.

### Checklist

- [ ] Linked to a related issue (if applicable) — no tracked issue; this is a regression surfaced during the Artemis Apollon-v4 migration.
- [x] Added a changeset (`@tumaet/apollon`, `minor`)
- [x] Tests added or updated (unit + E2E)
- [x] Documentation updated (`docs/library/api.md`)
- [x] Screenshots or screencasts attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)
