### PR TITLE
chore(ci): make Renovate the single dependency-age soak authority

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,8 +11,10 @@ packages:
 # produces a self-contained server runtime image.
 injectWorkspacePackages: true
 
-# Supply-chain hardening.
-minimumReleaseAge: 1440 # 1 day
+# Supply-chain hardening. Dependency-age cooldown is owned by Renovate
+# (minimumReleaseAge in renovate.json), which is the single soak authority:
+# a pnpm-level age floor rejects the exact versions Renovate pins in the
+# catalog/overrides and blocks it from regenerating the lockfile.
 blockExoticSubdeps: true
 
 # Shared version pins across 2+ workspaces. Each workspace package.json
@@ -106,6 +108,3 @@ allowBuilds:
   protobufjs: false # testcontainers→dockerode transitive; pure-JS, no native build
   "sharp": true
   "ssh2": true
-minimumReleaseAgeExclude:
-  # Renovate security update: pnpm@11.8.0
-  - pnpm@11.8.0


### PR DESCRIPTION
### Summary

Fixes the root cause behind the recurring `renovate/artifacts: Artifact file update failure` on dependency PRs, where every job dies at `pnpm install --frozen-lockfile` with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` and needs a hand-regenerated lockfile plus a hand-written exclude entry.

**Why it kept happening — two age-soaks that structurally cannot coexist:**

- `pnpm-workspace.yaml` had `minimumReleaseAge: 1440` — pnpm refuses to *install* any package younger than 1 day, on every `pnpm install` including Renovate's own lockfile step.
- The catalog, `overrides`, and `packageManager` all pin **exact** versions. When Renovate bumps any of them, it forces that exact new version — pnpm's floor can't downgrade an exact pin, so it **errors**, and Renovate can't regenerate the lockfile.
- Renovate **bypasses its own `minimumReleaseAge` for security updates** ([presets-security](https://docs.renovatebot.com/presets-security/), [#38324](https://github.com/renovatebot/renovate/discussions/38324), [#42260](https://github.com/renovatebot/renovate/discussions/42260)), so you can't delay around the floor either.

So any exact-pinned security bump (`pnpm@11.8.0`, `esbuild@0.28.1`, …) broke, and a human had to add a `minimumReleaseAgeExclude` entry **and** regenerate `pnpm-lock.yaml` by hand. Every time.

### The fix

Make **Renovate the single dependency-age soak authority** and drop the pnpm-level floor that fights it:

- Remove `minimumReleaseAge` (and its now-empty `minimumReleaseAgeExclude` list) from `pnpm-workspace.yaml`.
- Renovate owns the cooldown: `minimumReleaseAge: 7 days` for routine updates (a *stronger* soak than the 1 day this removes, and reliably applied because it never has to fight an exact pin).
- `blockExoticSubdeps`, `osvVulnerabilityAlerts`, and the GHSA `overrides` pins stay — supply-chain hardening is unchanged apart from the age floor.

Renovate's artifact step can now always regenerate the lockfile, so dependency PRs stop failing and no exclude entries are ever needed again.

### Release note

n/a — no Changesets-tracked package changed.

### Implementation notes

**Honest trade-off:** pnpm's floor was the only age-soak that applied to *transitive* installs and that Renovate couldn't bypass. Removing it means:
1. Transitive dependencies are no longer age-gated at install time (they still change only via reviewed Renovate PRs / lock file maintenance, and `blockExoticSubdeps` still blocks non-registry subdeps).
2. **Security updates now automerge with no age cooldown** (`vulnerabilityAlerts.minimumReleaseAge: null`, `automerge: true`) once CI is green. If you'd rather a human eyeball security releases before they hit a published npm/Docker/iOS artifact, drop `automerge` from `vulnerabilityAlerts` so security PRs are created immediately but merged by a person. Flagging this as a deliberate follow-up decision rather than changing it here.

This supersedes the earlier "align Renovate's soak to the 1-day floor" idea, which was wrong: security updates bypass `minimumReleaseAge`, so no Renovate-side delay can keep it clear of pnpm's floor.

Verified locally: `pnpm install --frozen-lockfile` passes supply-chain policies; `renovate-config-validator` clean; removing the floor left `pnpm-lock.yaml` byte-identical (it was never a resolution input).

### Steps for testing

1. `pnpm install --frozen-lockfile` → passes, no `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.
2. `npx --yes --package renovate renovate-config-validator` → no warnings.
3. On the next Renovate dependency PR (esp. a security bump to a catalog/override pin), confirm the lockfile is regenerated automatically — no `Artifact file update failure`, no manual exclude.

### Screenshots / screencasts

n/a — no UI change.

### Checklist

- [x] No Changesets-tracked package touched — no changeset needed
- [x] PR title's Conventional Commit type matches the change (`chore`)
- [x] Config validated + frozen install verified locally
- [ ] Tests — n/a (config-only)
- [x] Documentation — n/a
- [x] Screenshots — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)