### PR TITLE
chore(ci): audit Renovate — fix config warning, move to auto-PR flow with scoped automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Dashboard-only mode — PRs created only when approved from the dashboard",
-  "extends": [
-    "config:best-practices",
-    "docker:pinDigests",
-    "helpers:pinGitHubActionDigests",
-    ":semanticCommitTypeAll(chore)",
-    ":dependencyDashboardApproval"
-  ],
+  "description": "Auto-PR flow: non-major updates open weekly grouped PRs; low-risk lanes automerge on green CI; majors are gated on the dashboard.",
+  "extends": ["config:best-practices", ":semanticCommitTypeAll(chore)"],
   "labels": ["dependencies"],
 
   "timezone": "Europe/Berlin",
   "schedule": ["before 7am on monday"],
-  "minimumReleaseAge": "3 days",
 
-  "platformAutomerge": true,
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+
+  "platformAutomerge": false,
   "automergeStrategy": "squash",
   "semanticCommitScope": "deps",
 
@@ -26,35 +25,48 @@
 
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 7am on monday"],
+    "schedule": ["before 7am on tuesday"],
+    "automerge": true,
     "labels": ["dependencies", "lockfile-maintenance"]
   },
 
   "packageRules": [
     {
-      "description": "Group all minor and patch updates",
+      "description": "Batch every non-major update into one weekly review PR.",
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "minor and patch dependencies",
       "labels": ["dependencies"],
       "matchPackageNames": ["*"]
     },
     {
-      "description": "Major updates require extra care",
+      "description": "Majors carry breaking changes: gate them on the dashboard and soak longer so a human opts in per package.",
       "matchUpdateTypes": ["major"],
-      "minimumReleaseAge": "7 days",
+      "dependencyDashboardApproval": true,
+      "minimumReleaseAge": "14 days",
       "labels": ["dependencies", "breaking"]
     },
     {
-      "description": "GitHub Actions",
+      "description": "GitHub Actions are SHA-pinned and run cheap CI.",
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",
       "labels": ["dependencies", "ci"]
     },
     {
-      "description": "Docker images",
+      "description": "Docker base-image version bumps ship into published images — group them for review.",
       "matchManagers": ["dockerfile", "docker-compose"],
       "groupName": "Docker images",
       "labels": ["dependencies", "infrastructure"]
+    },
+    {
+      "description": "Automerge non-major GitHub Actions once CI is green — SHA-pinned, cheap to verify, high-toil to hand-merge.",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge digest-only re-pins (same tag, new SHA) across managers — no version change to review.",
+      "matchUpdateTypes": ["digest", "pinDigest"],
+      "automerge": true
     },
     {
       "description": "@types/pdfmake — pinned to 0.2.x because 0.3.x removed the .vfs property used by standalone/server/src/workers/pdf-conversion-worker-thread.ts. Re-evaluate when migrating the worker to the 0.3 API.",
@@ -63,12 +75,13 @@
     }
   ],
 
+  "osvVulnerabilityAlerts": true,
+
   "vulnerabilityAlerts": {
     "labels": ["security", "dependencies"],
     "schedule": ["at any time"],
     "minimumReleaseAge": null,
     "dependencyDashboardApproval": false,
-    "prPriority": 10,
     "automerge": true,
     "groupName": null
   },

--- a/vscode-extension/renovate.json
+++ b/vscode-extension/renovate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
-}


### PR DESCRIPTION
### Summary

