### PR TITLE
feat(library): snap activity-diagram lane resize to the grid

### DIFF
--- a/.changeset/swimlane-resize-grid-snap.md
+++ b/.changeset/swimlane-resize-grid-snap.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Activity-diagram lane separators now snap to the canvas grid while you drag them, matching how nodes and edge bends already snap. Lane boundaries line up cleanly instead of landing on arbitrary sub-pixel positions.

--- a/library/lib/nodes/activityDiagram/ActivitySwimlane.tsx
+++ b/library/lib/nodes/activityDiagram/ActivitySwimlane.tsx
@@ -7,6 +7,7 @@ import { ActivitySwimlaneProps } from "@/types"
 import { useDiagramStore } from "@/store"
 import { useShallow } from "zustand/shallow"
 import { getLaneOffsets, resizeLaneDivider } from "@/utils"
+import { CANVAS } from "@/constants"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
 import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
 import {
@@ -64,7 +65,13 @@ function LaneResizeHandles({
     const { index, start, origLanes, primaryExtent } = drag.current
     const deltaScreen = (isVertical ? e.clientX : e.clientY) - start
     const deltaPx = deltaScreen / (zoom || 1)
-    const next = resizeLaneDivider(origLanes, index, deltaPx, primaryExtent)
+    const next = resizeLaneDivider(
+      origLanes,
+      index,
+      deltaPx,
+      primaryExtent,
+      CANVAS.SNAP_TO_GRID_PX
+    )
     setNodes((nodes) =>
       nodes.map((n) =>
         n.id === id ? { ...n, data: { ...n.data, lanes: next } } : n

--- a/library/lib/utils/swimlaneUtils.ts
+++ b/library/lib/utils/swimlaneUtils.ts
@@ -73,16 +73,28 @@ export const laneIndexAtOffset = (
  * shared boundary by `deltaPx`, growing one lane and shrinking the other by the
  * same amount so the swimlane's outer size never changes. Neither lane drops
  * below `MIN_LANE_EXTENT`. Returns lanes with an explicit `size` on every entry.
+ *
+ * When `snapGridPx > 0` the moved boundary is snapped to that grid, so a lane
+ * separator lands on the same grid that nodes and edge bends snap to. The lane
+ * offsets are measured from the swimlane's own origin, which React Flow already
+ * keeps grid-aligned, so the snapped boundary lines up with the absolute grid.
  */
 export const resizeLaneDivider = (
   lanes: SwimlaneLane[],
   index: number,
   deltaPx: number,
-  primaryExtent: number
+  primaryExtent: number,
+  snapGridPx = 0
 ): SwimlaneLane[] => {
   if (index < 0 || index >= lanes.length - 1) return lanes
-  const extents = getLaneOffsets(lanes, primaryExtent).map((o) => o.extent)
+  const offsets = getLaneOffsets(lanes, primaryExtent)
+  const extents = offsets.map((o) => o.extent)
   let delta = deltaPx
+  if (snapGridPx > 0) {
+    const boundary = offsets[index + 1].start + delta
+    const snapped = Math.round(boundary / snapGridPx) * snapGridPx
+    delta = snapped - offsets[index + 1].start
+  }
   delta = Math.max(delta, MIN_LANE_EXTENT - extents[index])
   delta = Math.min(delta, extents[index + 1] - MIN_LANE_EXTENT)
   extents[index] += delta

--- a/library/tests/unit/activitySwimlane.test.ts
+++ b/library/tests/unit/activitySwimlane.test.ts
@@ -120,6 +120,22 @@ describe("resizeLaneDivider", () => {
   it("ignores an out-of-range divider index", () => {
     expect(resizeLaneDivider(lanes, 1, 40, 400)).toBe(lanes)
   })
+
+  it("snaps the moved boundary to the grid when a step is given", () => {
+    // 400px equal lanes (boundary at 200); drag +43px → boundary 243 snaps to
+    // the nearest multiple of 5 (245), so lane A becomes 245 and B 155.
+    const next = resizeLaneDivider(lanes, 0, 43, 400, 5)
+    expect(next[0].size).toBeCloseTo(245)
+    expect(next[1].size).toBeCloseTo(155)
+    expect((next[0].size ?? 0) + (next[1].size ?? 0)).toBeCloseTo(400)
+  })
+
+  it("still honours the minimum after snapping", () => {
+    // Snap target would floor B below the minimum; the clamp wins.
+    const next = resizeLaneDivider(lanes, 0, 9999, 400, 5)
+    expect(next[0].size).toBeCloseTo(360)
+    expect(next[1].size).toBeCloseTo(40)
+  })
 })
 
 describe("flipSwimlaneChildPosition", () => {

--- a/standalone/webapp/tests/e2e/activity-swimlane.spec.ts
+++ b/standalone/webapp/tests/e2e/activity-swimlane.spec.ts
@@ -239,9 +239,7 @@ test.describe("activity swimlane", () => {
     expect(Math.abs(after.width - sl.width)).toBeLessThanOrEqual(TOL)
   })
 
-  test("lanes can be reordered by dragging in the popover", async ({
-    page,
-  }) => {
+  test("lanes can be reordered in the popover", async ({ page }) => {
     // Action sits in lane 2 ("System") — right half of the swimlane.
     await openFixtureInLocalEditor(
       page,
@@ -260,19 +258,25 @@ test.describe("activity swimlane", () => {
       .dblclick({ position: { x: 30, y: 12 } })
     const handles = page.getByLabel("Reorder lane")
     await expect(handles).toHaveCount(2)
-    const h1 = (await handles.nth(1).boundingBox())!
-    const h0 = (await handles.nth(0).boundingBox())!
-    // Drag the second lane's handle above the first (dnd-kit needs an initial
-    // nudge to start, then a move over the target).
-    await page.mouse.move(h1.x + h1.width / 2, h1.y + h1.height / 2)
-    await page.mouse.down()
-    await page.mouse.move(h1.x + h1.width / 2, h1.y + h1.height / 2 - 6, {
-      steps: 3,
-    })
-    await page.mouse.move(h0.x + h0.width / 2, h0.y - 4, { steps: 8 })
-    await page.mouse.up()
 
-    // Lane labels swapped...
+    // Reorder via dnd-kit's KeyboardSensor instead of a synthetic pointer drag.
+    // A mouse drag's success hinges on collision detection sampling the pointer
+    // mid-move, which is racy under loaded CI; the keyboard sensor is a
+    // deterministic state machine: pick the second lane's handle up (Space),
+    // move it up one slot (ArrowUp), and drop it (Space).
+    const handle = handles.nth(1)
+    // `press` targets the handle element directly (focus + key), so activation
+    // can't be lost to the popover's own focus management the way a bare
+    // `page.keyboard` press after `.focus()` can. dnd-kit then keeps focus on
+    // the lifted item, so the move/drop keys go to the right place.
+    await handle.press("Space")
+    // The lifted item gets aria-pressed once the keyboard drag is active; wait
+    // for that so the move key can't arrive before the pick-up is registered.
+    await expect(handle).toHaveAttribute("aria-pressed", "true")
+    await page.keyboard.press("ArrowUp")
+    await page.keyboard.press("Space")
+
+    // Lane labels swapped.
     await expect
       .poll(async () =>
         page


### PR DESCRIPTION
### Summary

Dragging an activity-diagram swimlane's lane separator was pixel-continuous, so lane boundaries could land on arbitrary sub-pixel positions — out of step with the rest of the canvas, where nodes (`snapGrid`) and edge bends already snap to a 5px grid. This makes the lane separator snap to that same grid while you drag it.

The snap lives in the pure `resizeLaneDivider` util (new optional `snapGridPx` arg); the component passes `CANVAS.SNAP_TO_GRID_PX`. Lane offsets are measured from the swimlane's own origin, which React Flow already keeps grid-aligned, so the snapped boundary lines up with the absolute grid. The minimum-lane clamp still wins at the extremes.

This branch also fixes a genuinely flaky lane-reorder e2e test (separate commit) — see below.

### Release note

Activity-diagram lane separators now snap to the canvas grid while you drag them, so lane boundaries line up cleanly.

### Implementation notes

- Snapping rounds the *moved boundary* to the grid, not the raw delta, so the separator lands on a grid line regardless of where the drag started.
- Default `snapGridPx = 0` keeps `resizeLaneDivider` a no-op snap unless a grid is passed — existing callers/tests are unaffected.
- Clamp order is snap → min-extent, so a snap that would shrink a lane below `MIN_LANE_EXTENT` is still clamped.

**Flaky e2e fix (root cause, not a bandaid):** the lane-reorder test drove dnd-kit through a synthetic `page.mouse` drag, whose success depends on collision detection sampling the pointer mid-move — a race that drops the reorder under loaded CI. No number of extra steps/waits makes a pointer drag deterministic. The popover already registers a `KeyboardSensor`, so the test now uses it: pick the handle up (`Space`), wait for dnd-kit to mark it active (`aria-pressed`), move up one slot (`ArrowUp`), drop (`Space`). Verified locally 5/5 on a clean server and the full spec 7/7.

### Steps for testing

1. Open an Activity diagram, drop a swimlane, and drag a lane separator.
2. The separator advances in 5px steps and the lane edges align with where nodes snap.
3. Drag a separator hard against a neighbour — the neighbour floors at the minimum lane size instead of snapping past it.

### Checklist

- [ ] Linked to a related issue (if applicable)
- [x] Added a changeset whose summary is written in the user's voice
- [x] PR title's Conventional Commit type (`feat`/`fix`/…) matches the kind of change
- [x] Tests added or updated
- [ ] Documentation updated (if applicable)
- [ ] Screenshots or screencasts attached (if a UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)