### PR TITLE
fix(library): stop the canvas jumping on the first palette drop

### DIFF
--- a/.changeset/fix-canvas-jump-first-node.md
+++ b/.changeset/fix-canvas-jump-first-node.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Dragging the first element from the palette onto an empty canvas no longer jumps the view — the element now lands where you drop it.

--- a/library/lib/App.tsx
+++ b/library/lib/App.tsx
@@ -234,7 +234,12 @@ function App({ onReactFlowInit, collaboration, awareness }: AppProps) {
             // pointer from a visible handle.
             elevateEdgesOnSelect
             onInit={(instance: ReactFlowInstance) => {
-              instance.fitView({ maxZoom: 1.0, minZoom: 1.0 })
+              // fitView on an empty canvas stays queued until nodes exist, then
+              // fires on the first one and jerks the viewport. Only fit with
+              // content; empty keeps the default (0,0)/zoom-1.
+              if (instance.getNodes().length > 0) {
+                instance.fitView({ maxZoom: 1.0, minZoom: 1.0 })
+              }
               handleReactFlowInit(instance)
             }}
             minZoom={CANVAS.MIN_SCALE_TO_ZOOM_OUT}

--- a/library/lib/apollon-editor.tsx
+++ b/library/lib/apollon-editor.tsx
@@ -321,6 +321,10 @@ export class ApollonEditor {
       if (!rf) return
       const rfNodes = rf.getNodes()
       const expected = this.diagramStore.getState().nodes.length
+      // fitView on an empty canvas stays queued until nodes exist, then fires
+      // on the first one and jerks the viewport. No-op when there's nothing to
+      // frame.
+      if (expected === 0) return
       const allMeasured =
         rfNodes.length >= expected &&
         rfNodes.every(

--- a/standalone/webapp/tests/e2e/canvas-first-drop-jump.spec.ts
+++ b/standalone/webapp/tests/e2e/canvas-first-drop-jump.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test"
-import { waitForCanvasReady } from "../helpers/canvas"
+import { openFixtureInLocalEditor, waitForCanvasReady } from "../helpers/canvas"
 
 /**
  * Dropping the first palette element onto an empty canvas must not move the
@@ -7,41 +7,15 @@ import { waitForCanvasReady } from "../helpers/canvas"
  * the first node, re-framing it and jerking the canvas.
  */
 
-async function openTemporaryLocalDiagram(
-  page: Page,
-  diagramType = "ClassDiagram"
-) {
-  const modelId = "e2e-first-drop-model-id"
-  await page.goto("/")
-  await page.evaluate(
-    ({ id, type }) => {
-      const storeValue = JSON.stringify({
-        state: {
-          models: {
-            [id]: {
-              id,
-              model: {
-                id,
-                type,
-                assessments: {},
-                edges: [],
-                nodes: [],
-                title: "E2E Diagram",
-                version: "4.0.0",
-              },
-              lastModifiedAt: new Date().toISOString(),
-            },
-          },
-          currentModelId: id,
-        },
-        version: 0,
-      })
-      localStorage.setItem("persistenceModelStore", storeValue)
-    },
-    { id: modelId, type: diagramType }
-  )
-  await page.goto(`/local/${modelId}`)
-  await expect(page).toHaveURL(new RegExp(`/local/${modelId}$`))
+// An empty Class Diagram — no nodes, so the very next drop is the first node.
+const EMPTY_MODEL = {
+  id: "e2e-first-drop-model-id",
+  type: "ClassDiagram",
+  assessments: {},
+  edges: [],
+  nodes: [],
+  title: "E2E Diagram",
+  version: "4.0.0",
 }
 
 // Read the .react-flow__viewport transform matrix -> {zoom, x, y}.
@@ -69,7 +43,11 @@ async function dropFirstPaletteElementAt(page: Page, x: number, y: number) {
 
 test.describe("First palette drop — no canvas jump", () => {
   test.beforeEach(async ({ page }) => {
-    await openTemporaryLocalDiagram(page)
+    // Seed the fixture via addInitScript BEFORE navigating (openFixtureInLocalEditor),
+    // then go straight to /local/<id>. Writing localStorage after a goto("/")
+    // races app hydration and can land on the "Diagram not found" page.
+    await openFixtureInLocalEditor(page, EMPTY_MODEL)
+    await expect(page).toHaveURL(new RegExp(`/local/${EMPTY_MODEL.id}$`))
     await waitForCanvasReady(page, false)
   })
 

--- a/standalone/webapp/tests/e2e/canvas-first-drop-jump.spec.ts
+++ b/standalone/webapp/tests/e2e/canvas-first-drop-jump.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, type Page } from "@playwright/test"
+import { waitForCanvasReady } from "../helpers/canvas"
+
+/**
+ * Dropping the first palette element onto an empty canvas must not move the
+ * viewport. A fitView issued while empty stays queued and otherwise fires on
+ * the first node, re-framing it and jerking the canvas.
+ */
+
+async function openTemporaryLocalDiagram(
+  page: Page,
+  diagramType = "ClassDiagram"
+) {
+  const modelId = "e2e-first-drop-model-id"
+  await page.goto("/")
+  await page.evaluate(
+    ({ id, type }) => {
+      const storeValue = JSON.stringify({
+        state: {
+          models: {
+            [id]: {
+              id,
+              model: {
+                id,
+                type,
+                assessments: {},
+                edges: [],
+                nodes: [],
+                title: "E2E Diagram",
+                version: "4.0.0",
+              },
+              lastModifiedAt: new Date().toISOString(),
+            },
+          },
+          currentModelId: id,
+        },
+        version: 0,
+      })
+      localStorage.setItem("persistenceModelStore", storeValue)
+    },
+    { id: modelId, type: diagramType }
+  )
+  await page.goto(`/local/${modelId}`)
+  await expect(page).toHaveURL(new RegExp(`/local/${modelId}$`))
+}
+
+// Read the .react-flow__viewport transform matrix -> {zoom, x, y}.
+async function readViewport(page: Page) {
+  return page.evaluate(() => {
+    const vp = document.querySelector<HTMLElement>(".react-flow__viewport")
+    if (!vp) return null
+    const m = new DOMMatrixReadOnly(getComputedStyle(vp).transform)
+    return { zoom: m.a, x: m.e, y: m.f }
+  })
+}
+
+// Drag the first palette element and drop it at the given viewport coordinates.
+async function dropFirstPaletteElementAt(page: Page, x: number, y: number) {
+  const palette = page.locator('[data-testid="apollon-palette"]').first()
+  const preview = palette.locator("[data-draggable-preview]").first()
+  await expect(preview).toBeVisible()
+  const box = await preview.boundingBox()
+  expect(box).not.toBeNull()
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(x, y, { steps: 10 })
+  await page.mouse.up()
+}
+
+test.describe("First palette drop — no canvas jump", () => {
+  test.beforeEach(async ({ page }) => {
+    await openTemporaryLocalDiagram(page)
+    await waitForCanvasReady(page, false)
+  })
+
+  test("viewport is unchanged after dropping the first node", async ({
+    page,
+  }) => {
+    const before = await readViewport(page)
+    expect(before, "viewport must be readable").not.toBeNull()
+
+    const canvas = page.locator(".react-flow").first()
+    const cbox = await canvas.boundingBox()
+    expect(cbox).not.toBeNull()
+
+    // Off-centre so a re-framing fit would shift the viewport measurably.
+    await dropFirstPaletteElementAt(
+      page,
+      cbox!.x + cbox!.width * 0.4,
+      cbox!.y + cbox!.height * 0.4
+    )
+
+    await expect(page.locator(".react-flow__node")).toHaveCount(1)
+
+    const after = await readViewport(page)
+    expect(after, "viewport must be readable").not.toBeNull()
+
+    expect(after!.zoom).toBeCloseTo(before!.zoom, 3)
+    expect(Math.abs(after!.x - before!.x)).toBeLessThanOrEqual(1)
+    expect(Math.abs(after!.y - before!.y)).toBeLessThanOrEqual(1)
+  })
+})


### PR DESCRIPTION
### Summary

Dropping the **first** element from the palette onto an empty canvas made the whole view lurch: the element didn't land where you released it, and the canvas visibly jumped. Every element after the first behaved fine.

The culprit is how React Flow's imperative `fitView()` behaves in v12. It doesn't fit immediately — it sets an internal `fitViewQueued` flag and waits for nodes to exist before resolving (see `@xyflow/react`'s `setNodes` path). We call `fitView` twice at startup — once in `App.tsx`'s `onInit` and once via the editor's mount-time fit — but at that point the canvas is empty, so nothing resolves the queued fit. It sits there pending until the first `setNodes`… which is the node you just dropped. React Flow then dutifully re-frames that lone node, and the viewport jumps.

The fix makes `fitView` a no-op when there are no nodes to frame, at both call sites. An empty canvas keeps its natural default viewport `(0,0)` / zoom 1, and no stale fit is left queued to ambush the first drop.

### Release note

Dragging the first element from the palette onto an empty canvas no longer jumps the view — the element now lands where you drop it.

### Implementation notes

- `library/lib/App.tsx` — only call `instance.fitView()` in `onInit` when `instance.getNodes().length > 0`.
- `library/lib/apollon-editor.tsx` — the public `fitView()` retries until nodes are measured; bail out early when the store has zero nodes.

Both guards are conservative: fitting an empty canvas never produced a meaningful result anyway (it only ever queued), so nothing about the non-empty path changes. Only the first node was ever affected, because React Flow clears the queued flag once it resolves — which is why a narrower one-site fix would have left the other latent call able to reintroduce the jump.

### Steps for testing

1. Open the editor with an empty diagram (e.g. create a new local Class Diagram).
2. Drag any element from the palette and drop it somewhere off-centre.
3. The element lands under the cursor and the canvas does **not** pan/jump.
4. Drop a few more elements — behaviour is unchanged, and existing diagrams still fit-to-view on load as before.

Automated coverage: `standalone/webapp/tests/e2e/canvas-first-drop-jump.spec.ts` records the viewport transform before and after the first drop and asserts it is unchanged. It fails on `main` (viewport shifts) and passes with this change.

### Screenshots / screencasts

n/a — no visual/UI surface changes; the fix removes an unwanted viewport movement. Behaviour is covered by the E2E test above.

### Checklist

- [ ] Linked to a related issue (if applicable)
- [x] Added a changeset whose summary is written in the user's voice (`pnpm changeset`, [how](https://ls1intum.github.io/Apollon/contributor/development/release-notes/)) — or this PR doesn't touch a Changesets-tracked package (`@tumaet/apollon`, `@tumaet/webapp`, `@tumaet/server`)
- [x] PR title's Conventional Commit type (`feat`/`fix`/…) matches the kind of change — it groups the release note
- [x] Tests added or updated
- [x] Documentation updated (if applicable) — n/a
- [x] Screenshots or screencasts attached (if a UI change) — n/a, no UI surface change