Audit and overhaul of the Renovate setup, prompted by the ⚠️ config warning on the [Dependency Dashboard (#558)](https://github.com/ls1intum/Apollon/issues/558) and its large, stale "Pending Approval" backlog. Two parts:

**Part 1 — correctness & hygiene** (the original warning):
- **Remove `vulnerabilityAlerts.prPriority`** — `prPriority` is only valid in `packageRules`; Renovate warned on it and ignored it. This was the "Found renovate config warnings" on #558.
- **Drop `docker:pinDigests` + `helpers:pinGitHubActionDigests`** from `extends` — [`config:best-practices`](https://docs.renovatebot.com/upgrade-best-practices/) already includes both.
- **Enable `osvVulnerabilityAlerts`** — OSV-database scanning + malicious-package detection beyond GitHub's native alerts.
- **Delete `vscode-extension/renovate.json`** — Renovate reads config [only from the repo root](https://docs.renovatebot.com/configuration-options/); this nested file (a leftover from the standalone extension repo) was never applied.

**Part 2 — strategy: dashboard-only → auto-PR flow with scoped automerge.**
The repo ran `:dependencyDashboardApproval`, gating *every* update behind a manual dashboard tick. Renovate's own docs advise against this — *"We do **not** recommend that you require approval for all updates … out of sight means out of mind"* ([dashboard docs](https://docs.renovatebot.com/key-concepts/dashboard/)). The [switch to that mode](https://github.com/ls1intum/Apollon/commit/73da86a9) was justified solely by a rebase-driven CI cascade — but the current config already neutralizes that with `rebaseWhen: "conflicted"` + weekly scheduling + grouping. The #558 backlog is the "out of sight, out of mind" failure already materialized.

| Change | Rationale |
|---|---|
| Drop blanket `:dependencyDashboardApproval` | Non-major updates now open **weekly grouped PRs**. Gate **majors only** (14-day soak) — the one place per-package human opt-in earns its keep. |
| Automerge low-risk, high-toil lanes on green CI: SHA-pinned **GitHub Actions**, **digest re-pins**, **lock file maintenance**, and disclosed-CVE **security** fixes | Renovate's [noise-reduction hierarchy](https://docs.renovatebot.com/noise-reduction/) puts automerge above manual gating. npm minor/patch still open a **human-reviewed** PR — this package ships to npm + Docker + iOS, so prod bumps keep a human. |
| `platformAutomerge: false` | Renovate waits for green CI **itself** rather than relying on branch-protection required checks, which are fragile here (path-filtered / skippable jobs). |
| `minimumReleaseAge` 3d → **7d**, `internalChecksFilter: "strict"` | 3 days sits *inside* the typical 24–72h malware-yank window ([axios supply-chain timeline](https://blog.gitguardian.com/renovate-dependabot-the-new-malware-delivery-system/)). 7d clears it; `strict` means no branch/CI is spent until the soak clears. `null` retained for disclosed CVEs. |
| `prConcurrentLimit: 5`, `prHourlyLimit: 2`; lock file maintenance moved off Monday | Backstops against a surprise firehose; avoids the one residual rebase collision with the npm PR. |

### Release note

n/a — no Changesets-tracked package changed (`@tumaet/apollon`, `@tumaet/webapp`, `@tumaet/server` untouched).

### Implementation notes

**How this was decided.** The strategy flip was pressure-tested by two independent principal-engineer reviews briefed to argue *opposite* sides (keep dashboard-only vs. move to auto-PR), each citing trusted sources. They converged: the blanket gate is an anti-pattern here; the disagreement narrowed to a single axis (should the npm lane flow or stay gated) plus the automerge governance call. Both were put to the maintainer, who chose **auto-PR flow** for npm (human-merged) and **true automerge** for the safe lanes.

**⚠️ Governance change made alongside this PR (not in the diff).** True automerge was inert because `main` requires 1 review and repo auto-merge was off. To make it work **without weakening review for humans**, `renovate[bot]` was added to the *review-bypass allowance* on `main`:
- Humans still require 1 approving review.
- Only `renovate[bot]` can bypass it — and only on its **own** PRs (it cannot merge anyone else's).
- Combined with `platformAutomerge: false`, Renovate self-merges **only after CI is green**.
- Fully reversible: remove `renovate` from the branch's `bypass_pull_request_allowances`.

**Config validated** with `renovate-config-validator` → `Config validated successfully`, **0 warnings** (was 1).

### Steps for testing

1. `npx --yes --package renovate renovate-config-validator` at repo root → `Config validated successfully`, no warnings.
2. On Renovate's next run, confirm #558's _Repository Problems_ warning clears and non-major updates begin opening PRs (no longer stuck behind approval).
3. Confirm a SHA-pinned GitHub Actions / digest PR automerges after CI goes green; confirm an npm minor/patch PR waits for a human.
4. Confirm a normal human PR still requires 1 review (bypass is scoped to `renovate[bot]`).

### Screenshots / screencasts

n/a — no UI change.

### Checklist

- [x] Linked to a related issue (#558)
- [x] No Changesets-tracked package touched — no changeset needed
- [x] PR title's Conventional Commit type matches the change (`chore`)
- [x] Config validated with `renovate-config-validator` (0 warnings)
- [ ] Tests — n/a (config-only)
- [x] Documentation — n/a
- [x] Screenshots — n/a (no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)