### PR TITLE
feat: shape-aware freeform edge connection points

### DIFF
--- a/.changeset/pretty-cities-speak.md
+++ b/.changeset/pretty-cities-speak.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": minor
+---
+
+Place Class diagram edge endpoints anywhere along node borders while reconnecting them.

--- a/.changeset/pretty-cities-speak.md
+++ b/.changeset/pretty-cities-speak.md
@@ -2,4 +2,4 @@
 "@tumaet/apollon": minor
 ---
 
-Place Class diagram edge endpoints anywhere along node borders while reconnecting them.
+Place edge endpoints anywhere along node borders across supported diagrams while reconnecting them.

--- a/.changeset/pretty-cities-speak.md
+++ b/.changeset/pretty-cities-speak.md
@@ -2,4 +2,4 @@
 "@tumaet/apollon": minor
 ---
 
-Place edge endpoints anywhere along node borders across supported diagrams while reconnecting them.
+Place and reconnect edge endpoints anywhere along a node's border, snapping to the grid, with a drag handle for moving an endpoint. Endpoints attach to each node's real shape rather than its bounding box and match the handles a node shows: use-case ovals connect along their curve, the flowchart input/output parallelogram along its slanted outline, and round or diamond nodes — activity start/end, BPMN events and gateways, flowchart decisions, petri places, and component/deployment interfaces — at their four N/E/S/W points. Legends, annotations, and swimlanes are not connection targets, and endpoints can be reconnected onto container nodes (activity, package, pool, subsystem). Drawing a connection shows a dashed preview that lands exactly where the edge will attach, dragging an endpoint across empty canvas follows the cursor instead of snapping back, connection arcs respond as soon as you reach them, and a connection attaches to the nearest node when several sit close together.

--- a/.changeset/shape-aware-connection-points.md
+++ b/.changeset/shape-aware-connection-points.md
@@ -1,5 +1,0 @@
----
-"@tumaet/apollon": patch
----
-
-Edges now attach to each node's real shape, and a node's connectable points match the handles it shows. Round and diamond nodes — activity start/end, BPMN events and gateways, flowchart decisions, petri places, and component/deployment interfaces — connect at their four N/E/S/W points. Use-case ovals connect anywhere along their curve, and the flowchart input/output parallelogram connects anywhere along its slanted outline (no more gap on the left/right sides). Legends, annotations and swimlanes are no longer connection targets. You can again reconnect an edge endpoint onto a container node (activity, package, pool, subsystem). On direct (straight) edges, the reconnect grip now sits on the edge and follows its angle. The input/output node's default label is now "Input / Output" so it wraps cleanly.

--- a/.changeset/shape-aware-connection-points.md
+++ b/.changeset/shape-aware-connection-points.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Edges now attach to each node's real shape, and a node's connectable points match the handles it shows. Round and diamond nodes — activity start/end, BPMN events and gateways, flowchart decisions, petri places, and component/deployment interfaces — connect at their four N/E/S/W points. Use-case ovals connect anywhere along their curve, and the flowchart input/output parallelogram connects anywhere along its slanted outline (no more gap on the left/right sides). Legends, annotations and swimlanes are no longer connection targets. You can again reconnect an edge endpoint onto a container node (activity, package, pool, subsystem). On direct (straight) edges, the reconnect grip now sits on the edge and follows its angle. The input/output node's default label is now "Input / Output" so it wraps cleanly.

--- a/.changeset/sharp-connection-preview.md
+++ b/.changeset/sharp-connection-preview.md
@@ -1,7 +1,0 @@
----
-"@tumaet/apollon": patch
----
-
-Drawing a connection now shows a clear dashed preview that appears once you drag away from a node and lands exactly where the edge will attach. Dragging an edge's endpoint across empty canvas follows your cursor instead of snapping back, and the endpoint grip stays on the edge tip instead of drifting away when you zoom out.
-
-Connection points are also easier to grab — a connection arc responds as soon as you reach it, without having to hover the node body first. A connection attaches to the nearest node when several sit close together, and a new connection snaps to the grid the same way dragging an existing endpoint does.

--- a/.changeset/sharp-connection-preview.md
+++ b/.changeset/sharp-connection-preview.md
@@ -1,0 +1,7 @@
+---
+"@tumaet/apollon": patch
+---
+
+Drawing a connection now shows a clear dashed preview that appears once you drag away from a node and lands exactly where the edge will attach. Dragging an edge's endpoint across empty canvas follows your cursor instead of snapping back, and the endpoint grip stays on the edge tip instead of drifting away when you zoom out.
+
+Connection points are also easier to grab — a connection arc responds as soon as you reach it, without having to hover the node body first. A connection attaches to the nearest node when several sit close together, and a new connection snaps to the grid the same way dragging an existing endpoint does.

--- a/library/lib/components/ReconnectConnectionLine.tsx
+++ b/library/lib/components/ReconnectConnectionLine.tsx
@@ -5,10 +5,12 @@ import {
   getSmoothStepPath,
   getStraightPath,
   Position,
+  type XYPosition,
 } from "@xyflow/react"
-import { EDGES } from "@/constants"
+import { CANVAS, EDGES } from "@/constants"
 import { pointsToSvgPath } from "@/edges/Connection"
 import { useDiagramStore, useMetadataStore } from "@/store/context"
+import { useFreeformDropTarget } from "@/hooks/useFreeformDropTarget"
 import { useShallow } from "zustand/shallow"
 import {
   adjustSourceCoordinates,
@@ -16,6 +18,20 @@ import {
   getEdgeMarkerStyles,
   preserveOrthogonalEdgePoints,
 } from "@/utils/edgeUtils"
+import {
+  getConnectionMode,
+  getEdgeAnchorFromPoint,
+  getEdgeAnchorPoint,
+} from "@/utils/connectionModes"
+
+// Hide the new-connection ghost until dragged this far from the source, so a
+// stray click doesn't flash a preview. Bypassed while hovering a node.
+const GHOST_MIN_DRAG_DISTANCE_PX = 40
+const GHOST_STROKE_WIDTH = 2
+const GHOST_DASH = "6 5"
+// Matches the connection indicator (`.connectionindicator`): a solid, opaque,
+// ~10px primary dot marking the connection point.
+const GHOST_SNAP_CIRCLE_RADIUS = 5
 
 const getFallbackConnectionPath = (
   connectionLineType: ConnectionLineType,
@@ -53,6 +69,7 @@ const getFallbackConnectionPath = (
 export const ReconnectConnectionLine = ({
   connectionLineStyle,
   connectionLineType,
+  fromNode,
   fromX,
   fromY,
   toX,
@@ -80,21 +97,70 @@ export const ReconnectConnectionLine = ({
     )
   )
 
+  // Resolve the drop target the same way the connection commit does, so the
+  // preview snaps exactly where the edge attaches on release.
+  const resolveDropTarget = useFreeformDropTarget()
+
   const path = useMemo(() => {
+    // Snap a pointer to the freeform border point of the node it would attach
+    // to; null over empty canvas or only the source node.
+    const snapToNodeUnder = (
+      pointer: XYPosition
+    ): {
+      point: XYPosition
+      position: Position
+      showSnapCircle: boolean
+    } | null => {
+      const target = resolveDropTarget(pointer, fromNode?.id)
+      // The resolver falls back to the source node when nothing else is under
+      // the pointer (a drop on your own body becomes a self-loop); the ghost
+      // never previews that, so a drag near the source stays gated.
+      if (!target || target.id === fromNode?.id) return null
+      // Shape-aware and shared with the commit, so the preview lands on the
+      // node's real shape (oval curve, diamond vertex, interface centre, …).
+      const anchor = getEdgeAnchorFromPoint(target.type, pointer, target.rect)
+      if (!anchor) return null // node is not a connection target (mode "none")
+      return {
+        ...getEdgeAnchorPoint(target.type, target.rect, anchor),
+        // Only the oval attaches purely via the freeform path (no native handle
+        // circles); other shapes get React Flow's own handle highlights, so a
+        // second circle here could drift from a handle-snapped drop.
+        showSnapCircle: getConnectionMode(target.type) === "ellipse",
+      }
+    }
+
     if (
       !previewEdge ||
       !reconnectPreviewHandleType ||
       reconnectPreviewBasePoints.length < 2
     ) {
-      return getFallbackConnectionPath(
-        connectionLineType,
-        fromX,
-        fromY,
-        toX,
-        toY,
-        fromPosition,
-        toPosition
-      )
+      // New connection — hidden until dragged clear of the source, or already
+      // hovering a node (see GHOST_MIN_DRAG_DISTANCE_PX). Grid-snap the pointer
+      // so the preview lands on the same point the commit does (useConnect
+      // resolves the drop through the editor's grid snapping too).
+      const snap = (v: number) =>
+        Math.round(v / CANVAS.SNAP_TO_GRID_PX) * CANVAS.SNAP_TO_GRID_PX
+      const pointer: XYPosition = { x: snap(toX), y: snap(toY) }
+      const snapped = snapToNodeUnder(pointer)
+      const draggedFar =
+        Math.hypot(toX - fromX, toY - fromY) >= GHOST_MIN_DRAG_DISTANCE_PX
+      if (!draggedFar && !snapped) return { d: "", snapPoint: null }
+
+      const end = snapped ?? { point: pointer, position: toPosition }
+      return {
+        d: getFallbackConnectionPath(
+          connectionLineType,
+          fromX,
+          fromY,
+          end.point.x,
+          end.point.y,
+          fromPosition,
+          end.position
+        ),
+        // Snap circle marks the live attach point: the edge connects
+        // continuously at any angle on the curve, not just at fixed handles.
+        snapPoint: snapped?.showSnapCircle ? snapped.point : null,
+      }
     }
 
     const markerPadding =
@@ -106,24 +172,12 @@ export const ReconnectConnectionLine = ({
     // React Flow reports the fixed opposite endpoint in onReconnectStart.
     const sourceAnchor =
       movedEnd === "source"
-        ? {
-            point: { x: toX, y: toY },
-            position: toPosition,
-          }
-        : {
-            point: { x: fromX, y: fromY },
-            position: fromPosition,
-          }
+        ? { point: { x: toX, y: toY }, position: toPosition }
+        : { point: { x: fromX, y: fromY }, position: fromPosition }
     const targetAnchor =
       movedEnd === "source"
-        ? {
-            point: { x: fromX, y: fromY },
-            position: fromPosition,
-          }
-        : {
-            point: { x: toX, y: toY },
-            position: toPosition,
-          }
+        ? { point: { x: fromX, y: fromY }, position: fromPosition }
+        : { point: { x: toX, y: toY }, position: toPosition }
 
     const adjustedSourceCoordinates = adjustSourceCoordinates(
       sourceAnchor.point.x,
@@ -152,15 +206,17 @@ export const ReconnectConnectionLine = ({
       targetAnchor.position
     )
 
-    return pointsToSvgPath(reconnectPreviewPoints)
+    return { d: pointsToSvgPath(reconnectPreviewPoints), snapPoint: null }
   }, [
     connectionLineType,
+    fromNode,
     fromPosition,
     fromX,
     fromY,
     previewEdge,
     reconnectPreviewBasePoints,
     reconnectPreviewHandleType,
+    resolveDropTarget,
     toPosition,
     toX,
     toY,
@@ -174,15 +230,36 @@ export const ReconnectConnectionLine = ({
       ? previewEdge.data.strokeColor
       : undefined
 
+  const stroke =
+    edgeStrokeColor ??
+    connectionLineStyle?.stroke ??
+    "var(--apollon-primary, #3e8acc)"
+
+  // Dashed, primary-coloured ghost; an empty `d` renders nothing when the ghost
+  // is gated off. The snap circle marks the live attach point on the target.
   return (
-    <path
-      d={path}
-      fill="none"
-      className="react-flow__connection-path"
-      style={{
-        ...connectionLineStyle,
-        stroke: edgeStrokeColor ?? connectionLineStyle?.stroke,
-      }}
-    />
+    <>
+      <path
+        d={path.d}
+        fill="none"
+        className="react-flow__connection-path"
+        style={{
+          ...connectionLineStyle,
+          stroke,
+          strokeWidth: GHOST_STROKE_WIDTH,
+          strokeDasharray: GHOST_DASH,
+          opacity: 1, // override React Flow's dimmed default; empty `d` hides it
+        }}
+      />
+      {path.snapPoint && (
+        <circle
+          className="apollon-connection-snap-circle"
+          cx={path.snapPoint.x}
+          cy={path.snapPoint.y}
+          r={GHOST_SNAP_CIRCLE_RADIUS}
+          fill="var(--apollon-primary, #3e8acc)"
+        />
+      )}
+    </>
   )
 }

--- a/library/lib/constants.ts
+++ b/library/lib/constants.ts
@@ -770,7 +770,7 @@ export const dropElementConfigs: Readonly<
       type: "flowchartInputOutput",
       width: 140,
       height: 70,
-      defaultData: { name: "Input/Output" },
+      defaultData: { name: "Input / Output" },
       svg: FlowchartInputOutputNodeSVG,
     },
     {

--- a/library/lib/edges/EdgeProps.ts
+++ b/library/lib/edges/EdgeProps.ts
@@ -1,5 +1,6 @@
 import { Edge, EdgeProps } from "@xyflow/react"
 import { IPoint } from "./Connection"
+import type { FreeformEdgeAnchor } from "@/utils/edgeUtils"
 
 // Define message structure with direction
 export interface MessageData {
@@ -14,6 +15,8 @@ export type CustomEdgeProps = {
   targetRole: string | null
   targetMultiplicity: string | null
   points: IPoint[]
+  sourceAnchor?: FreeformEdgeAnchor
+  targetAnchor?: FreeformEdgeAnchor
   label?: string | null
   messages?: MessageData[] // For communication diagram edges with direction-aware messages
   strokeColor?: string

--- a/library/lib/edges/GenericEdge.tsx
+++ b/library/lib/edges/GenericEdge.tsx
@@ -22,7 +22,7 @@ import { CANVAS, EDGES } from "@/constants"
 // Edge handles live inside the zoomed React Flow viewport. We want them to
 // keep a usable MINIMUM on-screen size when zoomed out (so they never shrink to
 // a few px), but to GROW with the edge when zoomed in (so they stay in
-// proportion to the now-thick edge instead of looking like a tiny dot on it).
+// proportion to the thick edge instead of looking like a tiny dot on it).
 //
 //   scale = 1 / min(zoom, 1)   (zoom floored to the canvas minimum)
 //     zoom <= 1  → 1/zoom  → constant on-screen size (counter-scaled)
@@ -76,15 +76,25 @@ const getEndpointDirection = (side?: EndpointSide): IPoint => {
   }
 }
 
+const normalizeDir = (v: IPoint): IPoint => {
+  const len = Math.hypot(v.x, v.y)
+  return len === 0 ? { x: 0, y: 0 } : { x: v.x / len, y: v.y / len }
+}
+
 export const getEndpointHitTargetRect = (
   point: IPoint,
   side?: EndpointSide,
   screenScale = 1,
-  hitTargetSize: number = EDGES.ENDPOINT_HIT_TARGET_SIZE
+  hitTargetSize: number = EDGES.ENDPOINT_HIT_TARGET_SIZE,
+  // Straight (direct) edges leave the node at an angle; pass the real outward
+  // edge direction so the target follows the line instead of an orthogonal side.
+  outwardDir?: IPoint
 ) => {
   const hitSize = hitTargetSize * screenScale
   const hitOffset = hitSize / 2
-  const direction = getEndpointDirection(side)
+  const direction = outwardDir
+    ? normalizeDir(outwardDir)
+    : getEndpointDirection(side)
 
   return {
     x: point.x + direction.x * hitOffset - hitOffset,
@@ -96,26 +106,55 @@ export const getEndpointHitTargetRect = (
 }
 
 const getEndpointGripRect = (
-  hitTarget: ReturnType<typeof getEndpointHitTargetRect>,
+  point: IPoint,
   side?: EndpointSide,
-  screenScale = 1
+  screenScale = 1,
+  outwardDir?: IPoint
 ) => {
-  const isHorizontalGrip = side === Position.Left || side === Position.Right
-  const width =
-    (isHorizontalGrip
-      ? FREEFORM_ENDPOINT_GRIP_LONG_AXIS
-      : FREEFORM_ENDPOINT_GRIP_SHORT_AXIS) * screenScale
-  const height =
-    (isHorizontalGrip
-      ? FREEFORM_ENDPOINT_GRIP_SHORT_AXIS
-      : FREEFORM_ENDPOINT_GRIP_LONG_AXIS) * screenScale
+  // Anchor the grip to the endpoint (+ small clearance for the marker), not the
+  // centre of the wide hit-target — otherwise it floats ~22px off the tip when
+  // zoomed out. The hit-target stays wide for grabbing.
+  const radius = FREEFORM_ENDPOINT_GRIP_RADIUS * screenScale
+  const long = FREEFORM_ENDPOINT_GRIP_LONG_AXIS * screenScale
+  const short = FREEFORM_ENDPOINT_GRIP_SHORT_AXIS * screenScale
 
+  if (outwardDir) {
+    // Straight edge: a bar whose long axis runs ALONG the edge, offset outward
+    // along it and rotated to its angle — so the grip tracks the line, not an
+    // orthogonal N/E/S/W side.
+    const dir = normalizeDir(outwardDir)
+    const clearance = long / 2 + radius
+    const cx = point.x + dir.x * clearance
+    const cy = point.y + dir.y * clearance
+    return {
+      x: cx - long / 2,
+      y: cy - short / 2,
+      width: long,
+      height: short,
+      radius,
+      rotationDeg: (Math.atan2(dir.y, dir.x) * 180) / Math.PI,
+      centerX: cx,
+      centerY: cy,
+    }
+  }
+
+  // Step edge: orthogonal grip aligned to the endpoint's side.
+  const isHorizontalGrip = side === Position.Left || side === Position.Right
+  const width = isHorizontalGrip ? long : short
+  const height = isHorizontalGrip ? short : long
+  const dir = getEndpointDirection(side)
+  const clearance = (isHorizontalGrip ? width : height) / 2 + radius
+  const cx = point.x + dir.x * clearance
+  const cy = point.y + dir.y * clearance
   return {
-    x: hitTarget.x + hitTarget.width / 2 - width / 2,
-    y: hitTarget.y + hitTarget.height / 2 - height / 2,
+    x: cx - width / 2,
+    y: cy - height / 2,
     width,
     height,
-    radius: FREEFORM_ENDPOINT_GRIP_RADIUS * screenScale,
+    radius,
+    rotationDeg: 0,
+    centerX: cx,
+    centerY: cy,
   }
 }
 
@@ -127,6 +166,7 @@ export const EdgeEndpointMarkers = ({
   isDiagramModifiable,
   canEditEndpoint = true,
   onEndpointPointerDown,
+  straight = false,
 }: {
   sourcePoint: IPoint
   targetPoint: IPoint
@@ -138,6 +178,9 @@ export const EdgeEndpointMarkers = ({
     event: ReactPointerEvent<SVGRectElement>,
     endpoint: "source" | "target"
   ) => void
+  // Direct/straight edges: orient the grip + hit-target along the actual edge
+  // angle instead of the endpoint's orthogonal N/E/S/W side.
+  straight?: boolean
 }) => {
   const sourceHandleRef = useRef<SVGRectElement | null>(null)
   const screenScale = useHandleScreenScale()
@@ -145,9 +188,9 @@ export const EdgeEndpointMarkers = ({
   useEffect(() => {
     if (!isDiagramModifiable) return
 
-    // NOTE: `.react-flow__edgeupdater*` are React Flow v12 internal class names.
-    // We deliberately defer reconnection to RF's native updater while our hit
-    // target controls UX; pin to RF v12 (revisit on a major React Flow bump).
+    // `.react-flow__edgeupdater*` are React Flow v12 internal class names.
+    // Reconnection defers to RF's native updater while the hit target controls
+    // UX; pinned to RF v12 (revisit on a major React Flow bump).
     const edgeGroup = sourceHandleRef.current?.closest(".react-flow__edge")
     const nativeUpdaters = Array.from(
       edgeGroup?.querySelectorAll<SVGElement>(".react-flow__edgeupdater") ?? []
@@ -187,8 +230,8 @@ export const EdgeEndpointMarkers = ({
     event.stopPropagation()
     const eventWindow = event.currentTarget.ownerDocument.defaultView ?? window
 
-    // Deliberately hand off to React Flow's native reconnect updater so
-    // reconnection stays owned by React Flow while our hit target controls UX.
+    // Hand off to React Flow's native reconnect updater so reconnection stays
+    // owned by React Flow while the hit target controls UX.
     nativeUpdater.dispatchEvent(
       new eventWindow.MouseEvent("mousedown", {
         bubbles: true,
@@ -206,17 +249,30 @@ export const EdgeEndpointMarkers = ({
       })
     )
   }
+  // For a straight edge the grip sits on the line, offset from its endpoint
+  // TOWARD the other endpoint (so it clears the marker on the node side) and
+  // rotated to the edge angle — the same "along the edge, away from the node"
+  // placement the orthogonal side gives a step edge. Step edges pass no
+  // direction and fall back to the side.
+  const sourceOutward = straight
+    ? { x: targetPoint.x - sourcePoint.x, y: targetPoint.y - sourcePoint.y }
+    : undefined
+  const targetOutward = straight
+    ? { x: sourcePoint.x - targetPoint.x, y: sourcePoint.y - targetPoint.y }
+    : undefined
   const sourceHitTarget = getEndpointHitTargetRect(
     sourcePoint,
     sourcePosition,
     screenScale,
-    onEndpointPointerDown ? FREEFORM_ENDPOINT_HIT_TARGET_SIZE : undefined
+    onEndpointPointerDown ? FREEFORM_ENDPOINT_HIT_TARGET_SIZE : undefined,
+    sourceOutward
   )
   const targetHitTarget = getEndpointHitTargetRect(
     targetPoint,
     targetPosition,
     screenScale,
-    onEndpointPointerDown ? FREEFORM_ENDPOINT_HIT_TARGET_SIZE : undefined
+    onEndpointPointerDown ? FREEFORM_ENDPOINT_HIT_TARGET_SIZE : undefined,
+    targetOutward
   )
   const className = [
     "edge-endpoint-handle",
@@ -226,14 +282,16 @@ export const EdgeEndpointMarkers = ({
     .join(" ")
   const showEndpointGrips = Boolean(onEndpointPointerDown)
   const sourceGrip = getEndpointGripRect(
-    sourceHitTarget,
+    sourcePoint,
     sourcePosition,
-    screenScale
+    screenScale,
+    sourceOutward
   )
   const targetGrip = getEndpointGripRect(
-    targetHitTarget,
+    targetPoint,
     targetPosition,
-    screenScale
+    screenScale,
+    targetOutward
   )
 
   return (
@@ -248,6 +306,7 @@ export const EdgeEndpointMarkers = ({
             height={sourceGrip.height}
             rx={sourceGrip.radius}
             ry={sourceGrip.radius}
+            transform={`rotate(${sourceGrip.rotationDeg} ${sourceGrip.centerX} ${sourceGrip.centerY})`}
             pointerEvents="none"
           />
           <rect
@@ -258,6 +317,7 @@ export const EdgeEndpointMarkers = ({
             height={targetGrip.height}
             rx={targetGrip.radius}
             ry={targetGrip.radius}
+            transform={`rotate(${targetGrip.rotationDeg} ${targetGrip.centerX} ${targetGrip.centerY})`}
             pointerEvents="none"
           />
         </>

--- a/library/lib/edges/GenericEdge.tsx
+++ b/library/lib/edges/GenericEdge.tsx
@@ -39,6 +39,10 @@ const useHandleScreenScale = (): number =>
   getHandleScreenScale(useStore((state) => state.transform[2]))
 
 export type BaseEdgeProps = ExtendedEdgeProps
+const FREEFORM_ENDPOINT_HIT_TARGET_SIZE = 44
+const FREEFORM_ENDPOINT_GRIP_LONG_AXIS = 18
+const FREEFORM_ENDPOINT_GRIP_SHORT_AXIS = 8
+const FREEFORM_ENDPOINT_GRIP_RADIUS = 4
 
 export const useEdgeState = (initialPoints?: IPoint[]) => {
   const [customPoints, setCustomPoints] = useState<IPoint[]>([])
@@ -75,9 +79,10 @@ const getEndpointDirection = (side?: EndpointSide): IPoint => {
 export const getEndpointHitTargetRect = (
   point: IPoint,
   side?: EndpointSide,
-  screenScale = 1
+  screenScale = 1,
+  hitTargetSize: number = EDGES.ENDPOINT_HIT_TARGET_SIZE
 ) => {
-  const hitSize = EDGES.ENDPOINT_HIT_TARGET_SIZE * screenScale
+  const hitSize = hitTargetSize * screenScale
   const hitOffset = hitSize / 2
   const direction = getEndpointDirection(side)
 
@@ -90,6 +95,30 @@ export const getEndpointHitTargetRect = (
   }
 }
 
+const getEndpointGripRect = (
+  hitTarget: ReturnType<typeof getEndpointHitTargetRect>,
+  side?: EndpointSide,
+  screenScale = 1
+) => {
+  const isHorizontalGrip = side === Position.Left || side === Position.Right
+  const width =
+    (isHorizontalGrip
+      ? FREEFORM_ENDPOINT_GRIP_LONG_AXIS
+      : FREEFORM_ENDPOINT_GRIP_SHORT_AXIS) * screenScale
+  const height =
+    (isHorizontalGrip
+      ? FREEFORM_ENDPOINT_GRIP_SHORT_AXIS
+      : FREEFORM_ENDPOINT_GRIP_LONG_AXIS) * screenScale
+
+  return {
+    x: hitTarget.x + hitTarget.width / 2 - width / 2,
+    y: hitTarget.y + hitTarget.height / 2 - height / 2,
+    width,
+    height,
+    radius: FREEFORM_ENDPOINT_GRIP_RADIUS * screenScale,
+  }
+}
+
 export const EdgeEndpointMarkers = ({
   sourcePoint,
   targetPoint,
@@ -97,6 +126,7 @@ export const EdgeEndpointMarkers = ({
   targetPosition,
   isDiagramModifiable,
   canEditEndpoint = true,
+  onEndpointPointerDown,
 }: {
   sourcePoint: IPoint
   targetPoint: IPoint
@@ -104,6 +134,10 @@ export const EdgeEndpointMarkers = ({
   targetPosition?: EndpointSide
   isDiagramModifiable: boolean
   canEditEndpoint?: boolean
+  onEndpointPointerDown?: (
+    event: ReactPointerEvent<SVGRectElement>,
+    endpoint: "source" | "target"
+  ) => void
 }) => {
   const sourceHandleRef = useRef<SVGRectElement | null>(null)
   const screenScale = useHandleScreenScale()
@@ -175,12 +209,14 @@ export const EdgeEndpointMarkers = ({
   const sourceHitTarget = getEndpointHitTargetRect(
     sourcePoint,
     sourcePosition,
-    screenScale
+    screenScale,
+    onEndpointPointerDown ? FREEFORM_ENDPOINT_HIT_TARGET_SIZE : undefined
   )
   const targetHitTarget = getEndpointHitTargetRect(
     targetPoint,
     targetPosition,
-    screenScale
+    screenScale,
+    onEndpointPointerDown ? FREEFORM_ENDPOINT_HIT_TARGET_SIZE : undefined
   )
   const className = [
     "edge-endpoint-handle",
@@ -188,9 +224,44 @@ export const EdgeEndpointMarkers = ({
   ]
     .filter(Boolean)
     .join(" ")
+  const showEndpointGrips = Boolean(onEndpointPointerDown)
+  const sourceGrip = getEndpointGripRect(
+    sourceHitTarget,
+    sourcePosition,
+    screenScale
+  )
+  const targetGrip = getEndpointGripRect(
+    targetHitTarget,
+    targetPosition,
+    screenScale
+  )
 
   return (
     <>
+      {showEndpointGrips && (
+        <>
+          <rect
+            className="edge-circle edge-endpoint-grip edge-endpoint-grip--source"
+            x={sourceGrip.x}
+            y={sourceGrip.y}
+            width={sourceGrip.width}
+            height={sourceGrip.height}
+            rx={sourceGrip.radius}
+            ry={sourceGrip.radius}
+            pointerEvents="none"
+          />
+          <rect
+            className="edge-circle edge-endpoint-grip edge-endpoint-grip--target"
+            x={targetGrip.x}
+            y={targetGrip.y}
+            width={targetGrip.width}
+            height={targetGrip.height}
+            rx={targetGrip.radius}
+            ry={targetGrip.radius}
+            pointerEvents="none"
+          />
+        </>
+      )}
       <rect
         ref={sourceHandleRef}
         className={`${className} edge-endpoint-handle--source`}
@@ -201,8 +272,13 @@ export const EdgeEndpointMarkers = ({
         rx={sourceHitTarget.radius}
         ry={sourceHitTarget.radius}
         pointerEvents={canEditEndpoint ? "all" : "none"}
+        onPointerDown={
+          canEditEndpoint && onEndpointPointerDown
+            ? (event) => onEndpointPointerDown(event, "source")
+            : undefined
+        }
         onMouseDown={
-          canEditEndpoint
+          canEditEndpoint && !onEndpointPointerDown
             ? (event) => forwardToNativeReconnect(event, "source")
             : undefined
         }
@@ -216,8 +292,13 @@ export const EdgeEndpointMarkers = ({
         rx={targetHitTarget.radius}
         ry={targetHitTarget.radius}
         pointerEvents={canEditEndpoint ? "all" : "none"}
+        onPointerDown={
+          canEditEndpoint && onEndpointPointerDown
+            ? (event) => onEndpointPointerDown(event, "target")
+            : undefined
+        }
         onMouseDown={
-          canEditEndpoint
+          canEditEndpoint && !onEndpointPointerDown
             ? (event) => forwardToNativeReconnect(event, "target")
             : undefined
         }
@@ -292,6 +373,7 @@ export const StepEdgeBody = ({
   targetPosition,
   isDiagramModifiable,
   canEditEndpoint,
+  handleEndpointPointerDown,
   allowMidpointDragging,
   bendHandles,
   handlePointerDown,
@@ -316,6 +398,10 @@ export const StepEdgeBody = ({
   targetPosition?: Position
   isDiagramModifiable: boolean
   canEditEndpoint: boolean
+  handleEndpointPointerDown?: (
+    event: ReactPointerEvent<SVGRectElement>,
+    endpoint: "source" | "target"
+  ) => void
   allowMidpointDragging: boolean
   bendHandles: BendHandle[]
   handlePointerDown: (
@@ -366,6 +452,7 @@ export const StepEdgeBody = ({
         targetPosition={targetPosition}
         isDiagramModifiable={isDiagramModifiable}
         canEditEndpoint={canEditEndpoint}
+        onEndpointPointerDown={handleEndpointPointerDown}
       />
 
       {isDiagramModifiable &&

--- a/library/lib/edges/edgeTypes/ActivityDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/ActivityDiagramEdge.tsx
@@ -55,6 +55,7 @@ export const ActivityDiagramEdge = ({
     markerStart,
     strokeDashArray,
     handlePointerDown,
+    handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
     isDiagramModifiable,
@@ -105,6 +106,7 @@ export const ActivityDiagramEdge = ({
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}
           bendHandles={bendHandles}
+          handleEndpointPointerDown={handleEndpointPointerDown}
           handlePointerDown={handlePointerDown}
         />
 

--- a/library/lib/edges/edgeTypes/ActivityDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/ActivityDiagramEdge.tsx
@@ -58,6 +58,8 @@ export const ActivityDiagramEdge = ({
     handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
   } = useStepPathEdge({
@@ -100,8 +102,8 @@ export const ActivityDiagramEdge = ({
           markerEnd={markerEnd}
           sourcePoint={sourcePoint}
           targetPoint={targetPoint}
-          sourcePosition={sourcePosition}
-          targetPosition={targetPosition}
+          sourcePosition={renderSourcePosition}
+          targetPosition={renderTargetPosition}
           isDiagramModifiable={isDiagramModifiable}
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}

--- a/library/lib/edges/edgeTypes/BPMNDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/BPMNDiagramEdge.tsx
@@ -63,6 +63,7 @@ export const BPMNDiagramEdge = ({
     markerStart,
     strokeDashArray,
     handlePointerDown,
+    handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
     isDiagramModifiable,
@@ -113,6 +114,7 @@ export const BPMNDiagramEdge = ({
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}
           bendHandles={bendHandles}
+          handleEndpointPointerDown={handleEndpointPointerDown}
           handlePointerDown={handlePointerDown}
         />
 

--- a/library/lib/edges/edgeTypes/BPMNDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/BPMNDiagramEdge.tsx
@@ -66,6 +66,8 @@ export const BPMNDiagramEdge = ({
     handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
   } = useStepPathEdge({
@@ -108,8 +110,8 @@ export const BPMNDiagramEdge = ({
           markerEnd={markerEnd}
           sourcePoint={sourcePoint}
           targetPoint={targetPoint}
-          sourcePosition={sourcePosition}
-          targetPosition={targetPosition}
+          sourcePosition={renderSourcePosition}
+          targetPosition={renderTargetPosition}
           isDiagramModifiable={isDiagramModifiable}
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}

--- a/library/lib/edges/edgeTypes/ClassDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/ClassDiagramEdge.tsx
@@ -68,6 +68,7 @@ export const ClassDiagramEdge = ({
     markerStart,
     strokeDashArray,
     handlePointerDown,
+    handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
     isDiagramModifiable,
@@ -116,6 +117,7 @@ export const ClassDiagramEdge = ({
           targetPosition={targetPosition}
           isDiagramModifiable={isDiagramModifiable}
           canEditEndpoint={canEditEndpoint}
+          handleEndpointPointerDown={handleEndpointPointerDown}
           allowMidpointDragging={allowMidpointDragging}
           bendHandles={bendHandles}
           handlePointerDown={handlePointerDown}

--- a/library/lib/edges/edgeTypes/ClassDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/ClassDiagramEdge.tsx
@@ -71,6 +71,8 @@ export const ClassDiagramEdge = ({
     handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
   } = useStepPathEdge({
@@ -113,8 +115,8 @@ export const ClassDiagramEdge = ({
           markerEnd={markerEnd}
           sourcePoint={sourcePoint}
           targetPoint={targetPoint}
-          sourcePosition={sourcePosition}
-          targetPosition={targetPosition}
+          sourcePosition={renderSourcePosition}
+          targetPosition={renderTargetPosition}
           isDiagramModifiable={isDiagramModifiable}
           canEditEndpoint={canEditEndpoint}
           handleEndpointPointerDown={handleEndpointPointerDown}
@@ -130,8 +132,8 @@ export const ClassDiagramEdge = ({
           sourceY={sourceY}
           targetX={targetX}
           targetY={targetY}
-          sourcePosition={sourcePosition}
-          targetPosition={targetPosition}
+          sourcePosition={renderSourcePosition}
+          targetPosition={renderTargetPosition}
           textColor={textColor}
         />
 

--- a/library/lib/edges/edgeTypes/CommunicationDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/CommunicationDiagramEdge.tsx
@@ -60,6 +60,8 @@ export const CommunicationDiagramEdge = ({
     handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
   } = useStepPathEdge({
@@ -111,8 +113,8 @@ export const CommunicationDiagramEdge = ({
           markerEnd={markerEnd}
           sourcePoint={sourcePoint}
           targetPoint={targetPoint}
-          sourcePosition={sourcePosition}
-          targetPosition={targetPosition}
+          sourcePosition={renderSourcePosition}
+          targetPosition={renderTargetPosition}
           isDiagramModifiable={isDiagramModifiable}
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}

--- a/library/lib/edges/edgeTypes/CommunicationDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/CommunicationDiagramEdge.tsx
@@ -57,6 +57,7 @@ export const CommunicationDiagramEdge = ({
     markerStart,
     strokeDashArray,
     handlePointerDown,
+    handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
     isDiagramModifiable,
@@ -116,6 +117,7 @@ export const CommunicationDiagramEdge = ({
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}
           bendHandles={bendHandles}
+          handleEndpointPointerDown={handleEndpointPointerDown}
           handlePointerDown={handlePointerDown}
         />
 

--- a/library/lib/edges/edgeTypes/ComponentDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/ComponentDiagramEdge.tsx
@@ -80,6 +80,7 @@ export const ComponentDiagramEdge = ({
     markerStart,
     strokeDashArray,
     handlePointerDown,
+    handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
     isDiagramModifiable,
@@ -130,6 +131,7 @@ export const ComponentDiagramEdge = ({
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}
           bendHandles={bendHandles}
+          handleEndpointPointerDown={handleEndpointPointerDown}
           handlePointerDown={handlePointerDown}
         />
 

--- a/library/lib/edges/edgeTypes/ComponentDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/ComponentDiagramEdge.tsx
@@ -83,6 +83,8 @@ export const ComponentDiagramEdge = ({
     handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
   } = useStepPathEdge({
@@ -125,8 +127,8 @@ export const ComponentDiagramEdge = ({
           markerEnd={markerEnd}
           sourcePoint={sourcePoint}
           targetPoint={targetPoint}
-          sourcePosition={sourcePosition}
-          targetPosition={targetPosition}
+          sourcePosition={renderSourcePosition}
+          targetPosition={renderTargetPosition}
           isDiagramModifiable={isDiagramModifiable}
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}

--- a/library/lib/edges/edgeTypes/DeploymentDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/DeploymentDiagramEdge.tsx
@@ -86,6 +86,8 @@ export const DeploymentDiagramEdge = ({
     handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
   } = useStepPathEdge({
@@ -128,8 +130,8 @@ export const DeploymentDiagramEdge = ({
           markerEnd={markerEnd}
           sourcePoint={sourcePoint}
           targetPoint={targetPoint}
-          sourcePosition={sourcePosition}
-          targetPosition={targetPosition}
+          sourcePosition={renderSourcePosition}
+          targetPosition={renderTargetPosition}
           isDiagramModifiable={isDiagramModifiable}
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}

--- a/library/lib/edges/edgeTypes/DeploymentDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/DeploymentDiagramEdge.tsx
@@ -83,6 +83,7 @@ export const DeploymentDiagramEdge = ({
     markerStart,
     strokeDashArray,
     handlePointerDown,
+    handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
     isDiagramModifiable,
@@ -133,6 +134,7 @@ export const DeploymentDiagramEdge = ({
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}
           bendHandles={bendHandles}
+          handleEndpointPointerDown={handleEndpointPointerDown}
           handlePointerDown={handlePointerDown}
         />
 

--- a/library/lib/edges/edgeTypes/FlowChartEdge.tsx
+++ b/library/lib/edges/edgeTypes/FlowChartEdge.tsx
@@ -55,6 +55,7 @@ export const FlowChartEdge = ({
     markerStart,
     strokeDashArray,
     handlePointerDown,
+    handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
     isDiagramModifiable,
@@ -105,6 +106,7 @@ export const FlowChartEdge = ({
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}
           bendHandles={bendHandles}
+          handleEndpointPointerDown={handleEndpointPointerDown}
           handlePointerDown={handlePointerDown}
         />
 

--- a/library/lib/edges/edgeTypes/FlowChartEdge.tsx
+++ b/library/lib/edges/edgeTypes/FlowChartEdge.tsx
@@ -58,6 +58,8 @@ export const FlowChartEdge = ({
     handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
   } = useStepPathEdge({
@@ -100,8 +102,8 @@ export const FlowChartEdge = ({
           markerEnd={markerEnd}
           sourcePoint={sourcePoint}
           targetPoint={targetPoint}
-          sourcePosition={sourcePosition}
-          targetPosition={targetPosition}
+          sourcePosition={renderSourcePosition}
+          targetPosition={renderTargetPosition}
           isDiagramModifiable={isDiagramModifiable}
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}

--- a/library/lib/edges/edgeTypes/ObjectDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/ObjectDiagramEdge.tsx
@@ -54,6 +54,7 @@ export const ObjectDiagramEdge = ({
     markerStart,
     strokeDashArray,
     handlePointerDown,
+    handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
     isDiagramModifiable,
@@ -104,6 +105,7 @@ export const ObjectDiagramEdge = ({
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}
           bendHandles={bendHandles}
+          handleEndpointPointerDown={handleEndpointPointerDown}
           handlePointerDown={handlePointerDown}
         />
 

--- a/library/lib/edges/edgeTypes/ObjectDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/ObjectDiagramEdge.tsx
@@ -57,6 +57,8 @@ export const ObjectDiagramEdge = ({
     handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
   } = useStepPathEdge({
@@ -99,8 +101,8 @@ export const ObjectDiagramEdge = ({
           markerEnd={markerEnd}
           sourcePoint={sourcePoint}
           targetPoint={targetPoint}
-          sourcePosition={sourcePosition}
-          targetPosition={targetPosition}
+          sourcePosition={renderSourcePosition}
+          targetPosition={renderTargetPosition}
           isDiagramModifiable={isDiagramModifiable}
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}

--- a/library/lib/edges/edgeTypes/PetriNetEdge.tsx
+++ b/library/lib/edges/edgeTypes/PetriNetEdge.tsx
@@ -62,6 +62,7 @@ export const PetriNetEdge = ({
     isDiagramModifiable,
     isReconnecting,
     canEditEndpoint,
+    handleEndpointPointerDown,
   } = useStraightPathEdge({
     id,
     type,
@@ -75,6 +76,7 @@ export const PetriNetEdge = ({
     targetPosition,
     sourceHandleId,
     targetHandleId,
+    data,
   })
 
   const { strokeColor, textColor } = getCustomColorsFromDataForEdge(data)
@@ -122,6 +124,7 @@ export const PetriNetEdge = ({
               targetPosition={targetPosition}
               isDiagramModifiable={isDiagramModifiable}
               canEditEndpoint={canEditEndpoint}
+              onEndpointPointerDown={handleEndpointPointerDown}
             />
           )}
         </g>

--- a/library/lib/edges/edgeTypes/PetriNetEdge.tsx
+++ b/library/lib/edges/edgeTypes/PetriNetEdge.tsx
@@ -127,6 +127,7 @@ export const PetriNetEdge = ({
               isDiagramModifiable={isDiagramModifiable}
               canEditEndpoint={canEditEndpoint}
               onEndpointPointerDown={handleEndpointPointerDown}
+              straight
             />
           )}
         </g>

--- a/library/lib/edges/edgeTypes/PetriNetEdge.tsx
+++ b/library/lib/edges/edgeTypes/PetriNetEdge.tsx
@@ -59,6 +59,8 @@ export const PetriNetEdge = ({
     strokeDashArray,
     sourcePoint,
     targetPoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
     isDiagramModifiable,
     isReconnecting,
     canEditEndpoint,
@@ -120,8 +122,8 @@ export const PetriNetEdge = ({
             <EdgeEndpointMarkers
               sourcePoint={sourcePoint}
               targetPoint={targetPoint}
-              sourcePosition={sourcePosition}
-              targetPosition={targetPosition}
+              sourcePosition={renderSourcePosition}
+              targetPosition={renderTargetPosition}
               isDiagramModifiable={isDiagramModifiable}
               canEditEndpoint={canEditEndpoint}
               onEndpointPointerDown={handleEndpointPointerDown}

--- a/library/lib/edges/edgeTypes/ReachabilityGraphArc.tsx
+++ b/library/lib/edges/edgeTypes/ReachabilityGraphArc.tsx
@@ -55,6 +55,7 @@ export const ReachabilityGraphEdge = ({
     markerStart,
     strokeDashArray,
     handlePointerDown,
+    handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
     isDiagramModifiable,
@@ -105,6 +106,7 @@ export const ReachabilityGraphEdge = ({
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}
           bendHandles={bendHandles}
+          handleEndpointPointerDown={handleEndpointPointerDown}
           handlePointerDown={handlePointerDown}
         />
 

--- a/library/lib/edges/edgeTypes/ReachabilityGraphArc.tsx
+++ b/library/lib/edges/edgeTypes/ReachabilityGraphArc.tsx
@@ -58,6 +58,8 @@ export const ReachabilityGraphEdge = ({
     handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
   } = useStepPathEdge({
@@ -100,8 +102,8 @@ export const ReachabilityGraphEdge = ({
           markerEnd={markerEnd}
           sourcePoint={sourcePoint}
           targetPoint={targetPoint}
-          sourcePosition={sourcePosition}
-          targetPosition={targetPosition}
+          sourcePosition={renderSourcePosition}
+          targetPosition={renderTargetPosition}
           isDiagramModifiable={isDiagramModifiable}
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}

--- a/library/lib/edges/edgeTypes/SfcDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/SfcDiagramEdge.tsx
@@ -81,6 +81,7 @@ export const SfcDiagramEdge = ({
     markerStart,
     strokeDashArray,
     handlePointerDown,
+    handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
     isDiagramModifiable,
@@ -187,6 +188,7 @@ export const SfcDiagramEdge = ({
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}
           bendHandles={visibleBendHandles}
+          handleEndpointPointerDown={handleEndpointPointerDown}
           handlePointerDown={handlePointerDown}
         >
           {/* SFC transition crossbar + condition label. Decorative, so it sets

--- a/library/lib/edges/edgeTypes/SfcDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/SfcDiagramEdge.tsx
@@ -84,6 +84,8 @@ export const SfcDiagramEdge = ({
     handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
   } = useStepPathEdge({
@@ -182,8 +184,8 @@ export const SfcDiagramEdge = ({
           markerEnd={markerEnd}
           sourcePoint={sourcePoint}
           targetPoint={targetPoint}
-          sourcePosition={sourcePosition}
-          targetPosition={targetPosition}
+          sourcePosition={renderSourcePosition}
+          targetPosition={renderTargetPosition}
           isDiagramModifiable={isDiagramModifiable}
           canEditEndpoint={canEditEndpoint}
           allowMidpointDragging={allowMidpointDragging}

--- a/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
+++ b/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
@@ -1,5 +1,9 @@
 import { BaseEdge } from "@xyflow/react"
-import { BaseEdgeProps, CommonEdgeElements } from "../GenericEdge"
+import {
+  BaseEdgeProps,
+  CommonEdgeElements,
+  EdgeEndpointMarkers,
+} from "../GenericEdge"
 import { useStraightPathEdge } from "@/hooks/useStraightPathEdge"
 import { useDiagramStore, usePopoverStore } from "@/store/context"
 import { useShallow } from "zustand/shallow"
@@ -45,7 +49,11 @@ export const SyntaxTreeEdge = ({
     markerEnd,
     markerStart,
     strokeDashArray,
+    sourcePoint,
+    targetPoint,
     isDiagramModifiable,
+    canEditEndpoint,
+    handleEndpointPointerDown,
   } = useStraightPathEdge({
     id,
     type,
@@ -59,6 +67,7 @@ export const SyntaxTreeEdge = ({
     targetPosition,
     sourceHandleId,
     targetHandleId,
+    data,
   })
   const { strokeColor } = getCustomColorsFromDataForEdge(data)
   const markerKey = `${id}-${markerStart ?? "none"}-${markerEnd ?? "none"}`
@@ -88,6 +97,16 @@ export const SyntaxTreeEdge = ({
             strokeWidth={EDGES.EDGE_HIGHLIGHT_STROKE_WIDTH}
             pointerEvents="stroke"
             style={{ opacity: 0.4 }}
+          />
+
+          <EdgeEndpointMarkers
+            sourcePoint={sourcePoint}
+            targetPoint={targetPoint}
+            sourcePosition={sourcePosition}
+            targetPosition={targetPosition}
+            isDiagramModifiable={isDiagramModifiable}
+            canEditEndpoint={canEditEndpoint}
+            onEndpointPointerDown={handleEndpointPointerDown}
           />
         </g>
 

--- a/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
+++ b/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
@@ -51,6 +51,8 @@ export const SyntaxTreeEdge = ({
     strokeDashArray,
     sourcePoint,
     targetPoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
     handleEndpointPointerDown,
@@ -102,8 +104,8 @@ export const SyntaxTreeEdge = ({
           <EdgeEndpointMarkers
             sourcePoint={sourcePoint}
             targetPoint={targetPoint}
-            sourcePosition={sourcePosition}
-            targetPosition={targetPosition}
+            sourcePosition={renderSourcePosition}
+            targetPosition={renderTargetPosition}
             isDiagramModifiable={isDiagramModifiable}
             canEditEndpoint={canEditEndpoint}
             onEndpointPointerDown={handleEndpointPointerDown}

--- a/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
+++ b/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
@@ -109,6 +109,7 @@ export const SyntaxTreeEdge = ({
             isDiagramModifiable={isDiagramModifiable}
             canEditEndpoint={canEditEndpoint}
             onEndpointPointerDown={handleEndpointPointerDown}
+            straight
           />
         </g>
 

--- a/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
@@ -1,5 +1,9 @@
 import { BaseEdge } from "@xyflow/react"
-import { BaseEdgeProps, CommonEdgeElements } from "../GenericEdge"
+import {
+  BaseEdgeProps,
+  CommonEdgeElements,
+  EdgeEndpointMarkers,
+} from "../GenericEdge"
 import { EdgeMiddleLabels } from "../labelTypes/EdgeMiddleLabels"
 import { EdgeIncludeExtendLabel } from "../labelTypes/EdgeIncludeExtendLabel"
 import { useEdgeConfig } from "@/hooks/useEdgeConfig"
@@ -59,7 +63,11 @@ export const UseCaseEdge = ({
     markerEnd,
     markerStart,
     strokeDashArray,
+    sourcePoint,
+    targetPoint,
     isDiagramModifiable,
+    canEditEndpoint,
+    handleEndpointPointerDown,
   } = useStraightPathEdge({
     id,
     type,
@@ -73,6 +81,7 @@ export const UseCaseEdge = ({
     targetPosition,
     sourceHandleId,
     targetHandleId,
+    data,
   })
 
   const { strokeColor, textColor } = getCustomColorsFromDataForEdge(data)
@@ -111,6 +120,18 @@ export const UseCaseEdge = ({
             pointerEvents="stroke"
             style={{ opacity: 0.4 }}
           />
+
+          {!isReconnecting && (
+            <EdgeEndpointMarkers
+              sourcePoint={sourcePoint}
+              targetPoint={targetPoint}
+              sourcePosition={sourcePosition}
+              targetPosition={targetPosition}
+              isDiagramModifiable={isDiagramModifiable}
+              canEditEndpoint={canEditEndpoint}
+              onEndpointPointerDown={handleEndpointPointerDown}
+            />
+          )}
         </g>
 
         <EdgeMiddleLabels

--- a/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
@@ -65,6 +65,8 @@ export const UseCaseEdge = ({
     strokeDashArray,
     sourcePoint,
     targetPoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
     handleEndpointPointerDown,
@@ -125,8 +127,8 @@ export const UseCaseEdge = ({
             <EdgeEndpointMarkers
               sourcePoint={sourcePoint}
               targetPoint={targetPoint}
-              sourcePosition={sourcePosition}
-              targetPosition={targetPosition}
+              sourcePosition={renderSourcePosition}
+              targetPosition={renderTargetPosition}
               isDiagramModifiable={isDiagramModifiable}
               canEditEndpoint={canEditEndpoint}
               onEndpointPointerDown={handleEndpointPointerDown}

--- a/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
@@ -132,6 +132,7 @@ export const UseCaseEdge = ({
               isDiagramModifiable={isDiagramModifiable}
               canEditEndpoint={canEditEndpoint}
               onEndpointPointerDown={handleEndpointPointerDown}
+              straight
             />
           )}
         </g>

--- a/library/lib/hooks/useConnect.ts
+++ b/library/lib/hooks/useConnect.ts
@@ -9,20 +9,20 @@ import {
 } from "@xyflow/react"
 import { useCallback, useRef } from "react"
 import {
-  findClosestHandle,
   generateUUID,
   getDefaultEdgeType,
-  getFreeformAnchorFromPoint,
   getSideHandleIdForPosition,
+  type FreeformEdgeAnchor,
 } from "@/utils"
-import { DiagramNodeTypeRecord } from "@/nodes"
+import { getEdgeAnchorFromPoint } from "@/utils/connectionModes"
 import { useDiagramStore, useMetadataStore } from "@/store/context"
+import { useFreeformDropTarget } from "./useFreeformDropTarget"
 import { useShallow } from "zustand/shallow"
 
 const withEndpointAnchor = (
   data: Edge["data"],
   endpoint: "source" | "target",
-  anchor: ReturnType<typeof getFreeformAnchorFromPoint> | null
+  anchor: FreeformEdgeAnchor | null
 ): Edge["data"] => {
   const nextData = { ...((data ?? {}) as Record<string, unknown>) }
   const key = endpoint === "source" ? "sourceAnchor" : "targetAnchor"
@@ -124,8 +124,8 @@ const isSameNodeSameHandleArea = (
 export const useConnect = () => {
   const startEdge = useRef<Edge | null>(null)
   const connectionStartParams = useRef<OnConnectStartParams | null>(null)
-  const { screenToFlowPosition, getIntersectingNodes, getInternalNode } =
-    useReactFlow()
+  const { screenToFlowPosition, getIntersectingNodes } = useReactFlow()
+  const resolveDropTarget = useFreeformDropTarget()
   const { setEdges, addEdge, edges } = useDiagramStore(
     useShallow((state) => ({
       setEdges: state.setEdges,
@@ -144,22 +144,14 @@ export const useConnect = () => {
 
   const defaultEdgeType = getDefaultEdgeType(diagramType)
 
-  const isFourHandleNode = useCallback(
-    (nodeType?: string) =>
-      nodeType === DiagramNodeTypeRecord.componentInterface ||
-      nodeType === DiagramNodeTypeRecord.petriNetPlace ||
-      nodeType === DiagramNodeTypeRecord.petriNetTransition ||
-      nodeType === DiagramNodeTypeRecord.sfcTransitionBranch,
-    []
-  )
   const getDropPosition = useCallback(
     (event: MouseEvent | TouchEvent) => {
       const { clientX, clientY } =
         "changedTouches" in event ? event.changedTouches[0] : event
-      return screenToFlowPosition(
-        { x: clientX, y: clientY },
-        { snapToGrid: false }
-      )
+      // Inherit the editor's grid snapping so a new edge snaps its endpoint to
+      // the grid exactly like reconnect does; screenToFlowPosition is called
+      // without overriding snapToGrid.
+      return screenToFlowPosition({ x: clientX, y: clientY })
     },
     [screenToFlowPosition]
   )
@@ -228,48 +220,22 @@ export const useConnect = () => {
       try {
         if (!connectionState.isValid) {
           const dropPosition = getDropPosition(event)
-          const intersectingNodes = getIntersectingNodes({
-            x: dropPosition.x - 5,
-            y: dropPosition.y - 5,
-            width: 10,
-            height: 10,
-          })
-
-          if (intersectingNodes.length === 0) return
-
-          const fromNodeId = connectionState.fromNode?.id
-          const nodeOnTop =
-            intersectingNodes.findLast((node) => node.id !== fromNodeId) ??
-            intersectingNodes[intersectingNodes.length - 1]
-
-          const internalNodeData = getInternalNode(nodeOnTop.id)
-
-          if (
-            !internalNodeData ||
-            nodeOnTop.width == null ||
-            nodeOnTop.height == null
+          const nodeOnTop = resolveDropTarget(
+            dropPosition,
+            connectionState.fromNode?.id
           )
-            return
+          if (!nodeOnTop) return
 
-          const targetRect = {
-            x: internalNodeData.internals.positionAbsolute.x,
-            y: internalNodeData.internals.positionAbsolute.y,
-            width: nodeOnTop.width,
-            height: nodeOnTop.height,
-          }
-          const targetAnchor = getFreeformAnchorFromPoint(
+          const targetRect = nodeOnTop.rect
+          // Shape-aware: the anchor lands on the node's real shape (oval curve,
+          // diamond vertex, interface centre, …), not just its bounding box.
+          const targetAnchor = getEdgeAnchorFromPoint(
+            nodeOnTop.type,
             dropPosition,
             targetRect
           )
-          const targetHandle = targetAnchor
-            ? getSideHandleIdForPosition(targetAnchor.side)
-            : findClosestHandle({
-                point: dropPosition,
-                rect: targetRect,
-                useFourHandles: isFourHandleNode(nodeOnTop.type),
-              })
-
-          if (!targetHandle) return
+          if (!targetAnchor) return // node is not a connection target (mode "none")
+          const targetHandle = getSideHandleIdForPosition(targetAnchor.side)
 
           if (startEdge.current) {
             const updatedEdge = edges.find(
@@ -354,9 +320,7 @@ export const useConnect = () => {
       defaultEdgeType,
       edges,
       getDropPosition,
-      getInternalNode,
-      getIntersectingNodes,
-      isFourHandleNode,
+      resolveDropTarget,
       setEdges,
       stopConnectionGuidance,
     ]

--- a/library/lib/hooks/useConnect.ts
+++ b/library/lib/hooks/useConnect.ts
@@ -223,7 +223,11 @@ export const useConnect = () => {
             const sourceNodeId = connectionState.fromNode!.id
             const sourceHandleId = connectionState.fromHandle?.id
 
-            if (sourceNodeId === nodeOnTop.id) {
+            // Disallow loop from a handle to the same handle on the same node.
+            if (
+              sourceNodeId === nodeOnTop.id &&
+              sourceHandleId === targetHandle
+            ) {
               return
             }
 

--- a/library/lib/hooks/useConnect.ts
+++ b/library/lib/hooks/useConnect.ts
@@ -8,10 +8,38 @@ import {
   OnEdgesDelete,
 } from "@xyflow/react"
 import { useCallback, useRef } from "react"
-import { findClosestHandle, generateUUID, getDefaultEdgeType } from "@/utils"
+import {
+  findClosestHandle,
+  generateUUID,
+  getDefaultEdgeType,
+  getFreeformAnchorFromPoint,
+  getSideHandleIdForPosition,
+} from "@/utils"
 import { DiagramNodeTypeRecord } from "@/nodes"
 import { useDiagramStore, useMetadataStore } from "@/store/context"
 import { useShallow } from "zustand/shallow"
+import { UMLDiagramType } from "@/types"
+
+const withEndpointAnchor = (
+  data: Edge["data"],
+  endpoint: "source" | "target",
+  anchor: ReturnType<typeof getFreeformAnchorFromPoint> | null
+): Edge["data"] => {
+  const nextData = { ...((data ?? {}) as Record<string, unknown>) }
+  const key = endpoint === "source" ? "sourceAnchor" : "targetAnchor"
+
+  if (anchor) {
+    nextData[key] = anchor
+  } else {
+    delete nextData[key]
+  }
+
+  if (!Array.isArray(nextData.points)) {
+    nextData.points = []
+  }
+
+  return nextData
+}
 
 export const useConnect = () => {
   const startEdge = useRef<Edge | null>(null)
@@ -132,16 +160,23 @@ export const useConnect = () => {
           )
             return
 
-          const targetHandle = findClosestHandle({
-            point: dropPosition,
-            rect: {
-              x: internalNodeData.internals.positionAbsolute.x,
-              y: internalNodeData.internals.positionAbsolute.y,
-              width: nodeOnTop.width,
-              height: nodeOnTop.height,
-            },
-            useFourHandles: isFourHandleNode(nodeOnTop.type),
-          })
+          const targetRect = {
+            x: internalNodeData.internals.positionAbsolute.x,
+            y: internalNodeData.internals.positionAbsolute.y,
+            width: nodeOnTop.width,
+            height: nodeOnTop.height,
+          }
+          const targetAnchor =
+            diagramType === UMLDiagramType.ClassDiagram
+              ? getFreeformAnchorFromPoint(dropPosition, targetRect)
+              : null
+          const targetHandle = targetAnchor
+            ? getSideHandleIdForPosition(targetAnchor.side)
+            : findClosestHandle({
+                point: dropPosition,
+                rect: targetRect,
+                useFourHandles: isFourHandleNode(nodeOnTop.type),
+              })
 
           if (!targetHandle) return
 
@@ -153,11 +188,25 @@ export const useConnect = () => {
             if (!updatedEdge) return
             const newEdge =
               connectionStartParams.current?.handleType === "source"
-                ? { ...updatedEdge, target: nodeOnTop.id, targetHandle }
+                ? {
+                    ...updatedEdge,
+                    target: nodeOnTop.id,
+                    targetHandle,
+                    data: withEndpointAnchor(
+                      updatedEdge.data,
+                      "target",
+                      targetAnchor
+                    ),
+                  }
                 : {
                     ...updatedEdge,
                     source: nodeOnTop.id,
                     sourceHandle: targetHandle,
+                    data: withEndpointAnchor(
+                      updatedEdge.data,
+                      "source",
+                      targetAnchor
+                    ),
                   }
 
             // Disallow loop from a handle to the same handle on the same node.
@@ -175,11 +224,7 @@ export const useConnect = () => {
             const sourceNodeId = connectionState.fromNode!.id
             const sourceHandleId = connectionState.fromHandle?.id
 
-            // Disallow loop from a handle to itself, but allow loops to other handles.
-            if (
-              sourceNodeId === nodeOnTop.id &&
-              sourceHandleId === targetHandle
-            ) {
+            if (sourceNodeId === nodeOnTop.id) {
               return
             }
 
@@ -191,6 +236,7 @@ export const useConnect = () => {
                 type: defaultEdgeType,
                 sourceHandle: sourceHandleId,
                 targetHandle,
+                data: withEndpointAnchor(undefined, "target", targetAnchor),
               })
             )
           }
@@ -203,6 +249,7 @@ export const useConnect = () => {
     },
     [
       defaultEdgeType,
+      diagramType,
       edges,
       getDropPosition,
       getInternalNode,
@@ -217,7 +264,7 @@ export const useConnect = () => {
     startEdge.current = null
     connectionStartParams.current = null
     stopConnectionGuidance()
-  }, [setEdges, stopConnectionGuidance])
+  }, [stopConnectionGuidance])
 
   return { onConnect, onConnectEnd, onConnectStart, onEdgesDelete }
 }

--- a/library/lib/hooks/useConnect.ts
+++ b/library/lib/hooks/useConnect.ts
@@ -15,6 +15,7 @@ import {
   type FreeformEdgeAnchor,
 } from "@/utils"
 import { getEdgeAnchorFromPoint } from "@/utils/connectionModes"
+import { HandleId } from "@/nodes/wrappers"
 import { useDiagramStore, useMetadataStore } from "@/store/context"
 import { useFreeformDropTarget } from "./useFreeformDropTarget"
 import { useShallow } from "zustand/shallow"
@@ -40,52 +41,22 @@ const withEndpointAnchor = (
   return nextData
 }
 
-const handleSlotBySide: Record<string, Record<string, number>> = {
-  top: {
-    "top-left": 0,
-    "top-between-left-mid-left": 1,
-    "top-mid-left": 2,
-    "top-between-mid-left-center": 3,
-    top: 4,
-    "top-between-center-mid-right": 5,
-    "top-mid-right": 6,
-    "top-between-mid-right-right": 7,
-    "top-right": 8,
-  },
-  right: {
-    "right-top": 0,
-    "right-between-top-mid-top": 1,
-    "right-mid-top": 2,
-    "right-between-mid-top-center": 3,
-    right: 4,
-    "right-between-center-mid-bottom": 5,
-    "right-mid-bottom": 6,
-    "right-between-mid-bottom-bottom": 7,
-    "right-bottom": 8,
-  },
-  bottom: {
-    "bottom-right": 0,
-    "bottom-between-right-mid-right": 1,
-    "bottom-mid-right": 2,
-    "bottom-between-mid-right-center": 3,
-    bottom: 4,
-    "bottom-between-center-mid-left": 5,
-    "bottom-mid-left": 6,
-    "bottom-between-mid-left-left": 7,
-    "bottom-left": 8,
-  },
-  left: {
-    "left-bottom": 0,
-    "left-between-bottom-mid-bottom": 1,
-    "left-mid-bottom": 2,
-    "left-between-mid-bottom-center": 3,
-    left: 4,
-    "left-between-center-mid-top": 5,
-    "left-mid-top": 6,
-    "left-between-mid-top-top": 7,
-    "left-top": 8,
-  },
-}
+// Slot (0-8) of every connection handle within its side, derived from the
+// HandleId enum's declaration order — the single source of truth — so adding or
+// renaming a handle can't silently desync this from the real handles. Each id's
+// first path segment names its side; slots increment per side in enum order
+// (top-left … top-right, then right-top …).
+const handleSlotBySide: Record<string, Record<string, number>> = (() => {
+  const bySide: Record<string, Record<string, number>> = {}
+  const nextSlot: Record<string, number> = {}
+  for (const handleId of Object.values(HandleId)) {
+    const side = handleId.split("-")[0]
+    bySide[side] ??= {}
+    nextSlot[side] ??= 0
+    bySide[side][handleId] = nextSlot[side]++
+  }
+  return bySide
+})()
 
 const getHandleSideAndSlot = (
   handleId?: string | null

--- a/library/lib/hooks/useConnect.ts
+++ b/library/lib/hooks/useConnect.ts
@@ -45,8 +45,13 @@ const withEndpointAnchor = (
 // HandleId enum's declaration order — the single source of truth — so adding or
 // renaming a handle can't silently desync this from the real handles. Each id's
 // first path segment names its side; slots increment per side in enum order
-// (top-left … top-right, then right-top …).
-const handleSlotBySide: Record<string, Record<string, number>> = (() => {
+// (top-left … top-right, then right-top …). Built lazily on first use, not at
+// module load: HandleId is defined in the node-wrapper module this hook is in an
+// import cycle with, so it isn't initialised yet while this module's top-level
+// code runs (the sibling path hooks likewise only read HandleId at call time).
+let handleSlotBySideCache: Record<string, Record<string, number>> | null = null
+const handleSlotBySide = (): Record<string, Record<string, number>> => {
+  if (handleSlotBySideCache) return handleSlotBySideCache
   const bySide: Record<string, Record<string, number>> = {}
   const nextSlot: Record<string, number> = {}
   for (const handleId of Object.values(HandleId)) {
@@ -55,15 +60,16 @@ const handleSlotBySide: Record<string, Record<string, number>> = (() => {
     nextSlot[side] ??= 0
     bySide[side][handleId] = nextSlot[side]++
   }
+  handleSlotBySideCache = bySide
   return bySide
-})()
+}
 
 const getHandleSideAndSlot = (
   handleId?: string | null
 ): { side: string; slot: number } | null => {
   if (!handleId) return null
 
-  for (const [side, slots] of Object.entries(handleSlotBySide)) {
+  for (const [side, slots] of Object.entries(handleSlotBySide())) {
     const slot = slots[handleId]
     if (slot != null) return { side, slot }
   }

--- a/library/lib/hooks/useConnect.ts
+++ b/library/lib/hooks/useConnect.ts
@@ -18,7 +18,6 @@ import {
 import { DiagramNodeTypeRecord } from "@/nodes"
 import { useDiagramStore, useMetadataStore } from "@/store/context"
 import { useShallow } from "zustand/shallow"
-import { UMLDiagramType } from "@/types"
 
 const withEndpointAnchor = (
   data: Edge["data"],
@@ -166,10 +165,10 @@ export const useConnect = () => {
             width: nodeOnTop.width,
             height: nodeOnTop.height,
           }
-          const targetAnchor =
-            diagramType === UMLDiagramType.ClassDiagram
-              ? getFreeformAnchorFromPoint(dropPosition, targetRect)
-              : null
+          const targetAnchor = getFreeformAnchorFromPoint(
+            dropPosition,
+            targetRect
+          )
           const targetHandle = targetAnchor
             ? getSideHandleIdForPosition(targetAnchor.side)
             : findClosestHandle({
@@ -249,7 +248,6 @@ export const useConnect = () => {
     },
     [
       defaultEdgeType,
-      diagramType,
       edges,
       getDropPosition,
       getInternalNode,

--- a/library/lib/hooks/useConnect.ts
+++ b/library/lib/hooks/useConnect.ts
@@ -40,6 +40,87 @@ const withEndpointAnchor = (
   return nextData
 }
 
+const handleSlotBySide: Record<string, Record<string, number>> = {
+  top: {
+    "top-left": 0,
+    "top-between-left-mid-left": 1,
+    "top-mid-left": 2,
+    "top-between-mid-left-center": 3,
+    top: 4,
+    "top-between-center-mid-right": 5,
+    "top-mid-right": 6,
+    "top-between-mid-right-right": 7,
+    "top-right": 8,
+  },
+  right: {
+    "right-top": 0,
+    "right-between-top-mid-top": 1,
+    "right-mid-top": 2,
+    "right-between-mid-top-center": 3,
+    right: 4,
+    "right-between-center-mid-bottom": 5,
+    "right-mid-bottom": 6,
+    "right-between-mid-bottom-bottom": 7,
+    "right-bottom": 8,
+  },
+  bottom: {
+    "bottom-right": 0,
+    "bottom-between-right-mid-right": 1,
+    "bottom-mid-right": 2,
+    "bottom-between-mid-right-center": 3,
+    bottom: 4,
+    "bottom-between-center-mid-left": 5,
+    "bottom-mid-left": 6,
+    "bottom-between-mid-left-left": 7,
+    "bottom-left": 8,
+  },
+  left: {
+    "left-bottom": 0,
+    "left-between-bottom-mid-bottom": 1,
+    "left-mid-bottom": 2,
+    "left-between-mid-bottom-center": 3,
+    left: 4,
+    "left-between-center-mid-top": 5,
+    "left-mid-top": 6,
+    "left-between-mid-top-top": 7,
+    "left-top": 8,
+  },
+}
+
+const getHandleSideAndSlot = (
+  handleId?: string | null
+): { side: string; slot: number } | null => {
+  if (!handleId) return null
+
+  for (const [side, slots] of Object.entries(handleSlotBySide)) {
+    const slot = slots[handleId]
+    if (slot != null) return { side, slot }
+  }
+
+  return null
+}
+
+const isSameNodeSameHandleArea = (
+  source: string | null,
+  target: string | null,
+  sourceHandle?: string | null,
+  targetHandle?: string | null
+): boolean => {
+  if (!source || source !== target) return false
+
+  const sourceHandlePosition = getHandleSideAndSlot(sourceHandle)
+  const targetHandlePosition = getHandleSideAndSlot(targetHandle)
+
+  if (!sourceHandlePosition || !targetHandlePosition) {
+    return sourceHandle === targetHandle
+  }
+
+  return (
+    sourceHandlePosition.side === targetHandlePosition.side &&
+    Math.abs(sourceHandlePosition.slot - targetHandlePosition.slot) <= 1
+  )
+}
+
 export const useConnect = () => {
   const startEdge = useRef<Edge | null>(null)
   const connectionStartParams = useRef<OnConnectStartParams | null>(null)
@@ -119,6 +200,17 @@ export const useConnect = () => {
 
   const onConnect = useCallback(
     (connection: Connection) => {
+      if (
+        isSameNodeSameHandleArea(
+          connection.source,
+          connection.target,
+          connection.sourceHandle,
+          connection.targetHandle
+        )
+      ) {
+        return
+      }
+
       const newEdge: Edge = {
         ...connection,
         id: generateUUID(),
@@ -210,8 +302,12 @@ export const useConnect = () => {
 
             // Disallow loop from a handle to the same handle on the same node.
             if (
-              newEdge.source === newEdge.target &&
-              newEdge.sourceHandle === newEdge.targetHandle
+              isSameNodeSameHandleArea(
+                newEdge.source,
+                newEdge.target,
+                newEdge.sourceHandle,
+                newEdge.targetHandle
+              )
             ) {
               return
             }
@@ -225,8 +321,12 @@ export const useConnect = () => {
 
             // Disallow loop from a handle to the same handle on the same node.
             if (
-              sourceNodeId === nodeOnTop.id &&
-              sourceHandleId === targetHandle
+              isSameNodeSameHandleArea(
+                sourceNodeId,
+                nodeOnTop.id,
+                sourceHandleId,
+                targetHandle
+              )
             ) {
               return
             }

--- a/library/lib/hooks/useEdges.ts
+++ b/library/lib/hooks/useEdges.ts
@@ -37,11 +37,17 @@ export function useEdgePopOver(id: string) {
 
   const handleSwap = () => {
     const edge = reactFlow.getEdge(id)
+    const data = { ...(edge?.data ?? {}) }
     reactFlow.updateEdge(id, {
       source: edge?.target,
       sourceHandle: edge?.targetHandle,
       target: edge?.source,
       targetHandle: edge?.sourceHandle,
+      data: {
+        ...data,
+        sourceAnchor: data.targetAnchor,
+        targetAnchor: data.sourceAnchor,
+      },
     })
   }
 

--- a/library/lib/hooks/useFreeformDropTarget.ts
+++ b/library/lib/hooks/useFreeformDropTarget.ts
@@ -1,0 +1,72 @@
+import { useCallback } from "react"
+import { useReactFlow, type Rect, type XYPosition } from "@xyflow/react"
+import { getConnectionMode } from "@/utils/connectionModes"
+
+/** Distance from a point to a rectangle (0 when the point is inside it). */
+const distanceToRect = (p: XYPosition, r: Rect): number => {
+  const dx = Math.max(r.x - p.x, 0, p.x - (r.x + r.width))
+  const dy = Math.max(r.y - p.y, 0, p.y - (r.y + r.height))
+  return Math.hypot(dx, dy)
+}
+
+// Half-size of the box hit-tested around a drop point; a drop must land within
+// this of a node's bounding box to attach. Kept generous so a drop just outside
+// a rounded shape still connects: an oval's box hugs the curve at the cardinals
+// but bulges out at the diagonals, so too small a value would reject
+// near-cardinal drops that visually sit on the shape.
+const DROP_HIT_RADIUS_PX = 11
+
+export type FreeformDropTarget = { id: string; type?: string; rect: Rect }
+
+/**
+ * Resolve which node a freeform connection drop lands on, and its rectangle.
+ *
+ * Shared by the connection commit (`useConnect.onConnectEnd`) and the
+ * connection ghost preview (`ReconnectConnectionLine`) so the preview never
+ * promises a target the drop won't honour. Returns the nearest intersecting
+ * node to the drop (distance to its box, 0 when inside it), skipping the drag's
+ * own source, ties broken by z order, so a drop that merely grazes a
+ * neighbour's box still attaches to the node it is over. Null over empty canvas.
+ */
+export function useFreeformDropTarget() {
+  const { getIntersectingNodes, getInternalNode } = useReactFlow()
+  return useCallback(
+    (point: XYPosition, fromNodeId?: string): FreeformDropTarget | null => {
+      const hits = getIntersectingNodes({
+        x: point.x - DROP_HIT_RADIUS_PX,
+        y: point.y - DROP_HIT_RADIUS_PX,
+        width: DROP_HIT_RADIUS_PX * 2,
+        height: DROP_HIT_RADIUS_PX * 2,
+      }).filter((node) => node.width != null && node.height != null)
+      if (hits.length === 0) return null
+
+      // Prefer a node other than the drag's own source; only fall back to the
+      // source when it is the sole candidate (a body-drop self-loop).
+      const nonSource = hits.filter((node) => node.id !== fromNodeId)
+      const pool = nonSource.length > 0 ? nonSource : hits
+
+      let best: FreeformDropTarget | null = null
+      let bestDistance = Infinity
+      // Iterate low→high z so, on a distance tie, the later (top-most) node wins.
+      pool.forEach((node) => {
+        // Legends, annotations and swimlane partitions are not targets.
+        if (getConnectionMode(node.type) === "none") return
+        const internal = getInternalNode(node.id)
+        if (!internal) return
+        const rect: Rect = {
+          x: internal.internals.positionAbsolute.x,
+          y: internal.internals.positionAbsolute.y,
+          width: node.width!,
+          height: node.height!,
+        }
+        const distance = distanceToRect(point, rect)
+        if (distance <= bestDistance) {
+          bestDistance = distance
+          best = { id: node.id, type: node.type, rect }
+        }
+      })
+      return best
+    },
+    [getIntersectingNodes, getInternalNode]
+  )
+}

--- a/library/lib/hooks/useFreeformDropTarget.ts
+++ b/library/lib/hooks/useFreeformDropTarget.ts
@@ -1,13 +1,6 @@
 import { useCallback } from "react"
 import { useReactFlow, type Rect, type XYPosition } from "@xyflow/react"
-import { getConnectionMode } from "@/utils/connectionModes"
-
-/** Distance from a point to a rectangle (0 when the point is inside it). */
-const distanceToRect = (p: XYPosition, r: Rect): number => {
-  const dx = Math.max(r.x - p.x, 0, p.x - (r.x + r.width))
-  const dy = Math.max(r.y - p.y, 0, p.y - (r.y + r.height))
-  return Math.hypot(dx, dy)
-}
+import { pickNearestConnectable } from "@/utils/connectionModes"
 
 // Half-size of the box hit-tested around a drop point; a drop must land within
 // this of a node's bounding box to attach. Kept generous so a drop just outside
@@ -45,27 +38,27 @@ export function useFreeformDropTarget() {
       const nonSource = hits.filter((node) => node.id !== fromNodeId)
       const pool = nonSource.length > 0 ? nonSource : hits
 
-      let best: FreeformDropTarget | null = null
-      let bestDistance = Infinity
-      // Iterate low→high z so, on a distance tie, the later (top-most) node wins.
-      pool.forEach((node) => {
-        // Legends, annotations and swimlane partitions are not targets.
-        if (getConnectionMode(node.type) === "none") return
+      const candidates = pool.flatMap((node) => {
         const internal = getInternalNode(node.id)
-        if (!internal) return
-        const rect: Rect = {
-          x: internal.internals.positionAbsolute.x,
-          y: internal.internals.positionAbsolute.y,
-          width: node.width!,
-          height: node.height!,
-        }
-        const distance = distanceToRect(point, rect)
-        if (distance <= bestDistance) {
-          bestDistance = distance
-          best = { id: node.id, type: node.type, rect }
-        }
+        return internal
+          ? [
+              {
+                node,
+                type: node.type,
+                rect: {
+                  x: internal.internals.positionAbsolute.x,
+                  y: internal.internals.positionAbsolute.y,
+                  width: node.width!,
+                  height: node.height!,
+                },
+              },
+            ]
+          : []
       })
+      const best = pickNearestConnectable(candidates, point)
       return best
+        ? { id: best.node.id, type: best.node.type, rect: best.rect }
+        : null
     },
     [getIntersectingNodes, getInternalNode]
   )

--- a/library/lib/hooks/useFreeformEndpointNode.ts
+++ b/library/lib/hooks/useFreeformEndpointNode.ts
@@ -1,0 +1,63 @@
+import { useCallback } from "react"
+import { useReactFlow, type Node, type Rect } from "@xyflow/react"
+import { getPositionOnCanvas, isParentNodeType } from "@/utils"
+import { distanceToRect } from "@/utils/connectionModes"
+import type { IPoint } from "../edges/Connection"
+
+// While dragging a freeform edge endpoint, it snaps to a node within this many
+// px of the node's box.
+export const FREEFORM_ENDPOINT_SNAP_RADIUS_PX = 48
+
+/**
+ * Node-rect helpers shared by both edge path hooks' endpoint-drag logic: the
+ * on-canvas rectangle of a node, and the nearest connectable (non-parent) node
+ * to a point within the snap radius (the fallback when nothing intersects the
+ * pointer directly).
+ */
+export function useFreeformEndpointNode() {
+  const { getNodes } = useReactFlow()
+
+  const getNodeRect = useCallback(
+    (node: Node): Rect | null => {
+      const nodes = getNodes()
+      const currentNode = nodes.find((candidate) => candidate.id === node.id)
+      const resolvedNode = currentNode ?? node
+      const width = resolvedNode.width ?? 0
+      const height = resolvedNode.height ?? 0
+
+      if (!width || !height) return null
+
+      const position = getPositionOnCanvas(resolvedNode, nodes)
+      return { x: position.x, y: position.y, width, height }
+    },
+    [getNodes]
+  )
+
+  const findFreeformEndpointNode = useCallback(
+    (flowPoint: IPoint): { node: Node; rect: Rect } | null => {
+      const nodes = getNodes()
+      let best: { node: Node; rect: Rect; distance: number } | null = null
+
+      for (const node of nodes) {
+        if (isParentNodeType(node.type)) continue
+
+        const rect = getNodeRect(node)
+        if (!rect) continue
+
+        const distance = distanceToRect(flowPoint, rect)
+
+        if (
+          distance <= FREEFORM_ENDPOINT_SNAP_RADIUS_PX &&
+          (!best || distance < best.distance)
+        ) {
+          best = { node, rect, distance }
+        }
+      }
+
+      return best ? { node: best.node, rect: best.rect } : null
+    },
+    [getNodeRect, getNodes]
+  )
+
+  return { getNodeRect, findFreeformEndpointNode }
+}

--- a/library/lib/hooks/useStepPathEdge.ts
+++ b/library/lib/hooks/useStepPathEdge.ts
@@ -251,32 +251,36 @@ export const useStepPathEdge = ({
   const targetNode =
     allNodes.find((node) => node.id === target) ?? getNode(target)
 
+  // Prefer the displayed React Flow node so a peer's live drag/resize overlay
+  // (applied to the nodes prop before it is persisted) keeps anchored endpoints
+  // attached during the movement; the subscribed store geometry is only a
+  // fallback (and the subscription that re-renders on the settled write).
   const sourceAbsolutePosition = useMemo(() => {
+    if (sourceNode) return getPositionOnCanvas(sourceNode, allNodes)
     if (sourceNodePositionX != null && sourceNodePositionY != null) {
       return { x: sourceNodePositionX, y: sourceNodePositionY }
     }
-    if (!sourceNode) return { x: reactFlowSourceX, y: reactFlowSourceY }
-    return getPositionOnCanvas(sourceNode, allNodes)
+    return { x: reactFlowSourceX, y: reactFlowSourceY }
   }, [
-    sourceNodePositionX,
-    sourceNodePositionY,
     sourceNode,
     allNodes,
+    sourceNodePositionX,
+    sourceNodePositionY,
     reactFlowSourceX,
     reactFlowSourceY,
   ])
 
   const targetAbsolutePosition = useMemo(() => {
+    if (targetNode) return getPositionOnCanvas(targetNode, allNodes)
     if (targetNodePositionX != null && targetNodePositionY != null) {
       return { x: targetNodePositionX, y: targetNodePositionY }
     }
-    if (!targetNode) return { x: reactFlowTargetX, y: reactFlowTargetY }
-    return getPositionOnCanvas(targetNode, allNodes)
+    return { x: reactFlowTargetX, y: reactFlowTargetY }
   }, [
-    targetNodePositionX,
-    targetNodePositionY,
     targetNode,
     allNodes,
+    targetNodePositionX,
+    targetNodePositionY,
     reactFlowTargetX,
     reactFlowTargetY,
   ])
@@ -287,8 +291,8 @@ export const useStepPathEdge = ({
         ? {
             x: sourceAbsolutePosition.x,
             y: sourceAbsolutePosition.y,
-            width: sourceNodeWidth ?? sourceNode.width ?? 0,
-            height: sourceNodeHeight ?? sourceNode.height ?? 0,
+            width: sourceNode.width ?? sourceNodeWidth ?? 0,
+            height: sourceNode.height ?? sourceNodeHeight ?? 0,
           }
         : null,
     [
@@ -305,8 +309,8 @@ export const useStepPathEdge = ({
         ? {
             x: targetAbsolutePosition.x,
             y: targetAbsolutePosition.y,
-            width: targetNodeWidth ?? targetNode.width ?? 0,
-            height: targetNodeHeight ?? targetNode.height ?? 0,
+            width: targetNode.width ?? targetNodeWidth ?? 0,
+            height: targetNode.height ?? targetNodeHeight ?? 0,
           }
         : null,
     [

--- a/library/lib/hooks/useStepPathEdge.ts
+++ b/library/lib/hooks/useStepPathEdge.ts
@@ -4,6 +4,7 @@ import {
   Position,
   useStore,
   useReactFlow,
+  type Node,
 } from "@xyflow/react"
 import { EDGES } from "@/constants"
 import {
@@ -33,6 +34,12 @@ import {
   normalizeOrthogonalEdgePoints,
   resolveOrthogonalEdgeReleasePoints,
   isInvalidOrthogonalEdgeRelease,
+  getFreeformAnchorFromPoint,
+  getFreeformAnchorPoint,
+  getSideHandleIdForPosition,
+  isClassDiagramEdgeType,
+  isFreeformEdgeAnchor,
+  type FreeformEdgeAnchor,
 } from "@/utils/edgeUtils"
 import {
   type BendHandle,
@@ -68,7 +75,11 @@ interface UseStepPathEdgeProps {
   targetPosition: Position
   sourceHandleId?: string | null
   targetHandleId?: string | null
-  data?: { points?: IPoint[] }
+  data?: {
+    points?: IPoint[]
+    sourceAnchor?: FreeformEdgeAnchor
+    targetAnchor?: FreeformEdgeAnchor
+  }
   allowMidpointDragging?: boolean
   enableStraightPath?: boolean
 }
@@ -92,6 +103,25 @@ export interface StepPathEdgeData {
   neighborGeometry: IPoint[][]
 }
 
+type EndpointType = "source" | "target"
+
+type EndpointDragCommit = {
+  endpoint: EndpointType
+  nodeId: string
+  handleId: string
+  anchor: FreeformEdgeAnchor
+  points: IPoint[]
+  sourceEndpoint: IPoint
+  targetEndpoint: IPoint
+  sourcePosition: Position
+  targetPosition: Position
+  sourceRect: Rect
+  targetRect: Rect
+  directPoints: IPoint[] | null
+}
+
+const FREEFORM_ENDPOINT_SNAP_RADIUS_PX = 48
+
 const arePointsEqual = (a: IPoint[], b: IPoint[]): boolean =>
   a.length === b.length &&
   a.every((point, index) => point.x === b[index].x && point.y === b[index].y)
@@ -101,12 +131,12 @@ export const useStepPathEdge = ({
   type,
   source,
   target,
-  sourceX,
-  sourceY,
-  targetX,
-  targetY,
-  sourcePosition,
-  targetPosition,
+  sourceX: reactFlowSourceX,
+  sourceY: reactFlowSourceY,
+  targetX: reactFlowTargetX,
+  targetY: reactFlowTargetY,
+  sourcePosition: reactFlowSourcePosition,
+  targetPosition: reactFlowTargetPosition,
   data,
   allowMidpointDragging = true,
   enableStraightPath = false,
@@ -121,13 +151,15 @@ export const useStepPathEdge = ({
   // release falls back to THIS — clamping at the last good position — instead
   // of snapping all the way back to the pre-drag shape.
   const lastValidDragRef = useRef<IPoint[]>([])
+  const endpointDragCommitRef = useRef<EndpointDragCommit | null>(null)
 
   const isDiagramModifiable = useDiagramModifiable()
   const zoom = useStore((state) => state.transform[2])
   const isReconnecting = useMetadataStore(
     (state) => state.reconnectPreviewEdgeId === id
   )
-  const { getNode, getNodes, screenToFlowPosition } = useReactFlow()
+  const { getIntersectingNodes, getNode, getNodes, screenToFlowPosition } =
+    useReactFlow()
 
   const [draggingHandle, setDraggingHandle] = useState<BendHandle | null>(null)
   // While a bend handle is being dragged we render from this live geometry
@@ -141,10 +173,63 @@ export const useStepPathEdge = ({
   )
 
   const { customPoints, setCustomPoints } = useEdgeState(data?.points)
-  const { setEdges } = useDiagramStore(
-    useShallow((state) => ({
-      setEdges: state.setEdges,
-    }))
+  const freeformAnchorsEnabled = isClassDiagramEdgeType(type)
+  const sourceAnchor = data?.sourceAnchor
+  const targetAnchor = data?.targetAnchor
+  const shouldSubscribeToNodeGeometry =
+    freeformAnchorsEnabled &&
+    (isFreeformEdgeAnchor(sourceAnchor) || isFreeformEdgeAnchor(targetAnchor))
+  const {
+    setEdges,
+    sourceNodePositionX,
+    sourceNodePositionY,
+    sourceNodeWidth,
+    sourceNodeHeight,
+    targetNodePositionX,
+    targetNodePositionY,
+    targetNodeWidth,
+    targetNodeHeight,
+  } = useDiagramStore(
+    useShallow((state) => {
+      if (!shouldSubscribeToNodeGeometry) {
+        return {
+          setEdges: state.setEdges,
+          sourceNodePositionX: undefined,
+          sourceNodePositionY: undefined,
+          sourceNodeWidth: undefined,
+          sourceNodeHeight: undefined,
+          targetNodePositionX: undefined,
+          targetNodePositionY: undefined,
+          targetNodeWidth: undefined,
+          targetNodeHeight: undefined,
+        }
+      }
+
+      const storeSourceNode = state.nodes.find((node) => node.id === source)
+      const storeTargetNode = state.nodes.find((node) => node.id === target)
+      const storeSourcePosition = storeSourceNode
+        ? getPositionOnCanvas(storeSourceNode, state.nodes)
+        : null
+      const storeTargetPosition = storeTargetNode
+        ? getPositionOnCanvas(storeTargetNode, state.nodes)
+        : null
+
+      return {
+        setEdges: state.setEdges,
+        sourceNodePositionX: storeSourcePosition?.x,
+        sourceNodePositionY: storeSourcePosition?.y,
+        sourceNodeWidth:
+          storeSourceNode?.width ?? storeSourceNode?.measured?.width,
+        sourceNodeHeight:
+          storeSourceNode?.height ?? storeSourceNode?.measured?.height,
+        targetNodePositionX: storeTargetPosition?.x,
+        targetNodePositionY: storeTargetPosition?.y,
+        targetNodeWidth:
+          storeTargetNode?.width ?? storeTargetNode?.measured?.width,
+        targetNodeHeight:
+          storeTargetNode?.height ?? storeTargetNode?.measured?.height,
+      }
+    })
   )
 
   const {
@@ -155,19 +240,105 @@ export const useStepPathEdge = ({
     offset = 0,
   } = getEdgeMarkerStyles(type)
   const padding = markerPadding ?? EDGES.MARKER_PADDING
-  const sourceNode = getNode(source)!
-  const targetNode = getNode(target)!
   const allNodes = getNodes()
+  const sourceNode =
+    allNodes.find((node) => node.id === source) ?? getNode(source)!
+  const targetNode =
+    allNodes.find((node) => node.id === target) ?? getNode(target)!
 
   const sourceAbsolutePosition = useMemo(() => {
-    if (!sourceNode) return { x: sourceX, y: sourceY }
+    if (sourceNodePositionX != null && sourceNodePositionY != null) {
+      return { x: sourceNodePositionX, y: sourceNodePositionY }
+    }
+    if (!sourceNode) return { x: reactFlowSourceX, y: reactFlowSourceY }
     return getPositionOnCanvas(sourceNode, allNodes)
-  }, [sourceNode, allNodes, sourceX, sourceY])
+  }, [
+    sourceNodePositionX,
+    sourceNodePositionY,
+    sourceNode,
+    allNodes,
+    reactFlowSourceX,
+    reactFlowSourceY,
+  ])
 
   const targetAbsolutePosition = useMemo(() => {
-    if (!targetNode) return { x: targetX, y: targetY }
+    if (targetNodePositionX != null && targetNodePositionY != null) {
+      return { x: targetNodePositionX, y: targetNodePositionY }
+    }
+    if (!targetNode) return { x: reactFlowTargetX, y: reactFlowTargetY }
     return getPositionOnCanvas(targetNode, allNodes)
-  }, [targetNode, allNodes, targetX, targetY])
+  }, [
+    targetNodePositionX,
+    targetNodePositionY,
+    targetNode,
+    allNodes,
+    reactFlowTargetX,
+    reactFlowTargetY,
+  ])
+
+  const sourceRect = useMemo(
+    () =>
+      sourceNode
+        ? {
+            x: sourceAbsolutePosition.x,
+            y: sourceAbsolutePosition.y,
+            width: sourceNodeWidth ?? sourceNode.width ?? 0,
+            height: sourceNodeHeight ?? sourceNode.height ?? 0,
+          }
+        : null,
+    [
+      sourceAbsolutePosition.x,
+      sourceAbsolutePosition.y,
+      sourceNode,
+      sourceNodeWidth,
+      sourceNodeHeight,
+    ]
+  )
+  const targetRect = useMemo(
+    () =>
+      targetNode
+        ? {
+            x: targetAbsolutePosition.x,
+            y: targetAbsolutePosition.y,
+            width: targetNodeWidth ?? targetNode.width ?? 0,
+            height: targetNodeHeight ?? targetNode.height ?? 0,
+          }
+        : null,
+    [
+      targetAbsolutePosition.x,
+      targetAbsolutePosition.y,
+      targetNode,
+      targetNodeWidth,
+      targetNodeHeight,
+    ]
+  )
+  const resolvedSourceAnchor = useMemo(
+    () =>
+      freeformAnchorsEnabled && sourceRect && isFreeformEdgeAnchor(sourceAnchor)
+        ? getFreeformAnchorPoint(sourceRect, sourceAnchor)
+        : null,
+    [freeformAnchorsEnabled, sourceAnchor, sourceRect]
+  )
+  const resolvedTargetAnchor = useMemo(
+    () =>
+      freeformAnchorsEnabled && targetRect && isFreeformEdgeAnchor(targetAnchor)
+        ? getFreeformAnchorPoint(targetRect, targetAnchor)
+        : null,
+    [freeformAnchorsEnabled, targetAnchor, targetRect]
+  )
+
+  const sourceX = resolvedSourceAnchor?.point.x ?? reactFlowSourceX
+  const sourceY = resolvedSourceAnchor?.point.y ?? reactFlowSourceY
+  const targetX = resolvedTargetAnchor?.point.x ?? reactFlowTargetX
+  const targetY = resolvedTargetAnchor?.point.y ?? reactFlowTargetY
+  const sourcePosition =
+    resolvedSourceAnchor?.position ?? reactFlowSourcePosition
+  const targetPosition =
+    resolvedTargetAnchor?.position ?? reactFlowTargetPosition
+  const sourceConnectionPointPadding = resolvedSourceAnchor
+    ? 0
+    : EDGES.SOURCE_CONNECTION_POINT_PADDING
+  const targetConnectionPointPadding = resolvedTargetAnchor ? 0 : padding
 
   // Round coordinates to whole pixels for pixel-perfect rendering
   // React Flow may return fractional values when node dimensions are odd
@@ -180,13 +351,13 @@ export const useStepPathEdge = ({
     roundedTargetX,
     roundedTargetY,
     targetPosition,
-    padding
+    targetConnectionPointPadding
   )
   const adjustedSourceCoordinates = adjustSourceCoordinates(
     roundedSourceX,
     roundedSourceY,
     sourcePosition,
-    EDGES.SOURCE_CONNECTION_POINT_PADDING
+    sourceConnectionPointPadding
   )
   const basePath = useMemo(() => {
     if (!enableStraightPath) {
@@ -206,14 +377,14 @@ export const useStepPathEdge = ({
     const straightPathPoints = tryFindStraightPath(
       {
         position: { x: sourceAbsolutePosition.x, y: sourceAbsolutePosition.y },
-        width: sourceNode.width ?? 100,
-        height: sourceNode.height ?? 160,
+        width: sourceRect?.width ?? sourceNode.width ?? 100,
+        height: sourceRect?.height ?? sourceNode.height ?? 160,
         direction: sourcePosition,
       },
       {
         position: { x: targetAbsolutePosition.x, y: targetAbsolutePosition.y },
-        width: targetNode.width ?? 100,
-        height: targetNode.height ?? 160,
+        width: targetRect?.width ?? targetNode.width ?? 100,
+        height: targetRect?.height ?? targetNode.height ?? 160,
         direction: targetPosition,
       },
       padding,
@@ -245,7 +416,11 @@ export const useStepPathEdge = ({
     sourceAbsolutePosition,
     targetAbsolutePosition,
     sourceNode,
+    sourceRect?.width,
+    sourceRect?.height,
     targetNode,
+    targetRect?.width,
+    targetRect?.height,
     sourcePosition,
     targetPosition,
     roundedSourceX,
@@ -266,15 +441,27 @@ export const useStepPathEdge = ({
     return result
   }, [basePath])
 
+  const hasStoredManualPoints = Boolean(data?.points && data.points.length > 0)
+  const hasLocalManualPoints = customPoints.length > 0
+  const shouldPreferComputedPath =
+    freeformAnchorsEnabled && computedPoints.length === 2
   const hasManualPoints =
-    (data?.points && data.points.length > 0) || customPoints.length > 0
+    !shouldPreferComputedPath &&
+    (hasStoredManualPoints || (!freeformAnchorsEnabled && hasLocalManualPoints))
 
   const activePoints = useMemo(() => {
+    if (shouldPreferComputedPath) {
+      return computedPoints
+    }
+
     let points: IPoint[]
     if (data?.points && data.points.length > 0) {
       points = data.points
     } else {
-      points = customPoints.length ? customPoints : computedPoints
+      points =
+        !freeformAnchorsEnabled && customPoints.length
+          ? customPoints
+          : computedPoints
     }
 
     if (hasManualPoints && points.length >= 2) {
@@ -298,7 +485,9 @@ export const useStepPathEdge = ({
     customPoints,
     computedPoints,
     data?.points,
+    freeformAnchorsEnabled,
     hasManualPoints,
+    shouldPreferComputedPath,
     adjustedSourceCoordinates.sourceX,
     adjustedSourceCoordinates.sourceY,
     adjustedTargetCoordinates.targetX,
@@ -308,6 +497,22 @@ export const useStepPathEdge = ({
   ])
 
   useEffect(() => {
+    if (shouldPreferComputedPath) {
+      if (hasLocalManualPoints) {
+        setCustomPoints([])
+      }
+      if (hasStoredManualPoints) {
+        setEdges((edges) =>
+          edges.map((edge) =>
+            edge.id === id
+              ? { ...edge, data: { ...edge.data, points: [] } }
+              : edge
+          )
+        )
+      }
+      return
+    }
+
     if (!hasManualPoints) return
 
     const storedPoints =
@@ -344,10 +549,13 @@ export const useStepPathEdge = ({
     activePoints,
     customPoints,
     data?.points,
+    hasLocalManualPoints,
     hasManualPoints,
+    hasStoredManualPoints,
     id,
     setCustomPoints,
     setEdges,
+    shouldPreferComputedPath,
     adjustedSourceCoordinates.sourceX,
     adjustedSourceCoordinates.sourceY,
     adjustedTargetCoordinates.targetX,
@@ -689,6 +897,7 @@ export const useStepPathEdge = ({
       id,
       setEdges,
       allowMidpointDragging,
+      screenToFlowPosition,
       setCustomPoints,
       targetPosition,
       sourcePosition,
@@ -696,6 +905,289 @@ export const useStepPathEdge = ({
       adjustedSourceCoordinates.sourceY,
       adjustedTargetCoordinates.targetX,
       adjustedTargetCoordinates.targetY,
+    ]
+  )
+
+  const getNodeRect = useCallback(
+    (node: Node): Rect | null => {
+      const nodes = getNodes()
+      const currentNode = nodes.find((candidate) => candidate.id === node.id)
+      const resolvedNode = currentNode ?? node
+      const width = resolvedNode.width ?? 0
+      const height = resolvedNode.height ?? 0
+
+      if (!width || !height) return null
+
+      const position = getPositionOnCanvas(resolvedNode, nodes)
+      return { x: position.x, y: position.y, width, height }
+    },
+    [getNodes]
+  )
+
+  const findFreeformEndpointNode = useCallback(
+    (flowPoint: IPoint): { node: Node; rect: Rect } | null => {
+      const nodes = getNodes()
+      let best: { node: Node; rect: Rect; distance: number } | null = null
+
+      for (const node of nodes) {
+        if (isParentNodeType(node.type)) continue
+
+        const rect = getNodeRect(node)
+        if (!rect) continue
+
+        const dx =
+          flowPoint.x < rect.x
+            ? rect.x - flowPoint.x
+            : flowPoint.x > rect.x + rect.width
+              ? flowPoint.x - (rect.x + rect.width)
+              : 0
+        const dy =
+          flowPoint.y < rect.y
+            ? rect.y - flowPoint.y
+            : flowPoint.y > rect.y + rect.height
+              ? flowPoint.y - (rect.y + rect.height)
+              : 0
+        const distance = Math.hypot(dx, dy)
+
+        if (
+          distance <= FREEFORM_ENDPOINT_SNAP_RADIUS_PX &&
+          (!best || distance < best.distance)
+        ) {
+          best = { node, rect, distance }
+        }
+      }
+
+      return best ? { node: best.node, rect: best.rect } : null
+    },
+    [getNodeRect, getNodes]
+  )
+
+  const handleEndpointPointerDown = useCallback(
+    (event: React.PointerEvent<SVGRectElement>, endpoint: EndpointType) => {
+      if (!freeformAnchorsEnabled) return
+
+      event.preventDefault()
+      event.stopPropagation()
+      endpointDragCommitRef.current = null
+
+      const ownerDocument = event.currentTarget.ownerDocument
+      const dragBaseline = [...activePoints]
+      const currentSourceEndpoint = {
+        x: adjustedSourceCoordinates.sourceX,
+        y: adjustedSourceCoordinates.sourceY,
+      }
+      const currentTargetEndpoint = {
+        x: adjustedTargetCoordinates.targetX,
+        y: adjustedTargetCoordinates.targetY,
+      }
+
+      if (dragBaseline.length >= 2) {
+        dragBaseline[0] = currentSourceEndpoint
+        dragBaseline[dragBaseline.length - 1] = currentTargetEndpoint
+      }
+
+      const resolveDragCommit = (
+        clientX: number,
+        clientY: number
+      ): EndpointDragCommit | null => {
+        const flowPoint = screenToFlowPosition({ x: clientX, y: clientY })
+        const intersectingNodes = getIntersectingNodes({
+          x: flowPoint.x - FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
+          y: flowPoint.y - FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
+          width: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
+          height: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
+        })
+        const directHitNode = intersectingNodes.findLast(
+          (node) =>
+            node.width != null &&
+            node.height != null &&
+            !isParentNodeType(node.type)
+        )
+        const directHitRect = directHitNode ? getNodeRect(directHitNode) : null
+        const snapTarget =
+          directHitNode && directHitRect
+            ? { node: directHitNode, rect: directHitRect }
+            : findFreeformEndpointNode(flowPoint)
+
+        if (!snapTarget) return null
+
+        const { node: nodeOnTop, rect } = snapTarget
+
+        const anchor = getFreeformAnchorFromPoint(flowPoint, rect)
+        const resolvedAnchor = getFreeformAnchorPoint(rect, anchor)
+        let sourceEndpoint = currentSourceEndpoint
+        let targetEndpoint = currentTargetEndpoint
+
+        if (endpoint === "source") {
+          const movingEndpoint = adjustSourceCoordinates(
+            resolvedAnchor.point.x,
+            resolvedAnchor.point.y,
+            resolvedAnchor.position,
+            0
+          )
+          sourceEndpoint = {
+            x: movingEndpoint.sourceX,
+            y: movingEndpoint.sourceY,
+          }
+        } else {
+          const movingEndpoint = adjustTargetCoordinates(
+            resolvedAnchor.point.x,
+            resolvedAnchor.point.y,
+            resolvedAnchor.position,
+            0
+          )
+          targetEndpoint = {
+            x: movingEndpoint.targetX,
+            y: movingEndpoint.targetY,
+          }
+        }
+        const nextSourcePosition =
+          endpoint === "source" ? resolvedAnchor.position : sourcePosition
+        const nextTargetPosition =
+          endpoint === "target" ? resolvedAnchor.position : targetPosition
+        const nextSourceRect =
+          endpoint === "source" ? rect : (sourceRect ?? rect)
+        const nextTargetRect =
+          endpoint === "target" ? rect : (targetRect ?? rect)
+        const directPoints = tryFindStraightPath(
+          {
+            position: { x: nextSourceRect.x, y: nextSourceRect.y },
+            width: nextSourceRect.width,
+            height: nextSourceRect.height,
+            direction: nextSourcePosition,
+          },
+          {
+            position: { x: nextTargetRect.x, y: nextTargetRect.y },
+            width: nextTargetRect.width,
+            height: nextTargetRect.height,
+            direction: nextTargetPosition,
+          },
+          0,
+          {
+            sourceX: sourceEndpoint.x,
+            sourceY: sourceEndpoint.y,
+            targetX: targetEndpoint.x,
+            targetY: targetEndpoint.y,
+          }
+        )
+        const preservedPoints = preserveOrthogonalEdgePoints(
+          dragBaseline,
+          sourceEndpoint,
+          targetEndpoint,
+          nextSourcePosition,
+          nextTargetPosition
+        )
+
+        return {
+          endpoint,
+          nodeId: nodeOnTop.id,
+          handleId: getSideHandleIdForPosition(resolvedAnchor.position),
+          anchor,
+          sourceEndpoint,
+          targetEndpoint,
+          sourcePosition: nextSourcePosition,
+          targetPosition: nextTargetPosition,
+          sourceRect: nextSourceRect,
+          targetRect: nextTargetRect,
+          directPoints,
+          points: directPoints ?? preservedPoints,
+        }
+      }
+
+      const handlePointerMove = (e: PointerEvent) => {
+        const commit = resolveDragCommit(e.clientX, e.clientY)
+        endpointDragCommitRef.current = commit
+        setDragPreviewPoints(commit?.points ?? null)
+      }
+
+      const handlePointerUp = () => {
+        const commit = endpointDragCommitRef.current
+        endpointDragCommitRef.current = null
+        setDragPreviewPoints(null)
+
+        if (commit) {
+          const normalizedPoints = hasManualPoints
+            ? normalizeOrthogonalEdgePoints(
+                commit.points,
+                commit.sourceEndpoint,
+                commit.targetEndpoint,
+                commit.sourcePosition,
+                commit.targetPosition
+              )
+            : null
+          const shouldClearManualPoints = commit.directPoints !== null
+
+          if (shouldClearManualPoints) {
+            setCustomPoints([])
+          } else if (normalizedPoints) {
+            setCustomPoints(normalizedPoints)
+          }
+
+          setEdges((edges) =>
+            edges.map((edge) => {
+              if (edge.id !== id) return edge
+
+              const nextData = {
+                ...((edge.data ?? {}) as Record<string, unknown>),
+              }
+              if (commit.endpoint === "source") {
+                nextData.sourceAnchor = commit.anchor
+              } else {
+                nextData.targetAnchor = commit.anchor
+              }
+              if (shouldClearManualPoints) {
+                nextData.points = []
+              } else if (normalizedPoints) {
+                nextData.points = normalizedPoints
+              } else if (!Array.isArray(nextData.points)) {
+                nextData.points = []
+              }
+
+              return commit.endpoint === "source"
+                ? {
+                    ...edge,
+                    source: commit.nodeId,
+                    sourceHandle: commit.handleId,
+                    data: nextData,
+                  }
+                : {
+                    ...edge,
+                    target: commit.nodeId,
+                    targetHandle: commit.handleId,
+                    data: nextData,
+                  }
+            })
+          )
+        }
+
+        ownerDocument.removeEventListener("pointermove", handlePointerMove)
+        ownerDocument.removeEventListener("pointerup", handlePointerUp)
+      }
+
+      ownerDocument.addEventListener("pointermove", handlePointerMove)
+      ownerDocument.addEventListener("pointerup", handlePointerUp, {
+        once: true,
+      })
+    },
+    [
+      activePoints,
+      adjustedSourceCoordinates.sourceX,
+      adjustedSourceCoordinates.sourceY,
+      adjustedTargetCoordinates.targetX,
+      adjustedTargetCoordinates.targetY,
+      freeformAnchorsEnabled,
+      findFreeformEndpointNode,
+      getIntersectingNodes,
+      getNodeRect,
+      hasManualPoints,
+      id,
+      screenToFlowPosition,
+      setCustomPoints,
+      setEdges,
+      sourceRect,
+      sourcePosition,
+      targetRect,
+      targetPosition,
     ]
   )
 
@@ -739,6 +1231,9 @@ export const useStepPathEdge = ({
     markerStart,
     strokeDashArray,
     handlePointerDown,
+    handleEndpointPointerDown: freeformAnchorsEnabled
+      ? handleEndpointPointerDown
+      : undefined,
     sourcePoint,
     targetPoint,
     toolbarPosition,

--- a/library/lib/hooks/useStepPathEdge.ts
+++ b/library/lib/hooks/useStepPathEdge.ts
@@ -936,8 +936,6 @@ export const useStepPathEdge = ({
       let best: { node: Node; rect: Rect; distance: number } | null = null
 
       for (const node of nodes) {
-        if (isParentNodeType(node.type)) continue
-
         const rect = getNodeRect(node)
         if (!rect) continue
 
@@ -998,16 +996,13 @@ export const useStepPathEdge = ({
       ): EndpointDragCommit | null => {
         const flowPoint = screenToFlowPosition({ x: clientX, y: clientY })
         const intersectingNodes = getIntersectingNodes({
-          x: flowPoint.x - FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
-          y: flowPoint.y - FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
-          width: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
-          height: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
+          x: flowPoint.x - 1,
+          y: flowPoint.y - 1,
+          width: 2,
+          height: 2,
         })
         const directHitNode = intersectingNodes.findLast(
-          (node) =>
-            node.width != null &&
-            node.height != null &&
-            !isParentNodeType(node.type)
+          (node) => node.width != null && node.height != null
         )
         const directHitRect = directHitNode ? getNodeRect(directHitNode) : null
         const snapTarget =

--- a/library/lib/hooks/useStepPathEdge.ts
+++ b/library/lib/hooks/useStepPathEdge.ts
@@ -37,7 +37,6 @@ import {
   getFreeformAnchorFromPoint,
   getFreeformAnchorPoint,
   getSideHandleIdForPosition,
-  isClassDiagramEdgeType,
   isFreeformEdgeAnchor,
   type FreeformEdgeAnchor,
 } from "@/utils/edgeUtils"
@@ -173,7 +172,7 @@ export const useStepPathEdge = ({
   )
 
   const { customPoints, setCustomPoints } = useEdgeState(data?.points)
-  const freeformAnchorsEnabled = isClassDiagramEdgeType(type)
+  const freeformAnchorsEnabled = true
   const sourceAnchor = data?.sourceAnchor
   const targetAnchor = data?.targetAnchor
   const shouldSubscribeToNodeGeometry =

--- a/library/lib/hooks/useStepPathEdge.ts
+++ b/library/lib/hooks/useStepPathEdge.ts
@@ -4,7 +4,6 @@ import {
   Position,
   useStore,
   useReactFlow,
-  type Node,
 } from "@xyflow/react"
 import { EDGES } from "@/constants"
 import {
@@ -41,7 +40,12 @@ import {
 import {
   getEdgeAnchorFromPoint,
   getEdgeAnchorPoint,
+  pickNearestConnectable,
 } from "@/utils/connectionModes"
+import {
+  FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
+  useFreeformEndpointNode,
+} from "./useFreeformEndpointNode"
 import {
   type BendHandle,
   applyInnerSegmentBend,
@@ -121,8 +125,6 @@ type EndpointDragCommit = {
   directPoints: IPoint[] | null
 }
 
-const FREEFORM_ENDPOINT_SNAP_RADIUS_PX = 48
-
 const arePointsEqual = (a: IPoint[], b: IPoint[]): boolean =>
   a.length === b.length &&
   a.every((point, index) => point.x === b[index].x && point.y === b[index].y)
@@ -178,12 +180,10 @@ export const useStepPathEdge = ({
   } | null>(null)
 
   const { customPoints, setCustomPoints } = useEdgeState(data?.points)
-  const freeformAnchorsEnabled = true
   const sourceAnchor = data?.sourceAnchor
   const targetAnchor = data?.targetAnchor
   const shouldSubscribeToNodeGeometry =
-    freeformAnchorsEnabled &&
-    (isFreeformEdgeAnchor(sourceAnchor) || isFreeformEdgeAnchor(targetAnchor))
+    isFreeformEdgeAnchor(sourceAnchor) || isFreeformEdgeAnchor(targetAnchor)
   const {
     setEdges,
     sourceNodePositionX,
@@ -247,9 +247,9 @@ export const useStepPathEdge = ({
   const padding = markerPadding ?? EDGES.MARKER_PADDING
   const allNodes = getNodes()
   const sourceNode =
-    allNodes.find((node) => node.id === source) ?? getNode(source)!
+    allNodes.find((node) => node.id === source) ?? getNode(source)
   const targetNode =
-    allNodes.find((node) => node.id === target) ?? getNode(target)!
+    allNodes.find((node) => node.id === target) ?? getNode(target)
 
   const sourceAbsolutePosition = useMemo(() => {
     if (sourceNodePositionX != null && sourceNodePositionY != null) {
@@ -319,17 +319,17 @@ export const useStepPathEdge = ({
   )
   const resolvedSourceAnchor = useMemo(
     () =>
-      freeformAnchorsEnabled && sourceRect && isFreeformEdgeAnchor(sourceAnchor)
+      sourceRect && isFreeformEdgeAnchor(sourceAnchor)
         ? getEdgeAnchorPoint(sourceNode?.type, sourceRect, sourceAnchor)
         : null,
-    [freeformAnchorsEnabled, sourceAnchor, sourceRect, sourceNode?.type]
+    [sourceAnchor, sourceRect, sourceNode?.type]
   )
   const resolvedTargetAnchor = useMemo(
     () =>
-      freeformAnchorsEnabled && targetRect && isFreeformEdgeAnchor(targetAnchor)
+      targetRect && isFreeformEdgeAnchor(targetAnchor)
         ? getEdgeAnchorPoint(targetNode?.type, targetRect, targetAnchor)
         : null,
-    [freeformAnchorsEnabled, targetAnchor, targetRect, targetNode?.type]
+    [targetAnchor, targetRect, targetNode?.type]
   )
 
   const sourceX = resolvedSourceAnchor?.point.x ?? reactFlowSourceX
@@ -382,14 +382,14 @@ export const useStepPathEdge = ({
     const straightPathPoints = tryFindStraightPath(
       {
         position: { x: sourceAbsolutePosition.x, y: sourceAbsolutePosition.y },
-        width: sourceRect?.width ?? sourceNode.width ?? 100,
-        height: sourceRect?.height ?? sourceNode.height ?? 160,
+        width: sourceRect?.width ?? sourceNode?.width ?? 100,
+        height: sourceRect?.height ?? sourceNode?.height ?? 160,
         direction: sourcePosition,
       },
       {
         position: { x: targetAbsolutePosition.x, y: targetAbsolutePosition.y },
-        width: targetRect?.width ?? targetNode.width ?? 100,
-        height: targetRect?.height ?? targetNode.height ?? 160,
+        width: targetRect?.width ?? targetNode?.width ?? 100,
+        height: targetRect?.height ?? targetNode?.height ?? 160,
         direction: targetPosition,
       },
       padding,
@@ -448,10 +448,9 @@ export const useStepPathEdge = ({
 
   const hasStoredManualPoints = Boolean(data?.points && data.points.length > 0)
   const hasLocalManualPoints = customPoints.length > 0
-  const hasManualPoints =
-    hasStoredManualPoints || (!freeformAnchorsEnabled && hasLocalManualPoints)
+  const hasManualPoints = hasStoredManualPoints
   const shouldPreferComputedPath =
-    freeformAnchorsEnabled && computedPoints.length === 2 && !hasManualPoints
+    computedPoints.length === 2 && !hasManualPoints
 
   const activePoints = useMemo(() => {
     if (shouldPreferComputedPath) {
@@ -462,10 +461,7 @@ export const useStepPathEdge = ({
     if (data?.points && data.points.length > 0) {
       points = data.points
     } else {
-      points =
-        !freeformAnchorsEnabled && customPoints.length
-          ? customPoints
-          : computedPoints
+      points = computedPoints
     }
 
     if (hasManualPoints && points.length >= 2) {
@@ -486,10 +482,8 @@ export const useStepPathEdge = ({
 
     return points
   }, [
-    customPoints,
     computedPoints,
     data?.points,
-    freeformAnchorsEnabled,
     hasManualPoints,
     shouldPreferComputedPath,
     adjustedSourceCoordinates.sourceX,
@@ -913,64 +907,10 @@ export const useStepPathEdge = ({
     ]
   )
 
-  const getNodeRect = useCallback(
-    (node: Node): Rect | null => {
-      const nodes = getNodes()
-      const currentNode = nodes.find((candidate) => candidate.id === node.id)
-      const resolvedNode = currentNode ?? node
-      const width = resolvedNode.width ?? 0
-      const height = resolvedNode.height ?? 0
-
-      if (!width || !height) return null
-
-      const position = getPositionOnCanvas(resolvedNode, nodes)
-      return { x: position.x, y: position.y, width, height }
-    },
-    [getNodes]
-  )
-
-  const findFreeformEndpointNode = useCallback(
-    (flowPoint: IPoint): { node: Node; rect: Rect } | null => {
-      const nodes = getNodes()
-      let best: { node: Node; rect: Rect; distance: number } | null = null
-
-      for (const node of nodes) {
-        if (isParentNodeType(node.type)) continue
-
-        const rect = getNodeRect(node)
-        if (!rect) continue
-
-        const dx =
-          flowPoint.x < rect.x
-            ? rect.x - flowPoint.x
-            : flowPoint.x > rect.x + rect.width
-              ? flowPoint.x - (rect.x + rect.width)
-              : 0
-        const dy =
-          flowPoint.y < rect.y
-            ? rect.y - flowPoint.y
-            : flowPoint.y > rect.y + rect.height
-              ? flowPoint.y - (rect.y + rect.height)
-              : 0
-        const distance = Math.hypot(dx, dy)
-
-        if (
-          distance <= FREEFORM_ENDPOINT_SNAP_RADIUS_PX &&
-          (!best || distance < best.distance)
-        ) {
-          best = { node, rect, distance }
-        }
-      }
-
-      return best ? { node: best.node, rect: best.rect } : null
-    },
-    [getNodeRect, getNodes]
-  )
+  const { getNodeRect, findFreeformEndpointNode } = useFreeformEndpointNode()
 
   const handleEndpointPointerDown = useCallback(
     (event: React.PointerEvent<SVGRectElement>, endpoint: EndpointType) => {
-      if (!freeformAnchorsEnabled) return
-
       event.preventDefault()
       event.stopPropagation()
       endpointDragCommitRef.current = null
@@ -1002,40 +942,15 @@ export const useStepPathEdge = ({
           width: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
           height: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
         })
-        // Snap to the NEAREST node (distance to its box, 0 when inside), not the
-        // top-most, so tightly packed nodes grab the one under the cursor. On an
-        // exact tie — nested nodes both under the pointer — the later, top-most
-        // node wins: the innermost child, or a container where no child sits.
-        const sizedHits = intersectingNodes.filter(
-          (node) => node.width != null && node.height != null
-        )
-        let snapNode: (typeof sizedHits)[number] | null = null
-        let snapRect: ReturnType<typeof getNodeRect> = null
-        let bestDistance = Infinity
-        for (const node of sizedHits) {
+        // Snap to the nearest connectable node under the pointer (see
+        // pickNearestConnectable); fall back to the wider freeform search.
+        const candidates = intersectingNodes.flatMap((node) => {
           const rect = getNodeRect(node)
-          if (!rect) continue
-          const dx = Math.max(
-            rect.x - flowPoint.x,
-            0,
-            flowPoint.x - (rect.x + rect.width)
-          )
-          const dy = Math.max(
-            rect.y - flowPoint.y,
-            0,
-            flowPoint.y - (rect.y + rect.height)
-          )
-          const distance = Math.hypot(dx, dy)
-          if (distance <= bestDistance) {
-            bestDistance = distance
-            snapNode = node
-            snapRect = rect
-          }
-        }
+          return rect ? [{ node, type: node.type, rect }] : []
+        })
         const snapTarget =
-          snapNode && snapRect
-            ? { node: snapNode, rect: snapRect }
-            : findFreeformEndpointNode(flowPoint)
+          pickNearestConnectable(candidates, flowPoint) ??
+          findFreeformEndpointNode(flowPoint)
 
         if (!snapTarget) return null
 
@@ -1254,7 +1169,6 @@ export const useStepPathEdge = ({
       adjustedSourceCoordinates.sourceY,
       adjustedTargetCoordinates.targetX,
       adjustedTargetCoordinates.targetY,
-      freeformAnchorsEnabled,
       findFreeformEndpointNode,
       getIntersectingNodes,
       getNodeRect,
@@ -1310,9 +1224,7 @@ export const useStepPathEdge = ({
     markerStart,
     strokeDashArray,
     handlePointerDown,
-    handleEndpointPointerDown: freeformAnchorsEnabled
-      ? handleEndpointPointerDown
-      : undefined,
+    handleEndpointPointerDown,
     sourcePoint,
     targetPoint,
     toolbarPosition,

--- a/library/lib/hooks/useStepPathEdge.ts
+++ b/library/lib/hooks/useStepPathEdge.ts
@@ -34,12 +34,14 @@ import {
   normalizeOrthogonalEdgePoints,
   resolveOrthogonalEdgeReleasePoints,
   isInvalidOrthogonalEdgeRelease,
-  getFreeformAnchorFromPoint,
-  getFreeformAnchorPoint,
   getSideHandleIdForPosition,
   isFreeformEdgeAnchor,
   type FreeformEdgeAnchor,
 } from "@/utils/edgeUtils"
+import {
+  getEdgeAnchorFromPoint,
+  getEdgeAnchorPoint,
+} from "@/utils/connectionModes"
 import {
   type BendHandle,
   applyInnerSegmentBend,
@@ -318,16 +320,16 @@ export const useStepPathEdge = ({
   const resolvedSourceAnchor = useMemo(
     () =>
       freeformAnchorsEnabled && sourceRect && isFreeformEdgeAnchor(sourceAnchor)
-        ? getFreeformAnchorPoint(sourceRect, sourceAnchor)
+        ? getEdgeAnchorPoint(sourceNode?.type, sourceRect, sourceAnchor)
         : null,
-    [freeformAnchorsEnabled, sourceAnchor, sourceRect]
+    [freeformAnchorsEnabled, sourceAnchor, sourceRect, sourceNode?.type]
   )
   const resolvedTargetAnchor = useMemo(
     () =>
       freeformAnchorsEnabled && targetRect && isFreeformEdgeAnchor(targetAnchor)
-        ? getFreeformAnchorPoint(targetRect, targetAnchor)
+        ? getEdgeAnchorPoint(targetNode?.type, targetRect, targetAnchor)
         : null,
-    [freeformAnchorsEnabled, targetAnchor, targetRect]
+    [freeformAnchorsEnabled, targetAnchor, targetRect, targetNode?.type]
   )
 
   const sourceX = resolvedSourceAnchor?.point.x ?? reactFlowSourceX
@@ -631,7 +633,7 @@ export const useStepPathEdge = ({
     // drop below the handle threshold).
     // Never strand an edge: if it is too short to offer a bend handle, the
     // endpoints must stay draggable so the user can always reshape it by
-    // reconnecting. (Avoids the "no handle, weird workaround" dead state.)
+    // reconnecting.
     const committedBendableCount = allowMidpointDragging
       ? getBendableSegments(
           activePoints,
@@ -663,12 +665,9 @@ export const useStepPathEdge = ({
   ])
 
   // The mid-segment midpoint + orientation, derived synchronously and purely
-  // from the polyline (no DOM measurement). This replaces a racy
-  // getPointAtLength + setTimeout(0) effect that lagged a frame, could lock to
-  // an off-edge/misclassified value (#634/#129), and never resolved in headless
-  // export — so exported labels fell back to the straight-line guess. Computed
-  // from renderPoints (pre line-jump bridges) it is also frame-stable and
-  // identical interactively and in export.
+  // from the polyline (no DOM measurement). Computed from renderPoints (pre
+  // line-jump bridges) so it is frame-stable and identical interactively and in
+  // headless export.
   const midSegment = useMemo(
     () =>
       getMidSegment(
@@ -936,6 +935,8 @@ export const useStepPathEdge = ({
       let best: { node: Node; rect: Rect; distance: number } | null = null
 
       for (const node of nodes) {
+        if (isParentNodeType(node.type)) continue
+
         const rect = getNodeRect(node)
         if (!rect) continue
 
@@ -996,26 +997,53 @@ export const useStepPathEdge = ({
       ): EndpointDragCommit | null => {
         const flowPoint = screenToFlowPosition({ x: clientX, y: clientY })
         const intersectingNodes = getIntersectingNodes({
-          x: flowPoint.x - 1,
-          y: flowPoint.y - 1,
-          width: 2,
-          height: 2,
+          x: flowPoint.x - FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
+          y: flowPoint.y - FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
+          width: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
+          height: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
         })
-        const directHitNode = intersectingNodes.findLast(
+        // Snap to the NEAREST node (distance to its box, 0 when inside), not the
+        // top-most, so tightly packed nodes grab the one under the cursor. On an
+        // exact tie — nested nodes both under the pointer — the later, top-most
+        // node wins: the innermost child, or a container where no child sits.
+        const sizedHits = intersectingNodes.filter(
           (node) => node.width != null && node.height != null
         )
-        const directHitRect = directHitNode ? getNodeRect(directHitNode) : null
+        let snapNode: (typeof sizedHits)[number] | null = null
+        let snapRect: ReturnType<typeof getNodeRect> = null
+        let bestDistance = Infinity
+        for (const node of sizedHits) {
+          const rect = getNodeRect(node)
+          if (!rect) continue
+          const dx = Math.max(
+            rect.x - flowPoint.x,
+            0,
+            flowPoint.x - (rect.x + rect.width)
+          )
+          const dy = Math.max(
+            rect.y - flowPoint.y,
+            0,
+            flowPoint.y - (rect.y + rect.height)
+          )
+          const distance = Math.hypot(dx, dy)
+          if (distance <= bestDistance) {
+            bestDistance = distance
+            snapNode = node
+            snapRect = rect
+          }
+        }
         const snapTarget =
-          directHitNode && directHitRect
-            ? { node: directHitNode, rect: directHitRect }
+          snapNode && snapRect
+            ? { node: snapNode, rect: snapRect }
             : findFreeformEndpointNode(flowPoint)
 
         if (!snapTarget) return null
 
         const { node: nodeOnTop, rect } = snapTarget
 
-        const anchor = getFreeformAnchorFromPoint(flowPoint, rect)
-        const resolvedAnchor = getFreeformAnchorPoint(rect, anchor)
+        const anchor = getEdgeAnchorFromPoint(nodeOnTop.type, flowPoint, rect)
+        if (!anchor) return null // node is not a connection target (mode "none")
+        const resolvedAnchor = getEdgeAnchorPoint(nodeOnTop.type, rect, anchor)
         let sourceEndpoint = currentSourceEndpoint
         let targetEndpoint = currentTargetEndpoint
 
@@ -1063,7 +1091,10 @@ export const useStepPathEdge = ({
             height: nextTargetRect.height,
             direction: nextTargetPosition,
           },
-          0,
+          // Use the edge's real marker padding (not 0, which tryFindStraightPath
+          // maps to a 15px offset) so the preview tip meets the node like the
+          // committed edge does — no gap on a straight drag.
+          padding,
           {
             sourceX: sourceEndpoint.x,
             sourceY: sourceEndpoint.y,
@@ -1098,15 +1129,53 @@ export const useStepPathEdge = ({
       const handlePointerMove = (e: PointerEvent) => {
         const commit = resolveDragCommit(e.clientX, e.clientY)
         endpointDragCommitRef.current = commit
-        setDragPreviewPoints(commit?.points ?? null)
-        setDragPreviewPositions(
-          commit
-            ? {
-                sourcePosition: commit.sourcePosition,
-                targetPosition: commit.targetPosition,
-              }
-            : null
+        if (commit) {
+          setDragPreviewPoints(commit.points)
+          setDragPreviewPositions({
+            sourcePosition: commit.sourcePosition,
+            targetPosition: commit.targetPosition,
+          })
+          return
+        }
+        // No snap target (empty canvas): free preview whose dragged end follows
+        // the cursor, still step-routed (preserved bends) to match the predicted
+        // edge. No commit is set, so releasing here reverts (no reconnect).
+        const flowPoint = screenToFlowPosition({ x: e.clientX, y: e.clientY })
+        const movingIsSource = endpoint === "source"
+        const fixedPoint = movingIsSource
+          ? currentTargetEndpoint
+          : currentSourceEndpoint
+        // Infer the dragged end's side from the drag direction so the step route
+        // enters/exits the free endpoint facing back toward the fixed end.
+        const dx = flowPoint.x - fixedPoint.x
+        const dy = flowPoint.y - fixedPoint.y
+        const movingPosition =
+          Math.abs(dx) >= Math.abs(dy)
+            ? dx >= 0
+              ? Position.Left
+              : Position.Right
+            : dy >= 0
+              ? Position.Top
+              : Position.Bottom
+        const previewSourcePosition = movingIsSource
+          ? movingPosition
+          : sourcePosition
+        const previewTargetPosition = movingIsSource
+          ? targetPosition
+          : movingPosition
+        setDragPreviewPoints(
+          preserveOrthogonalEdgePoints(
+            dragBaseline,
+            movingIsSource ? flowPoint : currentSourceEndpoint,
+            movingIsSource ? currentTargetEndpoint : flowPoint,
+            previewSourcePosition,
+            previewTargetPosition
+          )
         )
+        setDragPreviewPositions({
+          sourcePosition: previewSourcePosition,
+          targetPosition: previewTargetPosition,
+        })
       }
 
       const handlePointerUp = () => {
@@ -1233,7 +1302,7 @@ export const useStepPathEdge = ({
     bendHandles,
     isBendDragging: draggingHandle !== null,
     draggingHandleSegmentIndex: draggingHandle?.segmentIndex ?? null,
-    // The midpoint is now known synchronously on first render, so there is no
+    // The midpoint is known synchronously on first render, so there is no
     // pre-measurement straight-line flash to fade past — always true.
     hasInitialCalculation: true,
     isReconnecting,

--- a/library/lib/hooks/useStepPathEdge.ts
+++ b/library/lib/hooks/useStepPathEdge.ts
@@ -170,6 +170,10 @@ export const useStepPathEdge = ({
   const [dragPreviewPoints, setDragPreviewPoints] = useState<IPoint[] | null>(
     null
   )
+  const [dragPreviewPositions, setDragPreviewPositions] = useState<{
+    sourcePosition: Position
+    targetPosition: Position
+  } | null>(null)
 
   const { customPoints, setCustomPoints } = useEdgeState(data?.points)
   const freeformAnchorsEnabled = true
@@ -568,6 +572,10 @@ export const useStepPathEdge = ({
   // decorations; the persistence effect above stays keyed on `activePoints`
   // so a live preview never leaks into the store mid-drag.
   const renderPoints = dragPreviewPoints ?? activePoints
+  const renderSourcePosition =
+    dragPreviewPositions?.sourcePosition ?? sourcePosition
+  const renderTargetPosition =
+    dragPreviewPositions?.targetPosition ?? targetPosition
 
   // Bridge over edges this one crosses. Computed from `renderPoints` so the
   // arcs follow a live bend drag frame-by-frame (during a bend only THIS edge's
@@ -584,8 +592,8 @@ export const useStepPathEdge = ({
   )
 
   const markerSegmentPath = useMemo(
-    () => getMarkerSegmentPath(renderPoints, offset, targetPosition),
-    [renderPoints, offset, targetPosition]
+    () => getMarkerSegmentPath(renderPoints, offset, renderTargetPosition),
+    [renderPoints, offset, renderTargetPosition]
   )
 
   const overlayPath = useMemo(() => {
@@ -603,8 +611,8 @@ export const useStepPathEdge = ({
     if (!allowMidpointDragging) return []
     return getBendableSegments(
       renderPoints,
-      sourcePosition,
-      targetPosition,
+      renderSourcePosition,
+      renderTargetPosition,
       EDGES.BEND_HANDLE_SAFE_AREA_PX,
       minSegmentScreenLength,
       zoom
@@ -612,8 +620,8 @@ export const useStepPathEdge = ({
   }, [
     renderPoints,
     allowMidpointDragging,
-    sourcePosition,
-    targetPosition,
+    renderSourcePosition,
+    renderTargetPosition,
     minSegmentScreenLength,
     zoom,
   ])
@@ -1097,12 +1105,21 @@ export const useStepPathEdge = ({
         const commit = resolveDragCommit(e.clientX, e.clientY)
         endpointDragCommitRef.current = commit
         setDragPreviewPoints(commit?.points ?? null)
+        setDragPreviewPositions(
+          commit
+            ? {
+                sourcePosition: commit.sourcePosition,
+                targetPosition: commit.targetPosition,
+              }
+            : null
+        )
       }
 
       const handlePointerUp = () => {
         const commit = endpointDragCommitRef.current
         endpointDragCommitRef.current = null
         setDragPreviewPoints(null)
+        setDragPreviewPositions(null)
 
         if (commit) {
           const normalizedPoints = hasManualPoints
@@ -1238,5 +1255,7 @@ export const useStepPathEdge = ({
     toolbarPosition,
     isDiagramModifiable,
     canEditEndpoint,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
   }
 }

--- a/library/lib/hooks/useStepPathEdge.ts
+++ b/library/lib/hooks/useStepPathEdge.ts
@@ -446,11 +446,10 @@ export const useStepPathEdge = ({
 
   const hasStoredManualPoints = Boolean(data?.points && data.points.length > 0)
   const hasLocalManualPoints = customPoints.length > 0
-  const shouldPreferComputedPath =
-    freeformAnchorsEnabled && computedPoints.length === 2
   const hasManualPoints =
-    !shouldPreferComputedPath &&
-    (hasStoredManualPoints || (!freeformAnchorsEnabled && hasLocalManualPoints))
+    hasStoredManualPoints || (!freeformAnchorsEnabled && hasLocalManualPoints)
+  const shouldPreferComputedPath =
+    freeformAnchorsEnabled && computedPoints.length === 2 && !hasManualPoints
 
   const activePoints = useMemo(() => {
     if (shouldPreferComputedPath) {

--- a/library/lib/hooks/useStraightPathEdge.ts
+++ b/library/lib/hooks/useStraightPathEdge.ts
@@ -1,11 +1,22 @@
-import { useMemo, useRef } from "react"
-import { useStore } from "@xyflow/react"
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react"
+import { useReactFlow, useStore, type Node } from "@xyflow/react"
 import {
   calculateOverlayPath,
   calculateStraightPath,
   getEdgeMarkerStyles,
   adjustSourceCoordinates,
   adjustTargetCoordinates,
+  getFreeformAnchorFromPoint,
+  getFreeformAnchorPoint,
+  getSideHandleIdForPosition,
+  isFreeformEdgeAnchor,
+  type FreeformEdgeAnchor,
 } from "@/utils/edgeUtils"
 import { EDGES } from "@/constants"
 import { useDiagramModifiable } from "./useDiagramModifiable"
@@ -16,12 +27,14 @@ import {
   isLengthEditableAtZoom,
 } from "@/utils/geometry/bendHandles"
 import { getMidSegment } from "@/utils/geometry/edgeLabelLayout"
-import { useMetadataStore } from "@/store/context"
 import {
   useEdgeLineJumps,
   usePublishEdgeGeometry,
   buildEdgePath,
 } from "./useEdgeLineJumps"
+import { useDiagramStore, useMetadataStore } from "@/store/context"
+import { useShallow } from "zustand/shallow"
+import { getPositionOnCanvas, isParentNodeType } from "@/utils"
 
 export interface StraightPathEdgeData {
   pathMiddlePosition: IPoint
@@ -31,47 +44,220 @@ export interface StraightPathEdgeData {
   targetPoint: IPoint
 }
 
+type EndpointType = "source" | "target"
+
+type StraightEndpointDragCommit = {
+  endpoint: EndpointType
+  nodeId: string
+  handleId: string
+  anchor: FreeformEdgeAnchor
+  sourceEndpoint: IPoint
+  targetEndpoint: IPoint
+}
+
+const FREEFORM_ENDPOINT_SNAP_RADIUS_PX = 48
+
 export const useStraightPathEdge = ({
   id,
   type,
+  source,
+  target,
   sourceX,
   sourceY,
   targetX,
   targetY,
   sourcePosition,
   targetPosition,
-}: Omit<BaseEdgeProps, "data">) => {
+  data,
+}: BaseEdgeProps) => {
   const pathRef = useRef<SVGPathElement | null>(null)
+  const endpointDragCommitRef = useRef<StraightEndpointDragCommit | null>(null)
   const isDiagramModifiable = useDiagramModifiable()
   const zoom = useStore((state) => state.transform[2])
   const isReconnecting = useMetadataStore(
     (state) => state.reconnectPreviewEdgeId === id
+  )
+  const { getIntersectingNodes, getNode, getNodes, screenToFlowPosition } =
+    useReactFlow()
+  const [dragPreviewPoints, setDragPreviewPoints] = useState<IPoint[] | null>(
+    null
+  )
+  const sourceAnchor = data?.sourceAnchor
+  const targetAnchor = data?.targetAnchor
+  const shouldSubscribeToNodeGeometry =
+    isFreeformEdgeAnchor(sourceAnchor) || isFreeformEdgeAnchor(targetAnchor)
+  const {
+    setEdges,
+    sourceNodePositionX,
+    sourceNodePositionY,
+    sourceNodeWidth,
+    sourceNodeHeight,
+    targetNodePositionX,
+    targetNodePositionY,
+    targetNodeWidth,
+    targetNodeHeight,
+  } = useDiagramStore(
+    useShallow((state) => {
+      if (!shouldSubscribeToNodeGeometry) {
+        return {
+          setEdges: state.setEdges,
+          sourceNodePositionX: undefined,
+          sourceNodePositionY: undefined,
+          sourceNodeWidth: undefined,
+          sourceNodeHeight: undefined,
+          targetNodePositionX: undefined,
+          targetNodePositionY: undefined,
+          targetNodeWidth: undefined,
+          targetNodeHeight: undefined,
+        }
+      }
+
+      const storeSourceNode = state.nodes.find((node) => node.id === source)
+      const storeTargetNode = state.nodes.find((node) => node.id === target)
+      const storeSourcePosition = storeSourceNode
+        ? getPositionOnCanvas(storeSourceNode, state.nodes)
+        : null
+      const storeTargetPosition = storeTargetNode
+        ? getPositionOnCanvas(storeTargetNode, state.nodes)
+        : null
+
+      return {
+        setEdges: state.setEdges,
+        sourceNodePositionX: storeSourcePosition?.x,
+        sourceNodePositionY: storeSourcePosition?.y,
+        sourceNodeWidth:
+          storeSourceNode?.width ?? storeSourceNode?.measured?.width,
+        sourceNodeHeight:
+          storeSourceNode?.height ?? storeSourceNode?.measured?.height,
+        targetNodePositionX: storeTargetPosition?.x,
+        targetNodePositionY: storeTargetPosition?.y,
+        targetNodeWidth:
+          storeTargetNode?.width ?? storeTargetNode?.measured?.width,
+        targetNodeHeight:
+          storeTargetNode?.height ?? storeTargetNode?.measured?.height,
+      }
+    })
   )
 
   const { markerEnd, markerStart, strokeDashArray, markerPadding } =
     getEdgeMarkerStyles(type)
 
   const padding = markerPadding ?? EDGES.MARKER_PADDING
+  const allNodes = getNodes()
+  const sourceNode =
+    allNodes.find((node) => node.id === source) ?? getNode(source)!
+  const targetNode =
+    allNodes.find((node) => node.id === target) ?? getNode(target)!
+  const sourceAbsolutePosition = useMemo(() => {
+    if (sourceNodePositionX != null && sourceNodePositionY != null) {
+      return { x: sourceNodePositionX, y: sourceNodePositionY }
+    }
+    if (!sourceNode) return { x: sourceX, y: sourceY }
+    return getPositionOnCanvas(sourceNode, allNodes)
+  }, [
+    sourceNodePositionX,
+    sourceNodePositionY,
+    sourceNode,
+    allNodes,
+    sourceX,
+    sourceY,
+  ])
+  const targetAbsolutePosition = useMemo(() => {
+    if (targetNodePositionX != null && targetNodePositionY != null) {
+      return { x: targetNodePositionX, y: targetNodePositionY }
+    }
+    if (!targetNode) return { x: targetX, y: targetY }
+    return getPositionOnCanvas(targetNode, allNodes)
+  }, [
+    targetNodePositionX,
+    targetNodePositionY,
+    targetNode,
+    allNodes,
+    targetX,
+    targetY,
+  ])
+  const sourceRect = useMemo(
+    () =>
+      sourceNode
+        ? {
+            x: sourceAbsolutePosition.x,
+            y: sourceAbsolutePosition.y,
+            width: sourceNodeWidth ?? sourceNode.width ?? 0,
+            height: sourceNodeHeight ?? sourceNode.height ?? 0,
+          }
+        : null,
+    [
+      sourceAbsolutePosition.x,
+      sourceAbsolutePosition.y,
+      sourceNode,
+      sourceNodeWidth,
+      sourceNodeHeight,
+    ]
+  )
+  const targetRect = useMemo(
+    () =>
+      targetNode
+        ? {
+            x: targetAbsolutePosition.x,
+            y: targetAbsolutePosition.y,
+            width: targetNodeWidth ?? targetNode.width ?? 0,
+            height: targetNodeHeight ?? targetNode.height ?? 0,
+          }
+        : null,
+    [
+      targetAbsolutePosition.x,
+      targetAbsolutePosition.y,
+      targetNode,
+      targetNodeWidth,
+      targetNodeHeight,
+    ]
+  )
+  const resolvedSourceAnchor = useMemo(
+    () =>
+      sourceRect && isFreeformEdgeAnchor(sourceAnchor)
+        ? getFreeformAnchorPoint(sourceRect, sourceAnchor)
+        : null,
+    [sourceAnchor, sourceRect]
+  )
+  const resolvedTargetAnchor = useMemo(
+    () =>
+      targetRect && isFreeformEdgeAnchor(targetAnchor)
+        ? getFreeformAnchorPoint(targetRect, targetAnchor)
+        : null,
+    [targetAnchor, targetRect]
+  )
+  const resolvedSourceX = resolvedSourceAnchor?.point.x ?? sourceX
+  const resolvedSourceY = resolvedSourceAnchor?.point.y ?? sourceY
+  const resolvedTargetX = resolvedTargetAnchor?.point.x ?? targetX
+  const resolvedTargetY = resolvedTargetAnchor?.point.y ?? targetY
+  const resolvedSourcePosition =
+    resolvedSourceAnchor?.position ?? sourcePosition
+  const resolvedTargetPosition =
+    resolvedTargetAnchor?.position ?? targetPosition
+  const sourceConnectionPointPadding = resolvedSourceAnchor
+    ? 0
+    : EDGES.SOURCE_CONNECTION_POINT_PADDING
+  const targetConnectionPointPadding = resolvedTargetAnchor ? 0 : padding
 
   // Round coordinates to whole pixels for pixel-perfect rendering
   // React Flow may return fractional values when node dimensions are odd
-  const roundedSourceX = Math.round(sourceX)
-  const roundedSourceY = Math.round(sourceY)
-  const roundedTargetX = Math.round(targetX)
-  const roundedTargetY = Math.round(targetY)
+  const roundedSourceX = Math.round(resolvedSourceX)
+  const roundedSourceY = Math.round(resolvedSourceY)
+  const roundedTargetX = Math.round(resolvedTargetX)
+  const roundedTargetY = Math.round(resolvedTargetY)
 
   const adjustedTargetCoordinates = adjustTargetCoordinates(
     roundedTargetX,
     roundedTargetY,
-    targetPosition,
-    padding
+    resolvedTargetPosition,
+    targetConnectionPointPadding
   )
 
   const adjustedSourceCoordinates = adjustSourceCoordinates(
     roundedSourceX,
     roundedSourceY,
-    sourcePosition,
-    EDGES.SOURCE_CONNECTION_POINT_PADDING
+    resolvedSourcePosition,
+    sourceConnectionPointPadding
   )
 
   const basePoints = useMemo<IPoint[]>(
@@ -92,15 +278,16 @@ export const useStraightPathEdge = ({
       adjustedTargetCoordinates.targetY,
     ]
   )
+  const renderPoints = dragPreviewPoints ?? basePoints
 
   // Publish this edge's real geometry so other edges bridge over it accurately.
-  usePublishEdgeGeometry(id, basePoints)
+  usePublishEdgeGeometry(id, renderPoints)
 
   // UseCase include/extend edges are dashed connectors that never read as
   // crossings to disambiguate, so they opt out of bridging.
   const lineJumps = useEdgeLineJumps(
     id,
-    basePoints,
+    renderPoints,
     !isReconnecting && type !== "UseCaseInclude" && type !== "UseCaseExtend"
   )
 
@@ -110,51 +297,35 @@ export const useStraightPathEdge = ({
   // synchronous, DOM-free, export-stable computation.
   const { point: pathMiddlePosition, isHorizontal: isMiddlePathHorizontal } =
     useMemo(
-      () => getMidSegment(basePoints, basePoints[0], basePoints[1]),
-      [basePoints]
+      () => getMidSegment(renderPoints, renderPoints[0], renderPoints[1]),
+      [renderPoints]
     )
 
   const currentPath = useMemo(() => {
-    if (lineJumps.length > 0) return buildEdgePath(basePoints, lineJumps)
+    if (lineJumps.length > 0) return buildEdgePath(renderPoints, lineJumps)
     return calculateStraightPath(
-      adjustedSourceCoordinates.sourceX,
-      adjustedSourceCoordinates.sourceY,
-      adjustedTargetCoordinates.targetX,
-      adjustedTargetCoordinates.targetY,
+      renderPoints[0].x,
+      renderPoints[0].y,
+      renderPoints[1].x,
+      renderPoints[1].y,
       type
     )
-  }, [
-    adjustedSourceCoordinates.sourceX,
-    adjustedSourceCoordinates.sourceY,
-    adjustedTargetCoordinates.targetX,
-    adjustedTargetCoordinates.targetY,
-    type,
-    basePoints,
-    lineJumps,
-  ])
+  }, [renderPoints, type, lineJumps])
 
   const overlayPath = useMemo(() => {
     // When bridging, the arc'd path is the hit target too, so the selectable
     // stroke matches exactly what's drawn.
     if (lineJumps.length > 0) return currentPath
     return calculateOverlayPath(
-      adjustedSourceCoordinates.sourceX,
-      adjustedSourceCoordinates.sourceY,
-      adjustedTargetCoordinates.targetX,
-      adjustedTargetCoordinates.targetY,
+      renderPoints[0].x,
+      renderPoints[0].y,
+      renderPoints[1].x,
+      renderPoints[1].y,
       type
     )
-  }, [
-    adjustedSourceCoordinates.sourceX,
-    adjustedSourceCoordinates.sourceY,
-    adjustedTargetCoordinates.targetX,
-    adjustedTargetCoordinates.targetY,
-    type,
-    currentPath,
-    lineJumps,
-  ])
+  }, [renderPoints, type, currentPath, lineJumps])
 
-  const [sourcePoint, targetPoint] = basePoints
+  const [sourcePoint, targetPoint] = renderPoints
   const canvasLength = Math.hypot(
     targetPoint.x - sourcePoint.x,
     targetPoint.y - sourcePoint.y
@@ -177,6 +348,205 @@ export const useStraightPathEdge = ({
     targetPoint,
   }
 
+  const getNodeRect = useCallback(
+    (node: Node) => {
+      const nodes = getNodes()
+      const currentNode = nodes.find((candidate) => candidate.id === node.id)
+      const resolvedNode = currentNode ?? node
+      const width = resolvedNode.width ?? 0
+      const height = resolvedNode.height ?? 0
+
+      if (!width || !height) return null
+
+      const position = getPositionOnCanvas(resolvedNode, nodes)
+      return { x: position.x, y: position.y, width, height }
+    },
+    [getNodes]
+  )
+
+  const findFreeformEndpointNode = useCallback(
+    (
+      flowPoint: IPoint
+    ): { node: Node; rect: NonNullable<typeof sourceRect> } | null => {
+      const nodes = getNodes()
+      let best: {
+        node: Node
+        rect: NonNullable<typeof sourceRect>
+        distance: number
+      } | null = null
+
+      for (const node of nodes) {
+        if (isParentNodeType(node.type)) continue
+
+        const rect = getNodeRect(node)
+        if (!rect) continue
+
+        const dx =
+          flowPoint.x < rect.x
+            ? rect.x - flowPoint.x
+            : flowPoint.x > rect.x + rect.width
+              ? flowPoint.x - (rect.x + rect.width)
+              : 0
+        const dy =
+          flowPoint.y < rect.y
+            ? rect.y - flowPoint.y
+            : flowPoint.y > rect.y + rect.height
+              ? flowPoint.y - (rect.y + rect.height)
+              : 0
+        const distance = Math.hypot(dx, dy)
+
+        if (
+          distance <= FREEFORM_ENDPOINT_SNAP_RADIUS_PX &&
+          (!best || distance < best.distance)
+        ) {
+          best = { node, rect, distance }
+        }
+      }
+
+      return best ? { node: best.node, rect: best.rect } : null
+    },
+    [getNodeRect, getNodes]
+  )
+
+  const handleEndpointPointerDown = useCallback(
+    (event: ReactPointerEvent<SVGRectElement>, endpoint: EndpointType) => {
+      event.preventDefault()
+      event.stopPropagation()
+      endpointDragCommitRef.current = null
+
+      const ownerDocument = event.currentTarget.ownerDocument
+      const currentSourceEndpoint = basePoints[0]
+      const currentTargetEndpoint = basePoints[1]
+
+      const resolveDragCommit = (
+        clientX: number,
+        clientY: number
+      ): StraightEndpointDragCommit | null => {
+        const flowPoint = screenToFlowPosition({ x: clientX, y: clientY })
+        const intersectingNodes = getIntersectingNodes({
+          x: flowPoint.x - FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
+          y: flowPoint.y - FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
+          width: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
+          height: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
+        })
+        const directHitNode = intersectingNodes.findLast(
+          (node) =>
+            node.width != null &&
+            node.height != null &&
+            !isParentNodeType(node.type)
+        )
+        const directHitRect = directHitNode ? getNodeRect(directHitNode) : null
+        const snapTarget =
+          directHitNode && directHitRect
+            ? { node: directHitNode, rect: directHitRect }
+            : findFreeformEndpointNode(flowPoint)
+
+        if (!snapTarget) return null
+
+        const { node: nodeOnTop, rect } = snapTarget
+        const anchor = getFreeformAnchorFromPoint(flowPoint, rect)
+        const resolvedAnchor = getFreeformAnchorPoint(rect, anchor)
+        let sourceEndpoint = currentSourceEndpoint
+        let targetEndpoint = currentTargetEndpoint
+
+        if (endpoint === "source") {
+          const movingEndpoint = adjustSourceCoordinates(
+            resolvedAnchor.point.x,
+            resolvedAnchor.point.y,
+            resolvedAnchor.position,
+            0
+          )
+          sourceEndpoint = {
+            x: movingEndpoint.sourceX,
+            y: movingEndpoint.sourceY,
+          }
+        } else {
+          const movingEndpoint = adjustTargetCoordinates(
+            resolvedAnchor.point.x,
+            resolvedAnchor.point.y,
+            resolvedAnchor.position,
+            0
+          )
+          targetEndpoint = {
+            x: movingEndpoint.targetX,
+            y: movingEndpoint.targetY,
+          }
+        }
+
+        return {
+          endpoint,
+          nodeId: nodeOnTop.id,
+          handleId: getSideHandleIdForPosition(resolvedAnchor.position),
+          anchor,
+          sourceEndpoint,
+          targetEndpoint,
+        }
+      }
+
+      const handlePointerMove = (e: PointerEvent) => {
+        const commit = resolveDragCommit(e.clientX, e.clientY)
+        endpointDragCommitRef.current = commit
+        setDragPreviewPoints(
+          commit ? [commit.sourceEndpoint, commit.targetEndpoint] : null
+        )
+      }
+
+      const handlePointerUp = () => {
+        const commit = endpointDragCommitRef.current
+        endpointDragCommitRef.current = null
+        setDragPreviewPoints(null)
+
+        if (commit) {
+          setEdges((edges) =>
+            edges.map((edge) => {
+              if (edge.id !== id) return edge
+
+              const nextData = {
+                ...((edge.data ?? {}) as Record<string, unknown>),
+              }
+              if (commit.endpoint === "source") {
+                nextData.sourceAnchor = commit.anchor
+              } else {
+                nextData.targetAnchor = commit.anchor
+              }
+
+              return commit.endpoint === "source"
+                ? {
+                    ...edge,
+                    source: commit.nodeId,
+                    sourceHandle: commit.handleId,
+                    data: nextData,
+                  }
+                : {
+                    ...edge,
+                    target: commit.nodeId,
+                    targetHandle: commit.handleId,
+                    data: nextData,
+                  }
+            })
+          )
+        }
+
+        ownerDocument.removeEventListener("pointermove", handlePointerMove)
+        ownerDocument.removeEventListener("pointerup", handlePointerUp)
+      }
+
+      ownerDocument.addEventListener("pointermove", handlePointerMove)
+      ownerDocument.addEventListener("pointerup", handlePointerUp, {
+        once: true,
+      })
+    },
+    [
+      basePoints,
+      findFreeformEndpointNode,
+      getIntersectingNodes,
+      getNodeRect,
+      id,
+      screenToFlowPosition,
+      setEdges,
+    ]
+  )
+
   return {
     pathRef,
     edgeData,
@@ -190,5 +560,6 @@ export const useStraightPathEdge = ({
     isDiagramModifiable,
     isReconnecting,
     canEditEndpoint,
+    handleEndpointPointerDown,
   }
 }

--- a/library/lib/hooks/useStraightPathEdge.ts
+++ b/library/lib/hooks/useStraightPathEdge.ts
@@ -159,31 +159,35 @@ export const useStraightPathEdge = ({
     allNodes.find((node) => node.id === source) ?? getNode(source)
   const targetNode =
     allNodes.find((node) => node.id === target) ?? getNode(target)
+  // Prefer the displayed React Flow node so a peer's live drag/resize overlay
+  // (applied to the nodes prop before it is persisted) keeps anchored endpoints
+  // attached during the movement; the subscribed store geometry is only a
+  // fallback (and the subscription that re-renders on the settled write).
   const sourceAbsolutePosition = useMemo(() => {
+    if (sourceNode) return getPositionOnCanvas(sourceNode, allNodes)
     if (sourceNodePositionX != null && sourceNodePositionY != null) {
       return { x: sourceNodePositionX, y: sourceNodePositionY }
     }
-    if (!sourceNode) return { x: sourceX, y: sourceY }
-    return getPositionOnCanvas(sourceNode, allNodes)
+    return { x: sourceX, y: sourceY }
   }, [
-    sourceNodePositionX,
-    sourceNodePositionY,
     sourceNode,
     allNodes,
+    sourceNodePositionX,
+    sourceNodePositionY,
     sourceX,
     sourceY,
   ])
   const targetAbsolutePosition = useMemo(() => {
+    if (targetNode) return getPositionOnCanvas(targetNode, allNodes)
     if (targetNodePositionX != null && targetNodePositionY != null) {
       return { x: targetNodePositionX, y: targetNodePositionY }
     }
-    if (!targetNode) return { x: targetX, y: targetY }
-    return getPositionOnCanvas(targetNode, allNodes)
+    return { x: targetX, y: targetY }
   }, [
-    targetNodePositionX,
-    targetNodePositionY,
     targetNode,
     allNodes,
+    targetNodePositionX,
+    targetNodePositionY,
     targetX,
     targetY,
   ])
@@ -193,8 +197,8 @@ export const useStraightPathEdge = ({
         ? {
             x: sourceAbsolutePosition.x,
             y: sourceAbsolutePosition.y,
-            width: sourceNodeWidth ?? sourceNode.width ?? 0,
-            height: sourceNodeHeight ?? sourceNode.height ?? 0,
+            width: sourceNode.width ?? sourceNodeWidth ?? 0,
+            height: sourceNode.height ?? sourceNodeHeight ?? 0,
           }
         : null,
     [
@@ -211,8 +215,8 @@ export const useStraightPathEdge = ({
         ? {
             x: targetAbsolutePosition.x,
             y: targetAbsolutePosition.y,
-            width: targetNodeWidth ?? targetNode.width ?? 0,
-            height: targetNodeHeight ?? targetNode.height ?? 0,
+            width: targetNode.width ?? targetNodeWidth ?? 0,
+            height: targetNode.height ?? targetNodeHeight ?? 0,
           }
         : null,
     [

--- a/library/lib/hooks/useStraightPathEdge.ts
+++ b/library/lib/hooks/useStraightPathEdge.ts
@@ -5,7 +5,7 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from "react"
-import { Position, useReactFlow, useStore, type Node } from "@xyflow/react"
+import { Position, useReactFlow, useStore } from "@xyflow/react"
 import {
   calculateOverlayPath,
   calculateStraightPath,
@@ -19,7 +19,12 @@ import {
 import {
   getEdgeAnchorFromPoint,
   getEdgeAnchorPoint,
+  pickNearestConnectable,
 } from "@/utils/connectionModes"
+import {
+  FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
+  useFreeformEndpointNode,
+} from "./useFreeformEndpointNode"
 import { EDGES } from "@/constants"
 import { useDiagramModifiable } from "./useDiagramModifiable"
 import { IPoint } from "../edges/Connection"
@@ -36,7 +41,7 @@ import {
 } from "./useEdgeLineJumps"
 import { useDiagramStore, useMetadataStore } from "@/store/context"
 import { useShallow } from "zustand/shallow"
-import { getPositionOnCanvas, isParentNodeType } from "@/utils"
+import { getPositionOnCanvas } from "@/utils"
 
 export interface StraightPathEdgeData {
   pathMiddlePosition: IPoint
@@ -58,8 +63,6 @@ type StraightEndpointDragCommit = {
   sourceEndpoint: IPoint
   targetEndpoint: IPoint
 }
-
-const FREEFORM_ENDPOINT_SNAP_RADIUS_PX = 48
 
 export const useStraightPathEdge = ({
   id,
@@ -153,9 +156,9 @@ export const useStraightPathEdge = ({
   const padding = markerPadding ?? EDGES.MARKER_PADDING
   const allNodes = getNodes()
   const sourceNode =
-    allNodes.find((node) => node.id === source) ?? getNode(source)!
+    allNodes.find((node) => node.id === source) ?? getNode(source)
   const targetNode =
-    allNodes.find((node) => node.id === target) ?? getNode(target)!
+    allNodes.find((node) => node.id === target) ?? getNode(target)
   const sourceAbsolutePosition = useMemo(() => {
     if (sourceNodePositionX != null && sourceNodePositionY != null) {
       return { x: sourceNodePositionX, y: sourceNodePositionY }
@@ -359,65 +362,7 @@ export const useStraightPathEdge = ({
     targetPoint,
   }
 
-  const getNodeRect = useCallback(
-    (node: Node) => {
-      const nodes = getNodes()
-      const currentNode = nodes.find((candidate) => candidate.id === node.id)
-      const resolvedNode = currentNode ?? node
-      const width = resolvedNode.width ?? 0
-      const height = resolvedNode.height ?? 0
-
-      if (!width || !height) return null
-
-      const position = getPositionOnCanvas(resolvedNode, nodes)
-      return { x: position.x, y: position.y, width, height }
-    },
-    [getNodes]
-  )
-
-  const findFreeformEndpointNode = useCallback(
-    (
-      flowPoint: IPoint
-    ): { node: Node; rect: NonNullable<typeof sourceRect> } | null => {
-      const nodes = getNodes()
-      let best: {
-        node: Node
-        rect: NonNullable<typeof sourceRect>
-        distance: number
-      } | null = null
-
-      for (const node of nodes) {
-        if (isParentNodeType(node.type)) continue
-
-        const rect = getNodeRect(node)
-        if (!rect) continue
-
-        const dx =
-          flowPoint.x < rect.x
-            ? rect.x - flowPoint.x
-            : flowPoint.x > rect.x + rect.width
-              ? flowPoint.x - (rect.x + rect.width)
-              : 0
-        const dy =
-          flowPoint.y < rect.y
-            ? rect.y - flowPoint.y
-            : flowPoint.y > rect.y + rect.height
-              ? flowPoint.y - (rect.y + rect.height)
-              : 0
-        const distance = Math.hypot(dx, dy)
-
-        if (
-          distance <= FREEFORM_ENDPOINT_SNAP_RADIUS_PX &&
-          (!best || distance < best.distance)
-        ) {
-          best = { node, rect, distance }
-        }
-      }
-
-      return best ? { node: best.node, rect: best.rect } : null
-    },
-    [getNodeRect, getNodes]
-  )
+  const { getNodeRect, findFreeformEndpointNode } = useFreeformEndpointNode()
 
   const handleEndpointPointerDown = useCallback(
     (event: ReactPointerEvent<SVGRectElement>, endpoint: EndpointType) => {
@@ -440,40 +385,15 @@ export const useStraightPathEdge = ({
           width: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
           height: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
         })
-        // Snap to the NEAREST node (distance to its box, 0 when inside), not the
-        // top-most, so tightly packed nodes grab the one under the cursor. On an
-        // exact tie — nested nodes both under the pointer — the later, top-most
-        // node wins: the innermost child, or a container where no child sits.
-        const sizedHits = intersectingNodes.filter(
-          (node) => node.width != null && node.height != null
-        )
-        let snapNode: (typeof sizedHits)[number] | null = null
-        let snapRect: ReturnType<typeof getNodeRect> = null
-        let bestDistance = Infinity
-        for (const node of sizedHits) {
+        // Snap to the nearest connectable node under the pointer (see
+        // pickNearestConnectable); fall back to the wider freeform search.
+        const candidates = intersectingNodes.flatMap((node) => {
           const rect = getNodeRect(node)
-          if (!rect) continue
-          const dx = Math.max(
-            rect.x - flowPoint.x,
-            0,
-            flowPoint.x - (rect.x + rect.width)
-          )
-          const dy = Math.max(
-            rect.y - flowPoint.y,
-            0,
-            flowPoint.y - (rect.y + rect.height)
-          )
-          const distance = Math.hypot(dx, dy)
-          if (distance <= bestDistance) {
-            bestDistance = distance
-            snapNode = node
-            snapRect = rect
-          }
-        }
+          return rect ? [{ node, type: node.type, rect }] : []
+        })
         const snapTarget =
-          snapNode && snapRect
-            ? { node: snapNode, rect: snapRect }
-            : findFreeformEndpointNode(flowPoint)
+          pickNearestConnectable(candidates, flowPoint) ??
+          findFreeformEndpointNode(flowPoint)
 
         if (!snapTarget) return null
 

--- a/library/lib/hooks/useStraightPathEdge.ts
+++ b/library/lib/hooks/useStraightPathEdge.ts
@@ -12,12 +12,14 @@ import {
   getEdgeMarkerStyles,
   adjustSourceCoordinates,
   adjustTargetCoordinates,
-  getFreeformAnchorFromPoint,
-  getFreeformAnchorPoint,
   getSideHandleIdForPosition,
   isFreeformEdgeAnchor,
   type FreeformEdgeAnchor,
 } from "@/utils/edgeUtils"
+import {
+  getEdgeAnchorFromPoint,
+  getEdgeAnchorPoint,
+} from "@/utils/connectionModes"
 import { EDGES } from "@/constants"
 import { useDiagramModifiable } from "./useDiagramModifiable"
 import { IPoint } from "../edges/Connection"
@@ -34,7 +36,7 @@ import {
 } from "./useEdgeLineJumps"
 import { useDiagramStore, useMetadataStore } from "@/store/context"
 import { useShallow } from "zustand/shallow"
-import { getPositionOnCanvas } from "@/utils"
+import { getPositionOnCanvas, isParentNodeType } from "@/utils"
 
 export interface StraightPathEdgeData {
   pathMiddlePosition: IPoint
@@ -221,16 +223,16 @@ export const useStraightPathEdge = ({
   const resolvedSourceAnchor = useMemo(
     () =>
       sourceRect && isFreeformEdgeAnchor(sourceAnchor)
-        ? getFreeformAnchorPoint(sourceRect, sourceAnchor)
+        ? getEdgeAnchorPoint(sourceNode?.type, sourceRect, sourceAnchor)
         : null,
-    [sourceAnchor, sourceRect]
+    [sourceAnchor, sourceRect, sourceNode?.type]
   )
   const resolvedTargetAnchor = useMemo(
     () =>
       targetRect && isFreeformEdgeAnchor(targetAnchor)
-        ? getFreeformAnchorPoint(targetRect, targetAnchor)
+        ? getEdgeAnchorPoint(targetNode?.type, targetRect, targetAnchor)
         : null,
-    [targetAnchor, targetRect]
+    [targetAnchor, targetRect, targetNode?.type]
   )
   const resolvedSourceX = resolvedSourceAnchor?.point.x ?? sourceX
   const resolvedSourceY = resolvedSourceAnchor?.point.y ?? sourceY
@@ -302,9 +304,8 @@ export const useStraightPathEdge = ({
   )
 
   // Midpoint + orientation derived purely from the two endpoints. A straight
-  // edge's middle is analytic, so this replaces the old getPointAtLength +
-  // setTimeout effect (and its two redundant fallback effects) with one
-  // synchronous, DOM-free, export-stable computation.
+  // edge's middle is analytic, so it is computed synchronously, DOM-free, and
+  // export-stable.
   const { point: pathMiddlePosition, isHorizontal: isMiddlePathHorizontal } =
     useMemo(
       () => getMidSegment(renderPoints, renderPoints[0], renderPoints[1]),
@@ -386,6 +387,8 @@ export const useStraightPathEdge = ({
       } | null = null
 
       for (const node of nodes) {
+        if (isParentNodeType(node.type)) continue
+
         const rect = getNodeRect(node)
         if (!rect) continue
 
@@ -432,25 +435,52 @@ export const useStraightPathEdge = ({
       ): StraightEndpointDragCommit | null => {
         const flowPoint = screenToFlowPosition({ x: clientX, y: clientY })
         const intersectingNodes = getIntersectingNodes({
-          x: flowPoint.x - 1,
-          y: flowPoint.y - 1,
-          width: 2,
-          height: 2,
+          x: flowPoint.x - FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
+          y: flowPoint.y - FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
+          width: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
+          height: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
         })
-        const directHitNode = intersectingNodes.findLast(
+        // Snap to the NEAREST node (distance to its box, 0 when inside), not the
+        // top-most, so tightly packed nodes grab the one under the cursor. On an
+        // exact tie — nested nodes both under the pointer — the later, top-most
+        // node wins: the innermost child, or a container where no child sits.
+        const sizedHits = intersectingNodes.filter(
           (node) => node.width != null && node.height != null
         )
-        const directHitRect = directHitNode ? getNodeRect(directHitNode) : null
+        let snapNode: (typeof sizedHits)[number] | null = null
+        let snapRect: ReturnType<typeof getNodeRect> = null
+        let bestDistance = Infinity
+        for (const node of sizedHits) {
+          const rect = getNodeRect(node)
+          if (!rect) continue
+          const dx = Math.max(
+            rect.x - flowPoint.x,
+            0,
+            flowPoint.x - (rect.x + rect.width)
+          )
+          const dy = Math.max(
+            rect.y - flowPoint.y,
+            0,
+            flowPoint.y - (rect.y + rect.height)
+          )
+          const distance = Math.hypot(dx, dy)
+          if (distance <= bestDistance) {
+            bestDistance = distance
+            snapNode = node
+            snapRect = rect
+          }
+        }
         const snapTarget =
-          directHitNode && directHitRect
-            ? { node: directHitNode, rect: directHitRect }
+          snapNode && snapRect
+            ? { node: snapNode, rect: snapRect }
             : findFreeformEndpointNode(flowPoint)
 
         if (!snapTarget) return null
 
         const { node: nodeOnTop, rect } = snapTarget
-        const anchor = getFreeformAnchorFromPoint(flowPoint, rect)
-        const resolvedAnchor = getFreeformAnchorPoint(rect, anchor)
+        const anchor = getEdgeAnchorFromPoint(nodeOnTop.type, flowPoint, rect)
+        if (!anchor) return null // node is not a connection target (mode "none")
+        const resolvedAnchor = getEdgeAnchorPoint(nodeOnTop.type, rect, anchor)
         let sourceEndpoint = currentSourceEndpoint
         let targetEndpoint = currentTargetEndpoint
 
@@ -499,17 +529,25 @@ export const useStraightPathEdge = ({
       const handlePointerMove = (e: PointerEvent) => {
         const commit = resolveDragCommit(e.clientX, e.clientY)
         endpointDragCommitRef.current = commit
+        if (commit) {
+          setDragPreviewPoints([commit.sourceEndpoint, commit.targetEndpoint])
+          setDragPreviewPositions({
+            sourcePosition: commit.sourcePosition,
+            targetPosition: commit.targetPosition,
+          })
+          return
+        }
+        // No snap target (empty canvas): free preview whose dragged end follows
+        // the cursor (straight, matching this edge). No commit ⇒ reverts on
+        // release. Positions are irrelevant for a straight preview (the marker
+        // orients along the path, not by side).
+        const flowPoint = screenToFlowPosition({ x: e.clientX, y: e.clientY })
         setDragPreviewPoints(
-          commit ? [commit.sourceEndpoint, commit.targetEndpoint] : null
+          endpoint === "source"
+            ? [flowPoint, currentTargetEndpoint]
+            : [currentSourceEndpoint, flowPoint]
         )
-        setDragPreviewPositions(
-          commit
-            ? {
-                sourcePosition: commit.sourcePosition,
-                targetPosition: commit.targetPosition,
-              }
-            : null
-        )
+        setDragPreviewPositions(null)
       }
 
       const handlePointerUp = () => {

--- a/library/lib/hooks/useStraightPathEdge.ts
+++ b/library/lib/hooks/useStraightPathEdge.ts
@@ -5,7 +5,7 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from "react"
-import { useReactFlow, useStore, type Node } from "@xyflow/react"
+import { Position, useReactFlow, useStore, type Node } from "@xyflow/react"
 import {
   calculateOverlayPath,
   calculateStraightPath,
@@ -51,6 +51,8 @@ type StraightEndpointDragCommit = {
   nodeId: string
   handleId: string
   anchor: FreeformEdgeAnchor
+  sourcePosition: Position
+  targetPosition: Position
   sourceEndpoint: IPoint
   targetEndpoint: IPoint
 }
@@ -82,6 +84,10 @@ export const useStraightPathEdge = ({
   const [dragPreviewPoints, setDragPreviewPoints] = useState<IPoint[] | null>(
     null
   )
+  const [dragPreviewPositions, setDragPreviewPositions] = useState<{
+    sourcePosition: Position
+    targetPosition: Position
+  } | null>(null)
   const sourceAnchor = data?.sourceAnchor
   const targetAnchor = data?.targetAnchor
   const shouldSubscribeToNodeGeometry =
@@ -279,6 +285,10 @@ export const useStraightPathEdge = ({
     ]
   )
   const renderPoints = dragPreviewPoints ?? basePoints
+  const renderSourcePosition =
+    dragPreviewPositions?.sourcePosition ?? resolvedSourcePosition
+  const renderTargetPosition =
+    dragPreviewPositions?.targetPosition ?? resolvedTargetPosition
 
   // Publish this edge's real geometry so other edges bridge over it accurately.
   usePublishEdgeGeometry(id, renderPoints)
@@ -478,6 +488,14 @@ export const useStraightPathEdge = ({
           nodeId: nodeOnTop.id,
           handleId: getSideHandleIdForPosition(resolvedAnchor.position),
           anchor,
+          sourcePosition:
+            endpoint === "source"
+              ? resolvedAnchor.position
+              : resolvedSourcePosition,
+          targetPosition:
+            endpoint === "target"
+              ? resolvedAnchor.position
+              : resolvedTargetPosition,
           sourceEndpoint,
           targetEndpoint,
         }
@@ -489,12 +507,21 @@ export const useStraightPathEdge = ({
         setDragPreviewPoints(
           commit ? [commit.sourceEndpoint, commit.targetEndpoint] : null
         )
+        setDragPreviewPositions(
+          commit
+            ? {
+                sourcePosition: commit.sourcePosition,
+                targetPosition: commit.targetPosition,
+              }
+            : null
+        )
       }
 
       const handlePointerUp = () => {
         const commit = endpointDragCommitRef.current
         endpointDragCommitRef.current = null
         setDragPreviewPoints(null)
+        setDragPreviewPositions(null)
 
         if (commit) {
           setEdges((edges) =>
@@ -542,6 +569,8 @@ export const useStraightPathEdge = ({
       getIntersectingNodes,
       getNodeRect,
       id,
+      resolvedSourcePosition,
+      resolvedTargetPosition,
       screenToFlowPosition,
       setEdges,
     ]
@@ -561,5 +590,7 @@ export const useStraightPathEdge = ({
     isReconnecting,
     canEditEndpoint,
     handleEndpointPointerDown,
+    sourcePosition: renderSourcePosition,
+    targetPosition: renderTargetPosition,
   }
 }

--- a/library/lib/hooks/useStraightPathEdge.ts
+++ b/library/lib/hooks/useStraightPathEdge.ts
@@ -34,7 +34,7 @@ import {
 } from "./useEdgeLineJumps"
 import { useDiagramStore, useMetadataStore } from "@/store/context"
 import { useShallow } from "zustand/shallow"
-import { getPositionOnCanvas, isParentNodeType } from "@/utils"
+import { getPositionOnCanvas } from "@/utils"
 
 export interface StraightPathEdgeData {
   pathMiddlePosition: IPoint
@@ -386,8 +386,6 @@ export const useStraightPathEdge = ({
       } | null = null
 
       for (const node of nodes) {
-        if (isParentNodeType(node.type)) continue
-
         const rect = getNodeRect(node)
         if (!rect) continue
 
@@ -434,16 +432,13 @@ export const useStraightPathEdge = ({
       ): StraightEndpointDragCommit | null => {
         const flowPoint = screenToFlowPosition({ x: clientX, y: clientY })
         const intersectingNodes = getIntersectingNodes({
-          x: flowPoint.x - FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
-          y: flowPoint.y - FREEFORM_ENDPOINT_SNAP_RADIUS_PX,
-          width: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
-          height: FREEFORM_ENDPOINT_SNAP_RADIUS_PX * 2,
+          x: flowPoint.x - 1,
+          y: flowPoint.y - 1,
+          width: 2,
+          height: 2,
         })
         const directHitNode = intersectingNodes.findLast(
-          (node) =>
-            node.width != null &&
-            node.height != null &&
-            !isParentNodeType(node.type)
+          (node) => node.width != null && node.height != null
         )
         const directHitRect = directHitNode ? getNodeRect(directHitNode) : null
         const snapTarget =

--- a/library/lib/nodes/TitleAndDescriptionNode.tsx
+++ b/library/lib/nodes/TitleAndDescriptionNode.tsx
@@ -18,7 +18,12 @@ export function TitleAndDesctiption({
   }
 
   return (
-    <DefaultNodeWrapper width={width} height={height} elementId={id}>
+    <DefaultNodeWrapper
+      width={width}
+      height={height}
+      elementId={id}
+      hiddenHandles={true}
+    >
       <TitleAndDescriptionSVG
         width={width}
         height={height}

--- a/library/lib/nodes/bpmn/BPMNAnnotation.tsx
+++ b/library/lib/nodes/bpmn/BPMNAnnotation.tsx
@@ -24,7 +24,12 @@ export function BPMNAnnotation({
   }
 
   return (
-    <DefaultNodeWrapper width={width} height={height} elementId={id}>
+    <DefaultNodeWrapper
+      width={width}
+      height={height}
+      elementId={id}
+      isConnectableEnd={false}
+    >
       <NodeToolbar elementId={id} />
 
       <NodeResizer

--- a/library/lib/nodes/useCaseDiagram/UseCase.tsx
+++ b/library/lib/nodes/useCaseDiagram/UseCase.tsx
@@ -200,6 +200,13 @@ export function UseCase({
           }
           isConnectable={isDiagramModifiable}
           isConnectableStart={handle.isPrimaryHandle && isDiagramModifiable}
+          // Never end a connection on a fixed handle: React Flow only shows its
+          // snap circle at the 4 cardinal handles. Every drop instead routes
+          // through the freeform path, which attaches continuously along the
+          // curve and draws its own snap circle at the live attach point (see
+          // ReconnectConnectionLine), so the preview matches the landing at any
+          // angle.
+          isConnectableEnd={false}
         />
       ))}
 

--- a/library/lib/nodes/wrappers/DefaultNodeWrapper.tsx
+++ b/library/lib/nodes/wrappers/DefaultNodeWrapper.tsx
@@ -104,6 +104,10 @@ interface Props {
   elementId: string
   hiddenHandles?: HandleId[] | true
   className?: string
+  // Keep the handles (so existing edges anchored to them still render) but stop
+  // this node from being a connection TARGET. Used by non-connectable shapes that
+  // can still be an edge SOURCE, e.g. a BPMN annotation.
+  isConnectableEnd?: boolean
 }
 
 export function DefaultNodeWrapper({
@@ -111,6 +115,7 @@ export function DefaultNodeWrapper({
   children,
   hiddenHandles = [],
   className,
+  isConnectableEnd = true,
 }: Props) {
   // Subscribe to only the fields this wrapper uses, with shallow equality, so a
   // node re-renders its handles on resize/type change but not on the position
@@ -609,6 +614,7 @@ export function DefaultNodeWrapper({
                   }
                   isConnectable={isDiagramModifiable}
                   isConnectableStart={isPrimaryHandle && isDiagramModifiable}
+                  isConnectableEnd={isConnectableEnd}
                 />
               )
             })}

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -652,9 +652,12 @@
   opacity: 0.4;
   box-sizing: border-box;
 
-  /* Off by default; only grabbable while the node is hovered (or in click-to-
-     connect guidance mode) — see the hit-area note near the hover rules below. */
-  pointer-events: none;
+  /* Grabbable on its own hit area, not gated behind the node body: the arc
+     protrudes past the node box, so it must be reachable when approached from
+     outside. Hovering the armed arc triggers the node :hover that fades it in.
+     Disarmed for selected-not-hovered nodes and in guidance mode (see the
+     hit-area note near the hover rules). */
+  pointer-events: all;
   cursor: crosshair;
 
   /* --arc-scale is set by DefaultNodeWrapper to 1/zoom so the indicator keeps
@@ -714,13 +717,14 @@
   transition: opacity 120ms ease;
 }
 
-/* Hit-area fix (same idea as the #791 node-toolbar fix). A node's resize controls
-   and connection arcs PROTRUDE past its box, and a selected node is lifted above
-   its neighbours (`elevateNodesOnSelect`), so arming these affordances just because
-   the node is selected makes them swallow clicks meant for an overlapping node
-   beneath them. On a fine pointer we arm them on :hover instead — every gesture
-   that uses them starts by hovering — so a selected-not-hovered node lets clicks
-   fall through. Touch has no :hover; see the coarse-pointer fallback below. */
+/* A node's resize controls protrude past its box, and a selected node is lifted
+   above its neighbours (`elevateNodesOnSelect`), so arming them on selection
+   alone would cover clicks meant for an overlapping node beneath. Arm them on
+   :hover instead — every gesture that uses them starts by hovering — so a
+   selected-not-hovered node lets clicks fall through. Touch has no :hover; see
+   the coarse-pointer fallback below. (Connection arcs face the same overlap but
+   stay armed on their own hit area, disarmed only for a selected-not-hovered
+   node — see the arc rules below.) */
 .react-flow__node:hover .react-flow__resize-control {
   pointer-events: all;
 }
@@ -744,15 +748,14 @@
   pointer-events: all;
 }
 
-/* The arc ::before is armed on hover too, but scoped OUT of guidance mode: its
-   selector would otherwise out-specify the guidance "arcs off" rule below and
-   re-arm an invisible (opacity:0) arc, swallowing clicks over neighbours — the
-   very bug this fix removes. Guidance drives connections from the circle handle,
-   not the arc, so the arc stays inert there. */
-.apollon-editor:not(.apollon-editor--connection-guidance)
-  .react-flow__node:hover
+/* Arcs are armed on their own hit area (see the base rule above). A selected
+   node is lifted above its neighbours (elevateNodesOnSelect), so its protruding
+   arcs, if armed, would cover clicks meant for an overlapping node beneath it.
+   Disarm them while the node is selected but not hovered; hovering re-arms them,
+   so an arc on the node you're pointing at stays grabbable. */
+.react-flow__node.selected:not(:hover)
   .react-flow__handle.apollon-arc-handle::before {
-  pointer-events: all;
+  pointer-events: none;
 }
 
 .react-flow__node:hover .react-flow__handle {
@@ -772,13 +775,13 @@
   pointer-events: none;
 }
 
-/* Coarse-pointer fallback for the hit-area fix above. Touch devices never fire
-   :hover, so the hover-gated rules would leave a selected node's affordances
+/* Coarse-pointer fallback for the hover-gated rules above. Touch devices never
+   fire :hover, so those rules would leave a selected node's affordances
    ungrabbable — you could not start a connection or resize with a finger. Arm
-   them on selection instead, matching pre-fix behaviour. (A coarse pointer can't
-   hover to disambiguate an overlap anyway, so it keeps the swallow the fine-pointer
-   path removes.) The arc ::before is excluded in guidance mode so its hidden arcs
-   stay inert while the circle handles drive the connection. */
+   them on selection instead. (A coarse pointer can't hover to disambiguate an
+   overlap anyway, so the overlap trade-off doesn't apply.) The arc ::before is
+   excluded in guidance mode so its hidden arcs stay inert while the circle
+   handles drive the connection. */
 @media (hover: none), (pointer: coarse) {
   .react-flow__node.selected .react-flow__handle.connectionindicator,
   .react-flow__node.selected .react-flow__resize-control,

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -840,6 +840,18 @@
   vector-effect: non-scaling-stroke;
 }
 
+.edge-endpoint-grip {
+  opacity: 0;
+  fill: var(--apollon-background, #fff);
+  stroke: var(--apollon-primary, #3e8acc);
+  stroke-width: 2px;
+  transition:
+    fill 120ms ease,
+    opacity 120ms ease,
+    stroke 120ms ease;
+  vector-effect: non-scaling-stroke;
+}
+
 .edge-endpoint-handle {
   fill: transparent;
   stroke: transparent;
@@ -856,6 +868,19 @@
 .react-flow__edge.selected .edge-bend-handle {
   opacity: 1;
   fill: var(--apollon-primary, #3e8acc);
+}
+
+.react-flow__edge:hover .edge-endpoint-grip,
+.react-flow__edge.selected .edge-endpoint-grip {
+  opacity: 1;
+}
+
+.react-flow__edge.selected .edge-endpoint-grip {
+  fill: color-mix(
+    in srgb,
+    var(--apollon-primary, #3e8acc) 18%,
+    var(--apollon-background, #fff)
+  );
 }
 
 .react-flow__edge:hover .edge-bend-handle:hover,

--- a/library/lib/utils/connectionModes.ts
+++ b/library/lib/utils/connectionModes.ts
@@ -59,6 +59,37 @@ export function getConnectionMode(nodeType?: string): ConnectionMode {
   return (nodeType ? MODE_OVERRIDES[nodeType] : undefined) ?? "freeform-rect"
 }
 
+/** Distance from a point to a rectangle (0 when the point is inside it). */
+export function distanceToRect(point: XYPosition, rect: Rect): number {
+  const dx = Math.max(rect.x - point.x, 0, point.x - (rect.x + rect.width))
+  const dy = Math.max(rect.y - point.y, 0, point.y - (rect.y + rect.height))
+  return Math.hypot(dx, dy)
+}
+
+/**
+ * The connection candidate NEAREST `point` (distance to its box, 0 when inside),
+ * skipping non-connectable (`mode: "none"`) nodes. On an exact distance tie the
+ * later, top-most candidate wins — so a child beats the container it nests in,
+ * while a container stays reachable where the pointer is over it but no child is.
+ * Shared by the new-connection drop resolver and both edge-endpoint drag hooks.
+ */
+export function pickNearestConnectable<T>(
+  candidates: ReadonlyArray<{ node: T; type?: string; rect: Rect }>,
+  point: XYPosition
+): { node: T; rect: Rect } | null {
+  let best: { node: T; rect: Rect } | null = null
+  let bestDistance = Infinity
+  for (const candidate of candidates) {
+    if (getConnectionMode(candidate.type) === "none") continue
+    const distance = distanceToRect(point, candidate.rect)
+    if (distance <= bestDistance) {
+      bestDistance = distance
+      best = { node: candidate.node, rect: candidate.rect }
+    }
+  }
+  return best
+}
+
 const centerOf = (rect: Rect): XYPosition => ({
   x: rect.x + rect.width / 2,
   y: rect.y + rect.height / 2,
@@ -83,8 +114,9 @@ const projectOntoEllipse = (
   const rx = rect.width / 2 || 1
   const ry = rect.height / 2 || 1
   const dx = point.x - c.x
+  const dyRaw = point.y - c.y
   // degenerate: a drop exactly at the centre defaults to the top
-  const dy = point.x - c.x === 0 && point.y - c.y === 0 ? -1 : point.y - c.y
+  const dy = dx === 0 && dyRaw === 0 ? -1 : dyRaw
   const t = 1 / Math.hypot(dx / rx, dy / ry)
   return {
     point: { x: c.x + t * dx, y: c.y + t * dy },
@@ -93,10 +125,7 @@ const projectOntoEllipse = (
 }
 
 /** The four side-midpoint connection points of a node, keyed by side. */
-export function getFourCenterPoints(
-  _nodeType: string | undefined,
-  rect: Rect
-): Record<Position, XYPosition> {
+function getFourCenterPoints(rect: Rect): Record<Position, XYPosition> {
   const c = centerOf(rect)
   return {
     [Position.Top]: { x: c.x, y: rect.y },
@@ -227,7 +256,7 @@ export function getEdgeAnchorPoint(
 ): { point: XYPosition; position: Position } {
   switch (getConnectionMode(nodeType)) {
     case "four-center": {
-      const pts = getFourCenterPoints(nodeType, rect)
+      const pts = getFourCenterPoints(rect)
       return { point: pts[anchor.side], position: anchor.side }
     }
     case "ellipse":

--- a/library/lib/utils/connectionModes.ts
+++ b/library/lib/utils/connectionModes.ts
@@ -1,0 +1,245 @@
+import { Position, type Rect, type XYPosition } from "@xyflow/react"
+import {
+  type FreeformEdgeAnchor,
+  getFreeformAnchorFromPoint,
+  getFreeformAnchorPoint,
+} from "./edgeUtils"
+
+/**
+ * How an edge endpoint may attach to a node, decided by the node's visible
+ * shape rather than its bounding box. The anchor math below branches on this so
+ * a drop, its preview, and the rendered edge all agree.
+ *
+ * The stored anchor is always `{side, ratio}` on the node's bounding rectangle;
+ * the mode only changes how that anchor is turned into a pixel (project onto the
+ * oval, snap to a vertex, …) and how a drop is turned into an anchor.
+ */
+export type ConnectionMode =
+  | "freeform-rect" // anywhere on the rectangle border (default box shapes)
+  | "ellipse" // on the inscribed oval, at the angle you aimed (use-case)
+  | "parallelogram" // anywhere along the sheared outline (flowchart input/output)
+  | "four-center" // only the four side points — N/E/S/W (FOUR_WAY-handle nodes)
+  | "none" // not a connection target at all (legends, annotations, swimlanes)
+
+// A node's connectable points must match the handles it renders. Nodes that
+// render the full handle set stay `freeform-rect` (the default) and connect
+// anywhere along their border. Nodes that render only the four side handles
+// (FOUR_WAY_HANDLES_PRESET) connect at exactly those four points. The use-case
+// oval renders full handles but isn't a rectangle, so it gets `ellipse`. Only
+// the exceptions are listed here.
+const MODE_OVERRIDES: Record<string, ConnectionMode> = {
+  // Not connectable — legends / annotations / partition containers.
+  colorDescription: "none",
+  titleAndDesctiption: "none",
+  bpmnAnnotation: "none",
+  activitySwimlane: "none",
+  // The one true oval — full handles, so connect anywhere along the curve.
+  useCase: "ellipse",
+  // Everything below renders only the four side handles, so it connects at
+  // exactly those four N/E/S/W points (keep this list in sync with the nodes
+  // that pass FOUR_WAY_HANDLES_PRESET).
+  activityInitialNode: "four-center",
+  activityFinalNode: "four-center",
+  activityMergeNode: "four-center",
+  bpmnStartEvent: "four-center",
+  bpmnIntermediateEvent: "four-center",
+  bpmnEndEvent: "four-center",
+  bpmnGateway: "four-center",
+  flowchartDecision: "four-center",
+  petriNetPlace: "four-center",
+  petriNetTransition: "four-center",
+  componentInterface: "four-center",
+  deploymentInterface: "four-center",
+  sfcTransitionBranch: "four-center",
+  // Continuous along the sheared outline, like the oval is along its curve.
+  flowchartInputOutput: "parallelogram",
+}
+
+export function getConnectionMode(nodeType?: string): ConnectionMode {
+  return (nodeType ? MODE_OVERRIDES[nodeType] : undefined) ?? "freeform-rect"
+}
+
+const centerOf = (rect: Rect): XYPosition => ({
+  x: rect.x + rect.width / 2,
+  y: rect.y + rect.height / 2,
+})
+
+/** Dominant side for a direction from the ellipse centre, so the orthogonal
+ * step router still gets a Position to exit on. */
+const sideForDirection = (dx: number, dy: number, rx: number, ry: number) => {
+  const hx = Math.abs(dx) / (rx || 1)
+  const hy = Math.abs(dy) / (ry || 1)
+  if (hx >= hy) return dx >= 0 ? Position.Right : Position.Left
+  return dy >= 0 ? Position.Bottom : Position.Top
+}
+
+/** Project a point onto the inscribed ellipse along the ray from the centre —
+ * the endpoint lands on the curve at the angle you aimed. */
+const projectOntoEllipse = (
+  rect: Rect,
+  point: XYPosition
+): { point: XYPosition; position: Position } => {
+  const c = centerOf(rect)
+  const rx = rect.width / 2 || 1
+  const ry = rect.height / 2 || 1
+  const dx = point.x - c.x
+  // degenerate: a drop exactly at the centre defaults to the top
+  const dy = point.x - c.x === 0 && point.y - c.y === 0 ? -1 : point.y - c.y
+  const t = 1 / Math.hypot(dx / rx, dy / ry)
+  return {
+    point: { x: c.x + t * dx, y: c.y + t * dy },
+    position: sideForDirection(dx, dy, rx, ry),
+  }
+}
+
+/** The four side-midpoint connection points of a node, keyed by side. */
+export function getFourCenterPoints(
+  _nodeType: string | undefined,
+  rect: Rect
+): Record<Position, XYPosition> {
+  const c = centerOf(rect)
+  return {
+    [Position.Top]: { x: c.x, y: rect.y },
+    [Position.Right]: { x: rect.x + rect.width, y: c.y },
+    [Position.Bottom]: { x: c.x, y: rect.y + rect.height },
+    [Position.Left]: { x: rect.x, y: c.y },
+  } as Record<Position, XYPosition>
+}
+
+// The flowchart input/output parallelogram slants its left/right edges inward by
+// this many px (see FlowchartInputOutput SVG `M20,0 L${width},0 L${width-20},…`).
+const FLOWCHART_IO_SLANT = 20
+
+/** Shear a bounding-box border point onto the parallelogram's actual outline so
+ * the endpoint sits ON the slanted edge (no gap) at any height. */
+const projectOntoParallelogram = (
+  rect: Rect,
+  anchor: FreeformEdgeAnchor
+): { point: XYPosition; position: Position } => {
+  const { point, position } = getFreeformAnchorPoint(rect, anchor)
+  const o = FLOWCHART_IO_SLANT
+  const ty = (point.y - rect.y) / (rect.height || 1) // 0 at top → 1 at bottom
+  switch (position) {
+    case Position.Left: // slants from x+o (top) to x (bottom)
+      return { point: { x: rect.x + o * (1 - ty), y: point.y }, position }
+    case Position.Right: // slants from x+w (top) to x+w-o (bottom)
+      return {
+        point: { x: rect.x + rect.width - o * ty, y: point.y },
+        position,
+      }
+    case Position.Top: // top edge starts o in from the left
+      return {
+        point: { x: Math.max(point.x, rect.x + o), y: rect.y },
+        position,
+      }
+    case Position.Bottom: // bottom edge ends o short of the right
+      return {
+        point: {
+          x: Math.min(point.x, rect.x + rect.width - o),
+          y: rect.y + rect.height,
+        },
+        position,
+      }
+    default:
+      return { point, position }
+  }
+}
+
+const nearestSide = (rect: Rect, point: XYPosition): Position => {
+  const c = centerOf(rect)
+  return sideForDirection(
+    point.x - c.x,
+    point.y - c.y,
+    rect.width / 2,
+    rect.height / 2
+  )
+}
+
+const clampRatio = (r: number) => (r < 0 ? 0 : r > 1 ? 1 : r)
+
+/**
+ * The bounding-box border anchor where the ray from the CENTRE through `point`
+ * exits the rect. Projecting this onto the ellipse (which also rays from the
+ * centre) lands the endpoint at exactly the aimed ANGLE — including diagonals,
+ * where routing through the nearest bbox side instead would pull the point
+ * ~10° toward a cardinal.
+ */
+const rectBorderAlongRay = (
+  rect: Rect,
+  point: XYPosition
+): FreeformEdgeAnchor => {
+  const c = centerOf(rect)
+  const dx = point.x - c.x
+  const dy = point.y - c.y
+  if (dx === 0 && dy === 0) return { side: Position.Top, ratio: 0.5 }
+  const tx = dx !== 0 ? rect.width / 2 / Math.abs(dx) : Infinity
+  const ty = dy !== 0 ? rect.height / 2 / Math.abs(dy) : Infinity
+  if (tx <= ty) {
+    const yEdge = c.y + tx * dy
+    return {
+      side: dx > 0 ? Position.Right : Position.Left,
+      ratio: clampRatio((yEdge - rect.y) / rect.height),
+    }
+  }
+  const xEdge = c.x + ty * dx
+  return {
+    side: dy > 0 ? Position.Bottom : Position.Top,
+    ratio: clampRatio((xEdge - rect.x) / rect.width),
+  }
+}
+
+/**
+ * Shape-aware forward: turn a drop point into the stored `{side, ratio}` anchor.
+ * Returns null when the node is not a connection target (`none`).
+ */
+export function getEdgeAnchorFromPoint(
+  nodeType: string | undefined,
+  point: XYPosition,
+  rect: Rect
+): FreeformEdgeAnchor | null {
+  switch (getConnectionMode(nodeType)) {
+    case "none":
+      return null
+    case "four-center":
+      return { side: nearestSide(rect, point), ratio: 0.5 }
+    case "ellipse":
+      // Store the anchor ALONG THE RAY to the cursor so the curve projection
+      // lands at the aimed angle (no diagonal drift).
+      return rectBorderAlongRay(rect, point)
+    // parallelogram & freeform-rect store the nearest rect-border anchor; the
+    // shape projection at render lands on the slanted outline / border.
+    case "parallelogram":
+    case "freeform-rect":
+    default:
+      return getFreeformAnchorFromPoint(point, rect)
+  }
+}
+
+/**
+ * Shape-aware inverse: turn a stored anchor into the rendered pixel + Position,
+ * projecting onto the node's real shape. Rect anchors stored on round/diamond/
+ * interface nodes convert here on the fly.
+ */
+export function getEdgeAnchorPoint(
+  nodeType: string | undefined,
+  rect: Rect,
+  anchor: FreeformEdgeAnchor
+): { point: XYPosition; position: Position } {
+  switch (getConnectionMode(nodeType)) {
+    case "four-center": {
+      const pts = getFourCenterPoints(nodeType, rect)
+      return { point: pts[anchor.side], position: anchor.side }
+    }
+    case "ellipse":
+      return projectOntoEllipse(
+        rect,
+        getFreeformAnchorPoint(rect, anchor).point
+      )
+    case "parallelogram":
+      return projectOntoParallelogram(rect, anchor)
+    case "none":
+    case "freeform-rect":
+    default:
+      return getFreeformAnchorPoint(rect, anchor)
+  }
+}

--- a/library/lib/utils/edgeUtils.ts
+++ b/library/lib/utils/edgeUtils.ts
@@ -299,6 +299,23 @@ type RectHandlePoint = {
   side: Position
 }
 
+export type FreeformEdgeAnchor = {
+  side: Position
+  /**
+   * Offset along the side, normalized to the current node side length. The
+   * editor rounds the resolved point to whole flow pixels, so a drop can land
+   * on any pixel while still scaling sensibly if the node is resized later.
+   */
+  ratio: number
+}
+
+const sideToHandleId: Record<Position, "top" | "right" | "bottom" | "left"> = {
+  top: "top",
+  right: "right",
+  bottom: "bottom",
+  left: "left",
+}
+
 // Match the canvas grid step. Handle offsets snap to this so the X (or Y)
 // distance between any two handles on equally-sized nodes is always a
 // multiple of the grid step — which means a user dragging a node on the grid
@@ -316,6 +333,162 @@ const HANDLE_RATIO_END = 0.8
 
 const clamp = (value: number, min: number, max: number): number =>
   Math.max(min, Math.min(max, value))
+
+export function isClassDiagramEdgeType(type: string | undefined): boolean {
+  return typeof type === "string" && type.startsWith("Class")
+}
+
+export function isFreeformEdgeAnchor(
+  anchor: unknown
+): anchor is FreeformEdgeAnchor {
+  if (!anchor || typeof anchor !== "object") return false
+
+  const candidate = anchor as Partial<FreeformEdgeAnchor>
+  return (
+    (candidate.side === "top" ||
+      candidate.side === "right" ||
+      candidate.side === "bottom" ||
+      candidate.side === "left") &&
+    typeof candidate.ratio === "number" &&
+    Number.isFinite(candidate.ratio)
+  )
+}
+
+export function getSideHandleIdForPosition(
+  position: Position
+): "top" | "right" | "bottom" | "left" {
+  return sideToHandleId[position]
+}
+
+export function getFreeformAnchorFromPoint(
+  point: XYPosition,
+  rect: Rect
+): FreeformEdgeAnchor {
+  const right = rect.x + rect.width
+  const bottom = rect.y + rect.height
+  const x = clamp(point.x, rect.x, right)
+  const y = clamp(point.y, rect.y, bottom)
+  const candidates: Array<{
+    side: Position
+    point: XYPosition
+    axisLength: number
+    offset: number
+  }> = [
+    {
+      side: "top" as Position,
+      point: { x, y: rect.y },
+      axisLength: rect.width,
+      offset: x - rect.x,
+    },
+    {
+      side: "right" as Position,
+      point: { x: right, y },
+      axisLength: rect.height,
+      offset: y - rect.y,
+    },
+    {
+      side: "bottom" as Position,
+      point: { x, y: bottom },
+      axisLength: rect.width,
+      offset: x - rect.x,
+    },
+    {
+      side: "left" as Position,
+      point: { x: rect.x, y },
+      axisLength: rect.height,
+      offset: y - rect.y,
+    },
+  ]
+
+  let closest = candidates[0]
+  let minDistance = distance(point, closest.point)
+
+  for (const candidate of candidates.slice(1)) {
+    const candidateDistance = distance(point, candidate.point)
+    if (candidateDistance < minDistance) {
+      closest = candidate
+      minDistance = candidateDistance
+    }
+  }
+
+  const roundedOffset = clamp(Math.round(closest.offset), 0, closest.axisLength)
+
+  return {
+    side: closest.side,
+    ratio: closest.axisLength > 0 ? roundedOffset / closest.axisLength : 0.5,
+  }
+}
+
+export function getFreeformAnchorPoint(
+  rect: Rect,
+  anchor: FreeformEdgeAnchor
+): { point: XYPosition; position: Position } {
+  const ratio = clamp(anchor.ratio, 0, 1)
+
+  switch (anchor.side) {
+    case "top": {
+      const offset = Math.round(rect.width * ratio)
+      return {
+        point: { x: rect.x + offset, y: rect.y },
+        position: "top" as Position,
+      }
+    }
+    case "right": {
+      const offset = Math.round(rect.height * ratio)
+      return {
+        point: { x: rect.x + rect.width, y: rect.y + offset },
+        position: "right" as Position,
+      }
+    }
+    case "bottom": {
+      const offset = Math.round(rect.width * ratio)
+      return {
+        point: { x: rect.x + offset, y: rect.y + rect.height },
+        position: "bottom" as Position,
+      }
+    }
+    case "left": {
+      const offset = Math.round(rect.height * ratio)
+      return {
+        point: { x: rect.x, y: rect.y + offset },
+        position: "left" as Position,
+      }
+    }
+  }
+
+  const offset = Math.round(rect.width * ratio)
+  return {
+    point: { x: rect.x + offset, y: rect.y },
+    position: "top" as Position,
+  }
+}
+
+export function getNormalizedHandleOffset(
+  axisLength: number,
+  ratio: number
+): number {
+  if (!Number.isFinite(axisLength) || axisLength <= 0) return 0
+
+  // Keep exact boundaries exact when callers explicitly ask for them.
+  if (ratio <= 0) return 0
+  if (ratio >= 1) return axisLength
+
+  const raw = axisLength * ratio
+  const snapped = Math.round(raw / HANDLE_SNAP_STEP_PX) * HANDLE_SNAP_STEP_PX
+  return clamp(snapped, 0, axisLength)
+}
+
+export function getNormalizedHandleOffsetPercent(
+  axisLength: number,
+  ratio: number
+): string {
+  if (!Number.isFinite(axisLength) || axisLength <= 0) {
+    return `${ratio * 100}%`
+  }
+
+  const normalizedOffset = getNormalizedHandleOffset(axisLength, ratio)
+  return `${(normalizedOffset / axisLength) * 100}%`
+}
 
 // Visible half-circle arc-dragger length along the side it sits on. Two
 // adjacent visible arcs must have centers separated by at least this much

--- a/library/lib/utils/edgeUtils.ts
+++ b/library/lib/utils/edgeUtils.ts
@@ -334,10 +334,6 @@ const HANDLE_RATIO_END = 0.8
 const clamp = (value: number, min: number, max: number): number =>
   Math.max(min, Math.min(max, value))
 
-export function isClassDiagramEdgeType(type: string | undefined): boolean {
-  return typeof type === "string" && type.startsWith("Class")
-}
-
 export function isFreeformEdgeAnchor(
   anchor: unknown
 ): anchor is FreeformEdgeAnchor {

--- a/library/lib/utils/edgeUtils.ts
+++ b/library/lib/utils/edgeUtils.ts
@@ -450,40 +450,11 @@ export function getFreeformAnchorPoint(
         position: "left" as Position,
       }
     }
+    default: {
+      const unhandled: never = anchor.side
+      throw new Error(`getFreeformAnchorPoint: unhandled side ${unhandled}`)
+    }
   }
-
-  const offset = Math.round(rect.width * ratio)
-  return {
-    point: { x: rect.x + offset, y: rect.y },
-    position: "top" as Position,
-  }
-}
-
-export function getNormalizedHandleOffset(
-  axisLength: number,
-  ratio: number
-): number {
-  if (!Number.isFinite(axisLength) || axisLength <= 0) return 0
-
-  // Keep exact boundaries exact when callers explicitly ask for them.
-  if (ratio <= 0) return 0
-  if (ratio >= 1) return axisLength
-
-  const raw = axisLength * ratio
-  const snapped = Math.round(raw / HANDLE_SNAP_STEP_PX) * HANDLE_SNAP_STEP_PX
-  return clamp(snapped, 0, axisLength)
-}
-
-export function getNormalizedHandleOffsetPercent(
-  axisLength: number,
-  ratio: number
-): string {
-  if (!Number.isFinite(axisLength) || axisLength <= 0) {
-    return `${ratio * 100}%`
-  }
-
-  const normalizedOffset = getNormalizedHandleOffset(axisLength, ratio)
-  return `${(normalizedOffset / axisLength) * 100}%`
 }
 
 // Visible half-circle arc-dragger length along the side it sits on. Two

--- a/library/lib/utils/edgeUtils.ts
+++ b/library/lib/utils/edgeUtils.ts
@@ -422,32 +422,32 @@ export function getFreeformAnchorPoint(
   const ratio = clamp(anchor.ratio, 0, 1)
 
   switch (anchor.side) {
-    case "top": {
+    case Position.Top: {
       const offset = Math.round(rect.width * ratio)
       return {
         point: { x: rect.x + offset, y: rect.y },
-        position: "top" as Position,
+        position: Position.Top,
       }
     }
-    case "right": {
+    case Position.Right: {
       const offset = Math.round(rect.height * ratio)
       return {
         point: { x: rect.x + rect.width, y: rect.y + offset },
-        position: "right" as Position,
+        position: Position.Right,
       }
     }
-    case "bottom": {
+    case Position.Bottom: {
       const offset = Math.round(rect.width * ratio)
       return {
         point: { x: rect.x + offset, y: rect.y + rect.height },
-        position: "bottom" as Position,
+        position: Position.Bottom,
       }
     }
-    case "left": {
+    case Position.Left: {
       const offset = Math.round(rect.height * ratio)
       return {
         point: { x: rect.x, y: rect.y + offset },
-        position: "left" as Position,
+        position: Position.Left,
       }
     }
     default: {

--- a/library/tests/unit/EdgeEndpointMarkers.test.tsx
+++ b/library/tests/unit/EdgeEndpointMarkers.test.tsx
@@ -160,7 +160,11 @@ describe("EdgeEndpointMarkers", () => {
     expect(targetHandle).toHaveAttribute("y", "98")
   })
 
-  it("renders visible endpoint grips centered in the freeform hit targets", () => {
+  it("anchors the visible endpoint grips to the endpoints, just clear of the heads", () => {
+    // The grip hugs the endpoint (offset by half its length + the marker
+    // clearance), not the centre of the wide hit-target — so it never floats off
+    // the tip when zoomed out. Source at (10,20) exits right, target at (110,120)
+    // enters from the left; clearance = 18/2 + 4 = 13.
     const { container } = renderEndpointMarkers({
       onEndpointPointerDown: vi.fn(),
     })
@@ -170,13 +174,13 @@ describe("EdgeEndpointMarkers", () => {
     expect(container.querySelectorAll(".edge-endpoint-grip")).toHaveLength(2)
     expect(sourceGrip).toHaveAttribute("width", "18")
     expect(sourceGrip).toHaveAttribute("height", "8")
-    expect(sourceGrip).toHaveAttribute("x", "23")
+    expect(sourceGrip).toHaveAttribute("x", "14") // 10 + 13 clearance − 9 half-width
     expect(sourceGrip).toHaveAttribute("y", "16")
     expect(sourceGrip).toHaveAttribute("rx", "4")
     expect(sourceGrip).toHaveAttribute("pointer-events", "none")
     expect(targetGrip).toHaveAttribute("width", "18")
     expect(targetGrip).toHaveAttribute("height", "8")
-    expect(targetGrip).toHaveAttribute("x", "79")
+    expect(targetGrip).toHaveAttribute("x", "88") // 110 − 13 clearance − 9 half-width
     expect(targetGrip).toHaveAttribute("y", "116")
   })
 

--- a/library/tests/unit/EdgeEndpointMarkers.test.tsx
+++ b/library/tests/unit/EdgeEndpointMarkers.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render } from "@testing-library/react"
 import { Position, ReactFlowProvider } from "@xyflow/react"
+import type { ComponentProps } from "react"
 import { describe, expect, it, vi } from "vitest"
 import { EdgeEndpointMarkers } from "@/edges/GenericEdge"
 import { EDGES } from "@/constants"
@@ -9,9 +10,13 @@ import { EDGES } from "@/constants"
 const renderEndpointMarkers = ({
   isDiagramModifiable = true,
   canEditEndpoint = true,
+  onEndpointPointerDown,
 }: {
   isDiagramModifiable?: boolean
   canEditEndpoint?: boolean
+  onEndpointPointerDown?: ComponentProps<
+    typeof EdgeEndpointMarkers
+  >["onEndpointPointerDown"]
 } = {}) =>
   render(
     <ReactFlowProvider>
@@ -26,6 +31,7 @@ const renderEndpointMarkers = ({
             targetPosition={Position.Left}
             isDiagramModifiable={isDiagramModifiable}
             canEditEndpoint={canEditEndpoint}
+            onEndpointPointerDown={onEndpointPointerDown}
             diagramType="step"
           />
         </g>
@@ -38,6 +44,7 @@ describe("EdgeEndpointMarkers", () => {
     const { container } = renderEndpointMarkers()
 
     expect(container.querySelectorAll(".edge-endpoint-handle")).toHaveLength(2)
+    expect(container.querySelectorAll(".edge-endpoint-grip")).toHaveLength(0)
   })
 
   it("keeps endpoint hit targets large and on the edge side of the heads", () => {
@@ -132,5 +139,70 @@ describe("EdgeEndpointMarkers", () => {
     )
 
     expect(onNativeMouseDown).toHaveBeenCalledTimes(1)
+  })
+
+  it("uses a larger invisible hit target for freeform endpoint dragging", () => {
+    const { container } = renderEndpointMarkers({
+      onEndpointPointerDown: vi.fn(),
+    })
+    const sourceHandle = container.querySelector(
+      ".edge-endpoint-handle--source"
+    )
+    const targetHandle = container.querySelector(
+      ".edge-endpoint-handle--target"
+    )
+
+    expect(sourceHandle).toHaveAttribute("width", "44")
+    expect(sourceHandle).toHaveAttribute("height", "44")
+    expect(sourceHandle).toHaveAttribute("x", "10")
+    expect(sourceHandle).toHaveAttribute("y", "-2")
+    expect(targetHandle).toHaveAttribute("x", "66")
+    expect(targetHandle).toHaveAttribute("y", "98")
+  })
+
+  it("renders visible endpoint grips centered in the freeform hit targets", () => {
+    const { container } = renderEndpointMarkers({
+      onEndpointPointerDown: vi.fn(),
+    })
+    const sourceGrip = container.querySelector(".edge-endpoint-grip--source")
+    const targetGrip = container.querySelector(".edge-endpoint-grip--target")
+
+    expect(container.querySelectorAll(".edge-endpoint-grip")).toHaveLength(2)
+    expect(sourceGrip).toHaveAttribute("width", "18")
+    expect(sourceGrip).toHaveAttribute("height", "8")
+    expect(sourceGrip).toHaveAttribute("x", "23")
+    expect(sourceGrip).toHaveAttribute("y", "16")
+    expect(sourceGrip).toHaveAttribute("rx", "4")
+    expect(sourceGrip).toHaveAttribute("pointer-events", "none")
+    expect(targetGrip).toHaveAttribute("width", "18")
+    expect(targetGrip).toHaveAttribute("height", "8")
+    expect(targetGrip).toHaveAttribute("x", "79")
+    expect(targetGrip).toHaveAttribute("y", "116")
+  })
+
+  it("uses the freeform pointer handler instead of native reconnect when provided", () => {
+    const onEndpointPointerDown = vi.fn()
+    const { container } = renderEndpointMarkers({ onEndpointPointerDown })
+    const nativeUpdater = container.querySelector(
+      ".react-flow__edgeupdater-source"
+    )
+    const onNativeMouseDown = vi.fn()
+    nativeUpdater?.addEventListener("mousedown", onNativeMouseDown)
+
+    fireEvent.pointerDown(
+      container.querySelector(".edge-endpoint-handle--source")!,
+      {
+        button: 0,
+        buttons: 1,
+        clientX: 10,
+        clientY: 20,
+      }
+    )
+    fireEvent.mouseDown(
+      container.querySelector(".edge-endpoint-handle--source")!
+    )
+
+    expect(onEndpointPointerDown).toHaveBeenCalledTimes(1)
+    expect(onNativeMouseDown).not.toHaveBeenCalled()
   })
 })

--- a/library/tests/unit/connectionModes.test.ts
+++ b/library/tests/unit/connectionModes.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest"
+import { Position, type Rect, type XYPosition } from "@xyflow/react"
+import {
+  getConnectionMode,
+  getEdgeAnchorFromPoint,
+  getEdgeAnchorPoint,
+} from "@/utils/connectionModes"
+
+// center (180, 150), rx 80, ry 50
+const rect: Rect = { x: 100, y: 100, width: 160, height: 100 }
+const cx = rect.x + rect.width / 2
+const cy = rect.y + rect.height / 2
+
+const onEllipse = (p: XYPosition) =>
+  ((p.x - cx) / (rect.width / 2)) ** 2 + ((p.y - cy) / (rect.height / 2)) ** 2
+
+describe("getConnectionMode", () => {
+  it("defaults box shapes (and unknowns) to freeform-rect", () => {
+    expect(getConnectionMode("class")).toBe("freeform-rect")
+    expect(getConnectionMode("bpmnTask")).toBe("freeform-rect")
+    expect(getConnectionMode(undefined)).toBe("freeform-rect")
+    expect(getConnectionMode("")).toBe("freeform-rect")
+  })
+
+  it("classifies each non-rect shape by its real geometry", () => {
+    expect(getConnectionMode("useCase")).toBe("ellipse") // the one full-handle oval
+    expect(getConnectionMode("bpmnStartEvent")).toBe("four-center") // circle, 4 handles
+    expect(getConnectionMode("petriNetPlace")).toBe("four-center") // circle, 4 handles
+    expect(getConnectionMode("flowchartDecision")).toBe("four-center")
+    expect(getConnectionMode("bpmnGateway")).toBe("four-center")
+    expect(getConnectionMode("componentInterface")).toBe("four-center")
+    expect(getConnectionMode("deploymentInterface")).toBe("four-center")
+    expect(getConnectionMode("activitySwimlane")).toBe("none")
+    expect(getConnectionMode("bpmnAnnotation")).toBe("none")
+  })
+
+  it("gives every FOUR_WAY-handle node exactly four points (mode matches handles)", () => {
+    for (const t of [
+      "activityInitialNode",
+      "activityFinalNode",
+      "bpmnStartEvent",
+      "petriNetPlace",
+      "petriNetTransition",
+      "componentInterface",
+      "sfcTransitionBranch",
+    ]) {
+      expect(getConnectionMode(t)).toBe("four-center")
+    }
+  })
+})
+
+describe("ellipse mode", () => {
+  it("projects a bbox-corner drop onto the oval curve, in the aimed quadrant", () => {
+    const anchor = getEdgeAnchorFromPoint(
+      "useCase",
+      { x: rect.x + rect.width, y: rect.y }, // top-right bbox corner
+      rect
+    )!
+    const { point } = getEdgeAnchorPoint("useCase", rect, anchor)
+    expect(onEllipse(point)).toBeCloseTo(1, 1) // on the curve, not the corner
+    expect(point.x).toBeGreaterThan(cx) // top-right quadrant, near the aim
+    expect(point.y).toBeLessThan(cy)
+  })
+
+  it("keeps a side-midpoint drop at the midpoint (curve meets the box there)", () => {
+    const anchor = getEdgeAnchorFromPoint(
+      "useCase",
+      { x: cx, y: rect.y },
+      rect
+    )!
+    const { point } = getEdgeAnchorPoint("useCase", rect, anchor)
+    expect(point.x).toBeCloseTo(cx, 0)
+    expect(point.y).toBeCloseTo(rect.y, 0)
+  })
+})
+
+describe("parallelogram mode", () => {
+  // 20px slant: left edge runs x+20 (top) → x (bottom); right edge x+w (top) →
+  // x+w-20 (bottom). rect here is 160 wide, 100 tall, top-left (100,100).
+  it("shears a left-side anchor onto the slanted edge (top vs bottom differ)", () => {
+    const io = "flowchartInputOutput"
+    const top = getEdgeAnchorPoint(io, rect, { side: Position.Left, ratio: 0 })
+    const bottom = getEdgeAnchorPoint(io, rect, {
+      side: Position.Left,
+      ratio: 1,
+    })
+    expect(top.point.x).toBeCloseTo(rect.x + 20, 5) // inset at the top
+    expect(bottom.point.x).toBeCloseTo(rect.x, 5) // flush at the bottom
+  })
+
+  it("shears the right side the opposite way", () => {
+    const io = "flowchartInputOutput"
+    const top = getEdgeAnchorPoint(io, rect, { side: Position.Right, ratio: 0 })
+    const bottom = getEdgeAnchorPoint(io, rect, {
+      side: Position.Right,
+      ratio: 1,
+    })
+    expect(top.point.x).toBeCloseTo(rect.x + rect.width, 5) // flush at the top
+    expect(bottom.point.x).toBeCloseTo(rect.x + rect.width - 20, 5) // inset below
+  })
+
+  it("stays continuous (a mid-height drop is not snapped to a fixed point)", () => {
+    const io = "flowchartInputOutput"
+    const a = getEdgeAnchorFromPoint(io, { x: rect.x, y: rect.y + 20 }, rect)!
+    const b = getEdgeAnchorFromPoint(io, { x: rect.x, y: rect.y + 70 }, rect)!
+    expect(getEdgeAnchorPoint(io, rect, a).point.y).not.toBeCloseTo(
+      getEdgeAnchorPoint(io, rect, b).point.y,
+      1
+    )
+  })
+})
+
+describe("four-center mode", () => {
+  it("snaps to the nearest side midpoint", () => {
+    const anchor = getEdgeAnchorFromPoint(
+      "flowchartDecision",
+      { x: rect.x + rect.width, y: cy - 10 }, // near the right vertex
+      rect
+    )!
+    const resolved = getEdgeAnchorPoint("flowchartDecision", rect, anchor)
+    expect(resolved.position).toBe(Position.Right)
+    expect(resolved.point).toEqual({ x: rect.x + rect.width, y: cy })
+  })
+})
+
+describe("four-center interface", () => {
+  it("snaps an interface drop to a side midpoint (N/E/S/W), like its handles", () => {
+    const anchor = getEdgeAnchorFromPoint(
+      "componentInterface",
+      { x: rect.x + 4, y: cy + 4 }, // near the left edge
+      rect
+    )!
+    const resolved = getEdgeAnchorPoint("componentInterface", rect, anchor)
+    expect(resolved.position).toBe(Position.Left)
+    expect(resolved.point).toEqual({ x: rect.x, y: cy })
+  })
+})
+
+describe("none mode", () => {
+  it("is not a connection target", () => {
+    const at = { x: rect.x, y: rect.y }
+    expect(getEdgeAnchorFromPoint("activitySwimlane", at, rect)).toBeNull()
+    expect(getEdgeAnchorFromPoint("colorDescription", at, rect)).toBeNull()
+    expect(getEdgeAnchorFromPoint("titleAndDesctiption", at, rect)).toBeNull()
+    expect(getEdgeAnchorFromPoint("bpmnAnnotation", at, rect)).toBeNull()
+  })
+})

--- a/library/tests/unit/edgeUtils.test.ts
+++ b/library/tests/unit/edgeUtils.test.ts
@@ -21,7 +21,6 @@ import {
   reduceVisibleArcCountForZoom,
   getEdgeMarkerStyles,
   getMarkerSegmentPath,
-  isClassDiagramEdgeType,
   isInvalidOrthogonalEdgeRelease,
   normalizeOrthogonalEdgePoints,
   parseSvgPath,
@@ -497,11 +496,13 @@ describe("freeform rectangle anchors", () => {
     })
   })
 
-  it("detects class diagram edge types only", () => {
-    expect(isClassDiagramEdgeType("ClassUnidirectional")).toBe(true)
-    expect(isClassDiagramEdgeType("ClassDependency")).toBe(true)
-    expect(isClassDiagramEdgeType("ObjectLink")).toBe(false)
-    expect(isClassDiagramEdgeType(undefined)).toBe(false)
+  it("recognizes persisted freeform anchors", () => {
+    expect(
+      getFreeformAnchorPoint(rect, { side: Position.Left, ratio: 0.5 })
+    ).toEqual({
+      point: { x: 10, y: 60 },
+      position: Position.Left,
+    })
   })
 })
 

--- a/library/tests/unit/edgeUtils.test.ts
+++ b/library/tests/unit/edgeUtils.test.ts
@@ -15,9 +15,13 @@ import {
   getDefaultEdgeType,
   getDistributedHandleOffsets,
   getDistributedHandleOffsetPercents,
+  getFreeformAnchorFromPoint,
+  getFreeformAnchorPoint,
+  getSideHandleIdForPosition,
   reduceVisibleArcCountForZoom,
   getEdgeMarkerStyles,
   getMarkerSegmentPath,
+  isClassDiagramEdgeType,
   isInvalidOrthogonalEdgeRelease,
   normalizeOrthogonalEdgePoints,
   parseSvgPath,
@@ -464,6 +468,40 @@ describe("findClosestHandle", () => {
       rect,
     })
     expect(result).toBe("top-mid-left")
+  })
+})
+
+describe("freeform rectangle anchors", () => {
+  const rect = { x: 10, y: 20, width: 100, height: 80 }
+
+  it("stores the nearest side and resolves back to a rounded pixel", () => {
+    const anchor = getFreeformAnchorFromPoint({ x: 112, y: 57.4 }, rect)
+
+    expect(anchor.side).toBe(Position.Right)
+    expect(anchor.ratio).toBeCloseTo(37 / 80)
+    expect(getSideHandleIdForPosition(anchor.side)).toBe("right")
+    expect(getFreeformAnchorPoint(rect, anchor)).toEqual({
+      point: { x: 110, y: 57 },
+      position: Position.Right,
+    })
+  })
+
+  it("uses the boundary point closest to the pointer", () => {
+    const anchor = getFreeformAnchorFromPoint({ x: 33.6, y: 17 }, rect)
+
+    expect(anchor.side).toBe(Position.Top)
+    expect(anchor.ratio).toBeCloseTo(24 / 100)
+    expect(getFreeformAnchorPoint(rect, anchor)).toEqual({
+      point: { x: 34, y: 20 },
+      position: Position.Top,
+    })
+  })
+
+  it("detects class diagram edge types only", () => {
+    expect(isClassDiagramEdgeType("ClassUnidirectional")).toBe(true)
+    expect(isClassDiagramEdgeType("ClassDependency")).toBe(true)
+    expect(isClassDiagramEdgeType("ObjectLink")).toBe(false)
+    expect(isClassDiagramEdgeType(undefined)).toBe(false)
   })
 })
 

--- a/standalone/webapp/src/components/DeferredToastContainer.tsx
+++ b/standalone/webapp/src/components/DeferredToastContainer.tsx
@@ -26,6 +26,7 @@ export const DeferredToastContainer = () => {
   return (
     <Suspense fallback={null}>
       <ToastContainer
+        aria-label="Notifications"
         theme={currentTheme === "dark" ? "dark" : "light"}
         className="home-toast-container"
         toastClassName="home-toast"

--- a/standalone/webapp/src/components/home/DiagramCard.tsx
+++ b/standalone/webapp/src/components/home/DiagramCard.tsx
@@ -715,7 +715,7 @@ export function DiagramCardView({
         {...nav}
         // Expired links keep `preventDefault` AND `tabIndex={-1}`: aria-disabled
         // is advisory only, so TanStack <Link> would still navigate on Enter.
-        onClick={(event) => {
+        onClick={(event: ReactMouseEvent<HTMLAnchorElement>) => {
           if (isExpired) {
             event.preventDefault()
             return

--- a/standalone/webapp/src/components/modals/EmbedSnippetPanel.stories.tsx
+++ b/standalone/webapp/src/components/modals/EmbedSnippetPanel.stories.tsx
@@ -24,7 +24,7 @@ const meta = {
     (Story) => (
       <div className="w-[28rem] rounded-md bg-[var(--apollon-background)] p-4">
         <Story />
-        <ToastContainer position="bottom-center" />
+        <ToastContainer aria-label="Notifications" position="bottom-center" />
       </div>
     ),
   ],

--- a/standalone/webapp/src/components/navbar/FileMenu.tsx
+++ b/standalone/webapp/src/components/navbar/FileMenu.tsx
@@ -15,7 +15,7 @@ import {
   TooltipTrigger,
 } from "@tumaet/ui/components/tooltip"
 import { ChevronDownIcon, FilesIcon } from "lucide-react"
-import { toast } from "react-toastify"
+import { toast, type ToastContentProps } from "react-toastify"
 import { useModalContext } from "@/contexts"
 import { useMediaQuery } from "@/hooks"
 import {
@@ -108,10 +108,12 @@ export function FileMenuItems({ onSelect }: { onSelect: () => void }) {
         await toast.promise(action(), {
           pending: `Exporting ${format}…`,
           success: {
-            render: ({ data }) => exportSuccessMessage(format, data),
+            render: ({ data }: ToastContentProps<ExportRunResult | void>) =>
+              exportSuccessMessage(format, data),
           },
           error: {
-            render: ({ data }) => exportErrorMessage(format, data),
+            render: ({ data }: ToastContentProps<unknown>) =>
+              exportErrorMessage(format, data),
           },
         })
       } catch (err) {

--- a/standalone/webapp/src/components/navbar/SaveLocalCopyButton.test.tsx
+++ b/standalone/webapp/src/components/navbar/SaveLocalCopyButton.test.tsx
@@ -43,7 +43,7 @@ function renderWith(editorModel: UMLModel, initialPath = "/shared/remote-id") {
     <>
       <SaveLocalCopyButton color="black" />
       <LocationProbe />
-      <ToastContainer />
+      <ToastContainer aria-label="Notifications" />
     </>,
     {
       initialEntry: initialPath,

--- a/standalone/webapp/src/components/versioning/UndoRestoreToast.stories.tsx
+++ b/standalone/webapp/src/components/versioning/UndoRestoreToast.stories.tsx
@@ -49,6 +49,7 @@ const meta = {
             toast follows the --home-* surface tokens (dark in dark) instead of
             react-toastify's white default. */}
         <ToastContainer
+          aria-label="Notifications"
           position="bottom-center"
           className="home-toast-container"
           toastClassName="home-toast"

--- a/standalone/webapp/src/components/versioning/VersionListItem.tsx
+++ b/standalone/webapp/src/components/versioning/VersionListItem.tsx
@@ -14,6 +14,7 @@ import {
   type CSSProperties,
   type FC,
   type KeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
   type ReactNode,
 } from "react"
 import { Link } from "@tanstack/react-router"
@@ -482,7 +483,7 @@ export const VersionListItem: FC<ContainerProps> = ({
         [PREVIEW_VERSION_PARAM]: props.version.id,
       })}
       aria-label={accessibleName}
-      onClick={(e) => {
+      onClick={(e: ReactMouseEvent<HTMLAnchorElement>) => {
         // Let the browser handle modified clicks (open in a new tab/window).
         if (e.metaKey || e.ctrlKey || e.shiftKey) return
         e.preventDefault()

--- a/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
@@ -17,21 +17,6 @@ const classNoEdgeFixture = JSON.parse(
     "utf-8"
   )
 ) as Record<string, unknown>
-const activityFixture = JSON.parse(
-  fs.readFileSync(
-    path.join(__d, "..", "fixtures", "activity-diagram.json"),
-    "utf-8"
-  )
-) as Record<string, unknown>
-const bpmnFixture = JSON.parse(
-  fs.readFileSync(path.join(__d, "..", "fixtures", "bpmn.json"), "utf-8")
-) as Record<string, unknown>
-const communicationFixture = JSON.parse(
-  fs.readFileSync(
-    path.join(__d, "..", "fixtures", "communication-diagram.json"),
-    "utf-8"
-  )
-) as Record<string, unknown>
 const componentFixture = JSON.parse(
   fs.readFileSync(
     path.join(__d, "..", "fixtures", "component-diagram.json"),
@@ -43,27 +28,6 @@ const deploymentFixture = JSON.parse(
     path.join(__d, "..", "fixtures", "deployment-diagram.json"),
     "utf-8"
   )
-) as Record<string, unknown>
-const flowchartFixture = JSON.parse(
-  fs.readFileSync(path.join(__d, "..", "fixtures", "flowchart.json"), "utf-8")
-) as Record<string, unknown>
-const objectFixture = JSON.parse(
-  fs.readFileSync(
-    path.join(__d, "..", "fixtures", "object-diagram.json"),
-    "utf-8"
-  )
-) as Record<string, unknown>
-const petriNetFixture = JSON.parse(
-  fs.readFileSync(path.join(__d, "..", "fixtures", "petri-net.json"), "utf-8")
-) as Record<string, unknown>
-const reachabilityGraphFixture = JSON.parse(
-  fs.readFileSync(
-    path.join(__d, "..", "fixtures", "reachability-graph.json"),
-    "utf-8"
-  )
-) as Record<string, unknown>
-const sfcFixture = JSON.parse(
-  fs.readFileSync(path.join(__d, "..", "fixtures", "sfc.json"), "utf-8")
 ) as Record<string, unknown>
 const syntaxTreeFixture = JSON.parse(
   fs.readFileSync(path.join(__d, "..", "fixtures", "syntax-tree.json"), "utf-8")
@@ -85,7 +49,8 @@ function edgeById(page: Page, id: string): Locator {
 async function selectEdge(page: Page, id: string): Promise<Locator> {
   const edge = edgeById(page, id)
   await edge.locator(".edge-overlay, path").first().click({ force: true })
-  await page.waitForTimeout(150)
+  // Selection renders the endpoint handles; wait for that rather than sleeping.
+  await expect(edge.locator(".edge-endpoint-handle--target")).toBeVisible()
   return edge
 }
 
@@ -146,7 +111,6 @@ async function dragLocatorBy(
   await page.mouse.down()
   await page.mouse.move(x + dx, y + dy, { steps: 12 })
   await page.mouse.up()
-  await page.waitForTimeout(350)
 }
 
 async function expectFreeformTargetFollowsMovedNode({
@@ -165,26 +129,11 @@ async function expectFreeformTargetFollowsMovedNode({
 
   const edge = await selectEdge(page, edgeId)
   const targetHandle = edge.locator(".edge-endpoint-handle--target")
-  const targetGrip = edge.locator(".edge-endpoint-grip--target")
   await expect(targetHandle).toBeVisible()
-  // Wait for the grip to lay out before dragging. boundingBox is opacity-
-  // independent, so it also covers edges whose grip only fades in on hover, and
-  // it settles the edge geometry first.
-  const gripBox = await targetGrip.boundingBox()
-  if (!gripBox) throw new Error("target endpoint grip has no bounding box")
-  // The visible grip is a small elongated pill, well under the hit target.
-  // Assert on its intrinsic size (width/height attributes), not its on-screen
-  // bounding box — on a straight (direct) edge the grip is rotated to the edge
-  // angle, which enlarges the axis-aligned bounding box.
-  const gripW = Number(await targetGrip.getAttribute("width"))
-  const gripH = Number(await targetGrip.getAttribute("height"))
+  // Reading the handle box waits for the endpoint to lay out, settling the edge
+  // geometry before the drag. (Grip size/shape is covered by the marker tests.)
   const initialHandleBox = await targetHandle.boundingBox()
   if (!initialHandleBox) throw new Error("target endpoint has no bounding box")
-  const handleW = Number(await targetHandle.getAttribute("width"))
-  const handleH = Number(await targetHandle.getAttribute("height"))
-  expect(gripW).toBeLessThan(handleW / 2)
-  expect(gripH).toBeLessThan(handleH / 2)
-  expect(Math.max(gripW, gripH)).toBeGreaterThan(Math.min(gripW, gripH))
 
   const targetNode = page.locator(`.react-flow__node[data-id="${targetId}"]`)
   const targetBox = await targetNode.boundingBox()
@@ -203,7 +152,9 @@ async function expectFreeformTargetFollowsMovedNode({
     { steps: 12 }
   )
   await page.mouse.up()
-  await page.waitForTimeout(400)
+  // The freeform endpoint drag persists a {side, ratio} anchor; wait for that
+  // commit rather than sleeping, then capture the pre-move baseline.
+  await expect.poll(() => targetAnchorOf(page, edgeId)).not.toBeNull()
 
   const anchorBefore = await targetAnchorOf(page, edgeId)
   const nodeBefore = await centerOf(targetNode)
@@ -225,29 +176,36 @@ async function expectFreeformTargetFollowsMovedNode({
     ? page.locator(`.react-flow__node[data-id="${parentId}"]`)
     : targetNode
   await dragLocatorBy(page, nodeToMove, 90, 45)
-  await page.waitForTimeout(500) // let the moved node and its edge re-render settle
 
-  const nodeAfter = await centerOf(targetNode)
-  const endpointAfter = await centerOf(targetHandle)
-  const anchorAfter = await targetAnchorOf(page, edgeId)
-  const nodeDelta = {
-    x: nodeAfter.x - nodeBefore.x,
-    y: nodeAfter.y - nodeBefore.y,
-  }
-  const endpointDelta = {
-    x: endpointAfter.x - endpointBefore.x,
-    y: endpointAfter.y - endpointBefore.y,
-  }
-
-  // The move must actually displace the node, or the follow check is vacuous.
-  expect(Math.hypot(nodeDelta.x, nodeDelta.y)).toBeGreaterThan(20)
-  // The endpoint travels with the node. A few px of slack absorbs a straight
+  // Retry until the node has actually moved (>20px, else the check is vacuous)
+  // AND the endpoint has travelled with it. A few px of slack absorbs a straight
   // edge's grip rotating to the new angle (which nudges the handle's axis-aligned
-  // bbox centre); a freeform endpoint's stored {side, ratio} is exact, so assert
-  // that too when the endpoint carries one.
-  expect(Math.abs(endpointDelta.x - nodeDelta.x)).toBeLessThan(12)
-  expect(Math.abs(endpointDelta.y - nodeDelta.y)).toBeLessThan(12)
-  if (anchorBefore !== null) expect(anchorAfter).toEqual(anchorBefore)
+  // bbox centre); polling waits out the edge re-render instead of a fixed sleep.
+  await expect
+    .poll(
+      async () => {
+        const nodeAfter = await centerOf(targetNode)
+        const endpointAfter = await centerOf(targetHandle)
+        const nodeMoved = Math.hypot(
+          nodeAfter.x - nodeBefore.x,
+          nodeAfter.y - nodeBefore.y
+        )
+        const followX = Math.abs(
+          endpointAfter.x - endpointBefore.x - (nodeAfter.x - nodeBefore.x)
+        )
+        const followY = Math.abs(
+          endpointAfter.y - endpointBefore.y - (nodeAfter.y - nodeBefore.y)
+        )
+        return nodeMoved > 20 && followX < 12 && followY < 12
+      },
+      { message: "endpoint must follow the moved node" }
+    )
+    .toBe(true)
+
+  // A pure move leaves the exact {side, ratio} anchor untouched.
+  if (anchorBefore !== null) {
+    expect(await targetAnchorOf(page, edgeId)).toEqual(anchorBefore)
+  }
 }
 
 async function expectEndpointCanRetargetToNode({
@@ -290,163 +248,53 @@ async function expectEndpointCanRetargetToNode({
     { steps: 12 }
   )
   await page.mouse.up()
-  await page.waitForTimeout(400)
+
+  // Poll the persisted edge until the retarget commits, rather than sleeping and
+  // reading a one-shot snapshot that could race the commit.
+  await expect
+    .poll(
+      async () =>
+        (await storedEdges(page)).find((edge) => edge.id === edgeId)?.target
+    )
+    .toBe(targetId)
 
   const edgeState = (await storedEdges(page)).find((edge) => edge.id === edgeId)
   expect(edgeState).toMatchObject({ target: targetId, targetHandle })
   expect(edgeState?.data).toHaveProperty("targetAnchor")
 }
 
+// Following is diagram-agnostic — the stored {side, ratio} anchor is
+// mode-independent — so one representative shape per distinct code path covers
+// it rather than one per diagram type: step vs direct edge, rect / ellipse /
+// four-center anchor, and a top-level vs parent-pinned target node.
 const cases = [
+  // step edge, rect anchor, top-level target.
   {
     name: "ClassDiagram",
     fixture: classFixture,
     edgeId: "231f7ef5-b43d-4187-8996-f7726ed6e919",
     targetId: "32659cdc-bd03-46f3-918c-ee8dbba9c15b",
   },
+  // direct edge, ellipse anchor.
   {
-    name: "ActivityDiagram",
-    fixture: activityFixture,
-    edgeId: "edge-flow-initial-process",
-    targetId: "770e8400-e29b-41d4-a716-446655440021",
+    name: "UseCaseDiagram",
+    fixture: useCaseFixture,
+    edgeId: "edge-assoc-customer-browse",
+    targetId: "880e8400-e29b-41d4-a716-446655440033",
   },
-  {
-    name: "BPMNDiagram",
-    fixture: bpmnFixture,
-    edgeId: "edge-start-validate",
-    targetId: "cc3d4e5f-a6b7-4c8d-9e0f-1a2b3c4d5e6f",
-  },
-  {
-    name: "BPMNDiagram association flow",
-    fixture: bpmnFixture,
-    edgeId: "edge-annotation-validate",
-    targetId: "cc3d4e5f-a6b7-4c8d-9e0f-1a2b3c4d5e6f",
-  },
-  {
-    name: "BPMNDiagram data association flow",
-    fixture: bpmnFixture,
-    edgeId: "edge-payment-invoice",
-    targetId: "d40e1f2a-b3c4-4d5e-6f7a-8b9c0d1e2f3a",
-  },
-  {
-    name: "BPMNDiagram message flow",
-    fixture: bpmnFixture,
-    edgeId: "edge-subprocess-to-pool-task",
-    targetId: "ee5f6a7b-c8d9-4e0f-1a2b-3c4d5e6f7a8b",
-  },
-  {
-    name: "CommunicationDiagram",
-    fixture: communicationFixture,
-    edgeId: "edge-comm-client-server",
-    targetId: "990e8400-e29b-41d4-a716-446655440041",
-  },
-  {
-    name: "ComponentDiagram",
-    fixture: componentFixture,
-    edgeId: "edge-server-database",
-    targetId: "a87ff679-a2f3-4e71-9bda-d16a21e1a2f3",
-  },
-  {
-    name: "ComponentDiagram provided interface",
-    fixture: componentFixture,
-    edgeId: "edge-client-interface",
-    targetId: "1b4e28ba-2fa1-4d11-a2d3-b8f04f4e5c6d",
-  },
-  {
-    name: "ComponentDiagram required interface",
-    fixture: componentFixture,
-    edgeId: "edge-server-interface",
-    targetId: "1b4e28ba-2fa1-4d11-a2d3-b8f04f4e5c6d",
-  },
-  {
-    name: "ComponentDiagram three-quarter required interface",
-    fixture: componentFixture,
-    edgeId: "edge-three-quarter-interface",
-    targetId: "c2d3e4f5-a6b7-4c8d-9e0f-1a2b3c4d5e60",
-  },
-  {
-    name: "ComponentDiagram quarter required interface",
-    fixture: componentFixture,
-    edgeId: "edge-quarter-interface",
-    targetId: "c2d3e4f5-a6b7-4c8d-9e0f-1a2b3c4d5e61",
-  },
-  {
-    name: "DeploymentDiagram",
-    fixture: deploymentFixture,
-    edgeId: "377c3ef7-083e-42a3-acc3-89786f7f762f",
-    targetId: "f6a7b8c9-d0e1-4f2a-3b4c-5d6e7f809102",
-  },
-  {
-    name: "DeploymentDiagram association",
-    fixture: deploymentFixture,
-    edgeId: "9c143a9c-350d-4f90-bf2e-fa11b8809b25",
-    targetId: "b8c9d0e1-f2a3-4b4c-5d6e-7f8091021324",
-  },
-  {
-    name: "DeploymentDiagram provided interface",
-    fixture: deploymentFixture,
-    edgeId: "edge-deploy-provided",
-    targetId: "int-prov-001",
-  },
-  {
-    name: "DeploymentDiagram required interface",
-    fixture: deploymentFixture,
-    edgeId: "edge-deploy-required",
-    targetId: "int-req-001",
-  },
-  {
-    name: "DeploymentDiagram three-quarter required interface",
-    fixture: deploymentFixture,
-    edgeId: "edge-deploy-3q",
-    targetId: "int-3q-001",
-  },
-  {
-    name: "DeploymentDiagram quarter required interface",
-    fixture: deploymentFixture,
-    edgeId: "edge-deploy-q",
-    targetId: "int-q-001",
-  },
-  {
-    name: "Flowchart",
-    fixture: flowchartFixture,
-    edgeId: "edge-start-init",
-    targetId: "20b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
-  },
-  {
-    name: "ObjectDiagram",
-    fixture: objectFixture,
-    edgeId: "edge-link-dog-owner",
-    targetId: "660e8400-e29b-41d4-a716-446655440011",
-  },
-  {
-    name: "PetriNet",
-    fixture: petriNetFixture,
-    edgeId: "edge-p1-t1",
-    targetId: "22222222-2222-4222-a222-222222222222",
-  },
-  {
-    name: "ReachabilityGraph",
-    fixture: reachabilityGraphFixture,
-    edgeId: "edge-200-110",
-    targetId: "aaaa2222-bbbb-4ccc-dddd-eeee22222222",
-  },
-  {
-    name: "SfcDiagram",
-    fixture: sfcFixture,
-    edgeId: "edge-step1-actiontable",
-    targetId: "44dd5ee6-ff7a-4b8c-9d0e-1f2a3b4c5d6e",
-  },
+  // direct edge, rect anchor.
   {
     name: "SyntaxTree",
     fixture: syntaxTreeFixture,
     edgeId: "edge-expr-term-left",
     targetId: "e1f2a3b4-c5d6-4e7f-8a9b-0c1d2e3f4a5b",
   },
+  // four-center anchor on a parent-pinned interface (moved via its parent).
   {
-    name: "UseCaseDiagram",
-    fixture: useCaseFixture,
-    edgeId: "edge-assoc-customer-browse",
-    targetId: "880e8400-e29b-41d4-a716-446655440033",
+    name: "ComponentDiagram required interface",
+    fixture: componentFixture,
+    edgeId: "edge-server-interface",
+    targetId: "1b4e28ba-2fa1-4d11-a2d3-b8f04f4e5c6d",
   },
 ]
 
@@ -522,10 +370,10 @@ test("a new same-node edge can connect different handles", async ({ page }) => {
     steps: 12,
   })
   await page.mouse.up()
-  await page.waitForTimeout(400)
+
+  await expect.poll(async () => (await storedEdges(page)).length).toBe(1)
 
   const edges = await storedEdges(page)
-  expect(edges).toHaveLength(1)
   expect(edges[0]).toMatchObject({
     source: CLASS_SOURCE,
     target: CLASS_SOURCE,

--- a/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
@@ -5,15 +5,21 @@ import { fileURLToPath } from "node:url"
 import { waitForCanvasReady, openFixtureInLocalEditor } from "../helpers/canvas"
 
 const __d = path.dirname(fileURLToPath(import.meta.url))
-const fixture = JSON.parse(
+const classFixture = JSON.parse(
   fs.readFileSync(
     path.join(__d, "..", "fixtures", "two-class-fresh-edge.json"),
     "utf-8"
   )
 ) as Record<string, unknown>
-
-const EDGE = "231f7ef5-b43d-4187-8996-f7726ed6e919"
-const TARGET = "32659cdc-bd03-46f3-918c-ee8dbba9c15b"
+const objectFixture = JSON.parse(
+  fs.readFileSync(
+    path.join(__d, "..", "fixtures", "object-diagram.json"),
+    "utf-8"
+  )
+) as Record<string, unknown>
+const syntaxTreeFixture = JSON.parse(
+  fs.readFileSync(path.join(__d, "..", "fixtures", "syntax-tree.json"), "utf-8")
+) as Record<string, unknown>
 
 type Pt = { x: number; y: number }
 
@@ -30,7 +36,7 @@ async function selectEdge(page: Page, id: string): Promise<Locator> {
 
 function endPointOf(d: string | null): Pt {
   if (!d) throw new Error("edge path has no d attribute")
-  const matches = [...d.matchAll(/[ML]\s*(-?[\d.]+)\s+(-?[\d.]+)/g)]
+  const matches = [...d.matchAll(/[ML]\s*(-?[\d.]+)[,\s]+(-?[\d.]+)/g)]
   if (matches.length === 0) throw new Error(`edge path has no points: ${d}`)
   const end = matches[matches.length - 1]
   return { x: Number(end[1]), y: Number(end[2]) }
@@ -42,7 +48,7 @@ async function targetPointOf(edge: Locator): Promise<Pt> {
   )
 }
 
-async function storedTargetPosition(page: Page): Promise<Pt> {
+async function storedNodePosition(page: Page, targetId: string): Promise<Pt> {
   return page.evaluate((targetId) => {
     const raw = localStorage.getItem("persistenceModelStore")
     if (!raw) throw new Error("missing persistence model")
@@ -54,7 +60,7 @@ async function storedTargetPosition(page: Page): Promise<Pt> {
     })
     if (!node) throw new Error(`missing node ${targetId}`)
     return node.position as Pt
-  }, TARGET)
+  }, targetId)
 }
 
 async function dragLocatorBy(
@@ -74,13 +80,21 @@ async function dragLocatorBy(
   await page.waitForTimeout(350)
 }
 
-test("a freeform Class edge endpoint follows its node after the node moves", async ({
+async function expectFreeformTargetFollowsMovedNode({
   page,
-}) => {
+  fixture,
+  edgeId,
+  targetId,
+}: {
+  page: Page
+  fixture: Record<string, unknown>
+  edgeId: string
+  targetId: string
+}) {
   await openFixtureInLocalEditor(page, fixture)
   await waitForCanvasReady(page)
 
-  const edge = await selectEdge(page, EDGE)
+  const edge = await selectEdge(page, edgeId)
   const targetHandle = edge.locator(".edge-endpoint-handle--target")
   const targetGrip = edge.locator(".edge-endpoint-grip--target")
   await expect(targetHandle).toBeVisible()
@@ -95,9 +109,12 @@ test("a freeform Class edge endpoint follows its node after the node moves", asy
   const initialHandleBox = await targetHandle.boundingBox()
   if (!initialHandleBox) throw new Error("target endpoint has no bounding box")
   expect(targetGripBox.width).toBeLessThan(initialHandleBox.width / 2)
-  expect(targetGripBox.width).toBeGreaterThan(targetGripBox.height)
+  expect(targetGripBox.height).toBeLessThan(initialHandleBox.height / 2)
+  expect(Math.max(targetGripBox.width, targetGripBox.height)).toBeGreaterThan(
+    Math.min(targetGripBox.width, targetGripBox.height)
+  )
 
-  const targetNode = page.locator(`.react-flow__node[data-id="${TARGET}"]`)
+  const targetNode = page.locator(`.react-flow__node[data-id="${targetId}"]`)
   const targetBox = await targetNode.boundingBox()
   if (!targetBox) throw new Error("target node has no bounding box")
 
@@ -111,12 +128,12 @@ test("a freeform Class edge endpoint follows its node after the node moves", asy
   await page.waitForTimeout(400)
 
   const targetBefore = await targetPointOf(edge)
-  const nodeBefore = await storedTargetPosition(page)
+  const nodeBefore = await storedNodePosition(page, targetId)
 
   await dragLocatorBy(page, targetNode, 90, 45)
 
   const targetAfter = await targetPointOf(edge)
-  const nodeAfter = await storedTargetPosition(page)
+  const nodeAfter = await storedNodePosition(page, targetId)
   const nodeDelta = {
     x: nodeAfter.x - nodeBefore.x,
     y: nodeAfter.y - nodeBefore.y,
@@ -128,4 +145,38 @@ test("a freeform Class edge endpoint follows its node after the node moves", asy
 
   expect(endpointDelta.x).toBeCloseTo(nodeDelta.x, 0)
   expect(endpointDelta.y).toBeCloseTo(nodeDelta.y, 0)
-})
+}
+
+const cases = [
+  {
+    name: "ClassDiagram",
+    fixture: classFixture,
+    edgeId: "231f7ef5-b43d-4187-8996-f7726ed6e919",
+    targetId: "32659cdc-bd03-46f3-918c-ee8dbba9c15b",
+  },
+  {
+    name: "ObjectDiagram",
+    fixture: objectFixture,
+    edgeId: "edge-link-dog-owner",
+    targetId: "660e8400-e29b-41d4-a716-446655440011",
+  },
+  {
+    name: "SyntaxTree",
+    fixture: syntaxTreeFixture,
+    edgeId: "edge-expr-term-left",
+    targetId: "e1f2a3b4-c5d6-4e7f-8a9b-0c1d2e3f4a5b",
+  },
+]
+
+for (const { name, fixture, edgeId, targetId } of cases) {
+  test(`a freeform ${name} edge endpoint follows its node after the node moves`, async ({
+    page,
+  }) => {
+    await expectFreeformTargetFollowsMovedNode({
+      page,
+      fixture,
+      edgeId,
+      targetId,
+    })
+  })
+}

--- a/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, type Locator, type Page } from "@playwright/test"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+import { waitForCanvasReady, openFixtureInLocalEditor } from "../helpers/canvas"
+
+const __d = path.dirname(fileURLToPath(import.meta.url))
+const fixture = JSON.parse(
+  fs.readFileSync(
+    path.join(__d, "..", "fixtures", "two-class-fresh-edge.json"),
+    "utf-8"
+  )
+) as Record<string, unknown>
+
+const EDGE = "231f7ef5-b43d-4187-8996-f7726ed6e919"
+const TARGET = "32659cdc-bd03-46f3-918c-ee8dbba9c15b"
+
+type Pt = { x: number; y: number }
+
+function edgeById(page: Page, id: string): Locator {
+  return page.locator(`.react-flow__edge[data-id="${id}"]`)
+}
+
+async function selectEdge(page: Page, id: string): Promise<Locator> {
+  const edge = edgeById(page, id)
+  await edge.locator(".edge-overlay, path").first().click({ force: true })
+  await page.waitForTimeout(150)
+  return edge
+}
+
+function endPointOf(d: string | null): Pt {
+  if (!d) throw new Error("edge path has no d attribute")
+  const matches = [...d.matchAll(/[ML]\s*(-?[\d.]+)\s+(-?[\d.]+)/g)]
+  if (matches.length === 0) throw new Error(`edge path has no points: ${d}`)
+  const end = matches[matches.length - 1]
+  return { x: Number(end[1]), y: Number(end[2]) }
+}
+
+async function targetPointOf(edge: Locator): Promise<Pt> {
+  return endPointOf(
+    await edge.locator(".react-flow__edge-path").first().getAttribute("d")
+  )
+}
+
+async function storedTargetPosition(page: Page): Promise<Pt> {
+  return page.evaluate((targetId) => {
+    const raw = localStorage.getItem("persistenceModelStore")
+    if (!raw) throw new Error("missing persistence model")
+    const parsed = JSON.parse(raw)
+    const id = parsed.state.currentModelId
+    const nodes = parsed.state.models[id]?.model?.nodes ?? []
+    const node = nodes.find((candidate: { id: string }) => {
+      return candidate.id === targetId
+    })
+    if (!node) throw new Error(`missing node ${targetId}`)
+    return node.position as Pt
+  }, TARGET)
+}
+
+async function dragLocatorBy(
+  page: Page,
+  locator: Locator,
+  dx: number,
+  dy: number
+) {
+  const box = await locator.boundingBox()
+  if (!box) throw new Error("locator has no bounding box")
+  const x = box.x + box.width / 2
+  const y = box.y + box.height / 2
+  await page.mouse.move(x, y)
+  await page.mouse.down()
+  await page.mouse.move(x + dx, y + dy, { steps: 12 })
+  await page.mouse.up()
+  await page.waitForTimeout(350)
+}
+
+test("a freeform Class edge endpoint follows its node after the node moves", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, fixture)
+  await waitForCanvasReady(page)
+
+  const edge = await selectEdge(page, EDGE)
+  const targetHandle = edge.locator(".edge-endpoint-handle--target")
+  const targetGrip = edge.locator(".edge-endpoint-grip--target")
+  await expect(targetHandle).toBeVisible()
+  await expect
+    .poll(() =>
+      targetGrip.evaluate((element) => getComputedStyle(element).opacity)
+    )
+    .toBe("1")
+  const targetGripBox = await targetGrip.boundingBox()
+  if (!targetGripBox)
+    throw new Error("target endpoint grip has no bounding box")
+  const initialHandleBox = await targetHandle.boundingBox()
+  if (!initialHandleBox) throw new Error("target endpoint has no bounding box")
+  expect(targetGripBox.width).toBeLessThan(initialHandleBox.width / 2)
+  expect(targetGripBox.width).toBeGreaterThan(targetGripBox.height)
+
+  const targetNode = page.locator(`.react-flow__node[data-id="${TARGET}"]`)
+  const targetBox = await targetNode.boundingBox()
+  if (!targetBox) throw new Error("target node has no bounding box")
+
+  await page.mouse.move(
+    initialHandleBox.x + initialHandleBox.width / 2,
+    initialHandleBox.y + initialHandleBox.height / 2
+  )
+  await page.mouse.down()
+  await page.mouse.move(targetBox.x + 3, targetBox.y + 24, { steps: 12 })
+  await page.mouse.up()
+  await page.waitForTimeout(400)
+
+  const targetBefore = await targetPointOf(edge)
+  const nodeBefore = await storedTargetPosition(page)
+
+  await dragLocatorBy(page, targetNode, 90, 45)
+
+  const targetAfter = await targetPointOf(edge)
+  const nodeAfter = await storedTargetPosition(page)
+  const nodeDelta = {
+    x: nodeAfter.x - nodeBefore.x,
+    y: nodeAfter.y - nodeBefore.y,
+  }
+  const endpointDelta = {
+    x: targetAfter.x - targetBefore.x,
+    y: targetAfter.y - targetBefore.y,
+  }
+
+  expect(endpointDelta.x).toBeCloseTo(nodeDelta.x, 0)
+  expect(endpointDelta.y).toBeCloseTo(nodeDelta.y, 0)
+})

--- a/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
@@ -11,6 +11,12 @@ const classFixture = JSON.parse(
     "utf-8"
   )
 ) as Record<string, unknown>
+const classNoEdgeFixture = JSON.parse(
+  fs.readFileSync(
+    path.join(__d, "..", "fixtures", "two-class-no-edge.json"),
+    "utf-8"
+  )
+) as Record<string, unknown>
 const objectFixture = JSON.parse(
   fs.readFileSync(
     path.join(__d, "..", "fixtures", "object-diagram.json"),
@@ -22,6 +28,7 @@ const syntaxTreeFixture = JSON.parse(
 ) as Record<string, unknown>
 
 type Pt = { x: number; y: number }
+const CLASS_SOURCE = "95aac2b6-3e6b-4e6d-9201-52a498e6ea20"
 
 function edgeById(page: Page, id: string): Locator {
   return page.locator(`.react-flow__edge[data-id="${id}"]`)
@@ -61,6 +68,23 @@ async function storedNodePosition(page: Page, targetId: string): Promise<Pt> {
     if (!node) throw new Error(`missing node ${targetId}`)
     return node.position as Pt
   }, targetId)
+}
+
+async function storedEdges(page: Page): Promise<
+  Array<{
+    source: string
+    target: string
+    sourceHandle?: string | null
+    targetHandle?: string | null
+  }>
+> {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem("persistenceModelStore")
+    if (!raw) throw new Error("missing persistence model")
+    const parsed = JSON.parse(raw)
+    const id = parsed.state.currentModelId
+    return parsed.state.models[id]?.model?.edges ?? []
+  })
 }
 
 async function dragLocatorBy(
@@ -180,3 +204,38 @@ for (const { name, fixture, edgeId, targetId } of cases) {
     })
   })
 }
+
+test("a new same-node edge can connect different handles", async ({ page }) => {
+  await openFixtureInLocalEditor(page, classNoEdgeFixture)
+  await waitForCanvasReady(page)
+
+  const node = page.locator(`.react-flow__node[data-id="${CLASS_SOURCE}"]`)
+  const nodeBox = await node.boundingBox()
+  if (!nodeBox) throw new Error("source node has no bounding box")
+
+  await node.hover()
+  await page.waitForTimeout(120)
+  const rightHandle = node.locator('.react-flow__handle[data-handleid="right"]')
+  const handleBox = await rightHandle.first().boundingBox()
+  if (!handleBox) throw new Error("source handle has no bounding box")
+
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
+  )
+  await page.mouse.down()
+  await page.mouse.move(nodeBox.x + nodeBox.width / 2, nodeBox.y + 4, {
+    steps: 12,
+  })
+  await page.mouse.up()
+  await page.waitForTimeout(400)
+
+  const edges = await storedEdges(page)
+  expect(edges).toHaveLength(1)
+  expect(edges[0]).toMatchObject({
+    source: CLASS_SOURCE,
+    target: CLASS_SOURCE,
+    sourceHandle: "right",
+    targetHandle: "top",
+  })
+})

--- a/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
@@ -99,6 +99,18 @@ async function centerOf(locator: Locator): Promise<Pt> {
   }
 }
 
+/** The persisted `{side, ratio}` anchor of an edge's target endpoint. */
+async function targetAnchorOf(page: Page, edgeId: string) {
+  return page.evaluate((id) => {
+    const raw = localStorage.getItem("persistenceModelStore")
+    if (!raw) return null
+    const p = JSON.parse(raw)
+    const model = p.state.models[p.state.currentModelId]?.model
+    const edge = (model?.edges || []).find((e: { id: string }) => e.id === id)
+    return edge?.data?.targetAnchor ?? null
+  }, edgeId)
+}
+
 async function storedEdges(page: Page): Promise<
   Array<{
     id: string
@@ -126,8 +138,10 @@ async function dragLocatorBy(
 ) {
   const box = await locator.boundingBox()
   if (!box) throw new Error("locator has no bounding box")
+  // Grab near the top edge, not the centre: a container's centre is covered by
+  // its children (dragging there would move a child, not the container).
   const x = box.x + box.width / 2
-  const y = box.y + box.height / 2
+  const y = box.y + Math.min(box.height * 0.2, 8)
   await page.mouse.move(x, y)
   await page.mouse.down()
   await page.mouse.move(x + dx, y + dy, { steps: 12 })
@@ -153,16 +167,24 @@ async function expectFreeformTargetFollowsMovedNode({
   const targetHandle = edge.locator(".edge-endpoint-handle--target")
   const targetGrip = edge.locator(".edge-endpoint-grip--target")
   await expect(targetHandle).toBeVisible()
-  const targetGripBox = await targetGrip.boundingBox()
-  if (!targetGripBox)
-    throw new Error("target endpoint grip has no bounding box")
+  // Wait for the grip to lay out before dragging. boundingBox is opacity-
+  // independent, so it also covers edges whose grip only fades in on hover, and
+  // it settles the edge geometry first.
+  const gripBox = await targetGrip.boundingBox()
+  if (!gripBox) throw new Error("target endpoint grip has no bounding box")
+  // The visible grip is a small elongated pill, well under the hit target.
+  // Assert on its intrinsic size (width/height attributes), not its on-screen
+  // bounding box — on a straight (direct) edge the grip is rotated to the edge
+  // angle, which enlarges the axis-aligned bounding box.
+  const gripW = Number(await targetGrip.getAttribute("width"))
+  const gripH = Number(await targetGrip.getAttribute("height"))
   const initialHandleBox = await targetHandle.boundingBox()
   if (!initialHandleBox) throw new Error("target endpoint has no bounding box")
-  expect(targetGripBox.width).toBeLessThan(initialHandleBox.width / 2)
-  expect(targetGripBox.height).toBeLessThan(initialHandleBox.height / 2)
-  expect(Math.max(targetGripBox.width, targetGripBox.height)).toBeGreaterThan(
-    Math.min(targetGripBox.width, targetGripBox.height)
-  )
+  const handleW = Number(await targetHandle.getAttribute("width"))
+  const handleH = Number(await targetHandle.getAttribute("height"))
+  expect(gripW).toBeLessThan(handleW / 2)
+  expect(gripH).toBeLessThan(handleH / 2)
+  expect(Math.max(gripW, gripH)).toBeGreaterThan(Math.min(gripW, gripH))
 
   const targetNode = page.locator(`.react-flow__node[data-id="${targetId}"]`)
   const targetBox = await targetNode.boundingBox()
@@ -183,24 +205,49 @@ async function expectFreeformTargetFollowsMovedNode({
   await page.mouse.up()
   await page.waitForTimeout(400)
 
-  const targetBefore = await centerOf(targetHandle)
+  const anchorBefore = await targetAnchorOf(page, edgeId)
   const nodeBefore = await centerOf(targetNode)
+  const endpointBefore = await centerOf(targetHandle)
 
-  await dragLocatorBy(page, targetNode, 90, 45)
+  // Move the node so its endpoint has to follow. A child pinned to its parent's
+  // border (e.g. a component interface) can't be dragged freely on its own, so
+  // move its parent — the child, and the endpoint, travel with it rigidly.
+  const parentId = await page.evaluate((id) => {
+    const raw = localStorage.getItem("persistenceModelStore")
+    if (!raw) return null
+    const p = JSON.parse(raw)
+    const model = p.state.models[p.state.currentModelId]?.model
+    return (
+      model?.nodes.find((n: { id: string }) => n.id === id)?.parentId ?? null
+    )
+  }, targetId)
+  const nodeToMove = parentId
+    ? page.locator(`.react-flow__node[data-id="${parentId}"]`)
+    : targetNode
+  await dragLocatorBy(page, nodeToMove, 90, 45)
+  await page.waitForTimeout(500) // let the moved node and its edge re-render settle
 
-  const targetAfter = await centerOf(targetHandle)
   const nodeAfter = await centerOf(targetNode)
+  const endpointAfter = await centerOf(targetHandle)
+  const anchorAfter = await targetAnchorOf(page, edgeId)
   const nodeDelta = {
     x: nodeAfter.x - nodeBefore.x,
     y: nodeAfter.y - nodeBefore.y,
   }
   const endpointDelta = {
-    x: targetAfter.x - targetBefore.x,
-    y: targetAfter.y - targetBefore.y,
+    x: endpointAfter.x - endpointBefore.x,
+    y: endpointAfter.y - endpointBefore.y,
   }
 
-  expect(endpointDelta.x).toBeCloseTo(nodeDelta.x, 0)
-  expect(endpointDelta.y).toBeCloseTo(nodeDelta.y, 0)
+  // The move must actually displace the node, or the follow check is vacuous.
+  expect(Math.hypot(nodeDelta.x, nodeDelta.y)).toBeGreaterThan(20)
+  // The endpoint travels with the node. A few px of slack absorbs a straight
+  // edge's grip rotating to the new angle (which nudges the handle's axis-aligned
+  // bbox centre); a freeform endpoint's stored {side, ratio} is exact, so assert
+  // that too when the endpoint carries one.
+  expect(Math.abs(endpointDelta.x - nodeDelta.x)).toBeLessThan(12)
+  expect(Math.abs(endpointDelta.y - nodeDelta.y)).toBeLessThan(12)
+  if (anchorBefore !== null) expect(anchorAfter).toEqual(anchorBefore)
 }
 
 async function expectEndpointCanRetargetToNode({

--- a/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
@@ -101,10 +101,12 @@ async function centerOf(locator: Locator): Promise<Pt> {
 
 async function storedEdges(page: Page): Promise<
   Array<{
+    id: string
     source: string
     target: string
     sourceHandle?: string | null
     targetHandle?: string | null
+    data?: Record<string, unknown>
   }>
 > {
   return page.evaluate(() => {
@@ -199,6 +201,53 @@ async function expectFreeformTargetFollowsMovedNode({
 
   expect(endpointDelta.x).toBeCloseTo(nodeDelta.x, 0)
   expect(endpointDelta.y).toBeCloseTo(nodeDelta.y, 0)
+}
+
+async function expectEndpointCanRetargetToNode({
+  page,
+  fixture,
+  edgeId,
+  targetId,
+  targetHandle = "left",
+  targetRatio = { x: 0.05, y: 0.2 },
+}: {
+  page: Page
+  fixture: Record<string, unknown>
+  edgeId: string
+  targetId: string
+  targetHandle?: string
+  targetRatio?: Pt
+}) {
+  await openFixtureInLocalEditor(page, fixture)
+  await waitForCanvasReady(page)
+
+  const edge = await selectEdge(page, edgeId)
+  const endpointHandle = edge.locator(".edge-endpoint-handle--target")
+  await expect(endpointHandle).toBeVisible()
+
+  const endpointBox = await endpointHandle.boundingBox()
+  if (!endpointBox) throw new Error("target endpoint has no bounding box")
+
+  const targetNode = page.locator(`.react-flow__node[data-id="${targetId}"]`)
+  const targetBox = await targetNode.boundingBox()
+  if (!targetBox) throw new Error("target node has no bounding box")
+
+  await page.mouse.move(
+    endpointBox.x + endpointBox.width / 2,
+    endpointBox.y + endpointBox.height / 2
+  )
+  await page.mouse.down()
+  await page.mouse.move(
+    targetBox.x + targetBox.width * targetRatio.x,
+    targetBox.y + targetBox.height * targetRatio.y,
+    { steps: 12 }
+  )
+  await page.mouse.up()
+  await page.waitForTimeout(400)
+
+  const edgeState = (await storedEdges(page)).find((edge) => edge.id === edgeId)
+  expect(edgeState).toMatchObject({ target: targetId, targetHandle })
+  expect(edgeState?.data).toHaveProperty("targetAnchor")
 }
 
 const cases = [
@@ -366,6 +415,42 @@ for (const { name, fixture, edgeId, targetId } of cases) {
     })
   })
 }
+
+test("a freeform ComponentDiagram endpoint can retarget to a component subsystem", async ({
+  page,
+}) => {
+  await expectEndpointCanRetargetToNode({
+    page,
+    fixture: componentFixture,
+    edgeId: "edge-server-database",
+    targetId: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    targetRatio: { x: 0.03, y: 0.12 },
+  })
+})
+
+test("a freeform DeploymentDiagram endpoint can retarget to a deployment node", async ({
+  page,
+}) => {
+  await expectEndpointCanRetargetToNode({
+    page,
+    fixture: deploymentFixture,
+    edgeId: "edge-appcontainer-interface",
+    targetId: "a7b8c9d0-e1f2-4a3b-4c5d-6e7f80910213",
+    targetRatio: { x: 0.05, y: 0.2 },
+  })
+})
+
+test("a freeform DeploymentDiagram endpoint can retarget to a deployment component", async ({
+  page,
+}) => {
+  await expectEndpointCanRetargetToNode({
+    page,
+    fixture: deploymentFixture,
+    edgeId: "edge-appcontainer-interface",
+    targetId: "b8c9d0e1-f2a3-4b4c-5d6e-7f8091021324",
+    targetRatio: { x: 0.08, y: 0.25 },
+  })
+})
 
 test("a new same-node edge can connect different handles", async ({ page }) => {
   await openFixtureInLocalEditor(page, classNoEdgeFixture)

--- a/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
@@ -17,14 +17,62 @@ const classNoEdgeFixture = JSON.parse(
     "utf-8"
   )
 ) as Record<string, unknown>
+const activityFixture = JSON.parse(
+  fs.readFileSync(
+    path.join(__d, "..", "fixtures", "activity-diagram.json"),
+    "utf-8"
+  )
+) as Record<string, unknown>
+const bpmnFixture = JSON.parse(
+  fs.readFileSync(path.join(__d, "..", "fixtures", "bpmn.json"), "utf-8")
+) as Record<string, unknown>
+const communicationFixture = JSON.parse(
+  fs.readFileSync(
+    path.join(__d, "..", "fixtures", "communication-diagram.json"),
+    "utf-8"
+  )
+) as Record<string, unknown>
+const componentFixture = JSON.parse(
+  fs.readFileSync(
+    path.join(__d, "..", "fixtures", "component-diagram.json"),
+    "utf-8"
+  )
+) as Record<string, unknown>
+const deploymentFixture = JSON.parse(
+  fs.readFileSync(
+    path.join(__d, "..", "fixtures", "deployment-diagram.json"),
+    "utf-8"
+  )
+) as Record<string, unknown>
+const flowchartFixture = JSON.parse(
+  fs.readFileSync(path.join(__d, "..", "fixtures", "flowchart.json"), "utf-8")
+) as Record<string, unknown>
 const objectFixture = JSON.parse(
   fs.readFileSync(
     path.join(__d, "..", "fixtures", "object-diagram.json"),
     "utf-8"
   )
 ) as Record<string, unknown>
+const petriNetFixture = JSON.parse(
+  fs.readFileSync(path.join(__d, "..", "fixtures", "petri-net.json"), "utf-8")
+) as Record<string, unknown>
+const reachabilityGraphFixture = JSON.parse(
+  fs.readFileSync(
+    path.join(__d, "..", "fixtures", "reachability-graph.json"),
+    "utf-8"
+  )
+) as Record<string, unknown>
+const sfcFixture = JSON.parse(
+  fs.readFileSync(path.join(__d, "..", "fixtures", "sfc.json"), "utf-8")
+) as Record<string, unknown>
 const syntaxTreeFixture = JSON.parse(
   fs.readFileSync(path.join(__d, "..", "fixtures", "syntax-tree.json"), "utf-8")
+) as Record<string, unknown>
+const useCaseFixture = JSON.parse(
+  fs.readFileSync(
+    path.join(__d, "..", "fixtures", "use-case-diagram.json"),
+    "utf-8"
+  )
 ) as Record<string, unknown>
 
 type Pt = { x: number; y: number }
@@ -41,33 +89,14 @@ async function selectEdge(page: Page, id: string): Promise<Locator> {
   return edge
 }
 
-function endPointOf(d: string | null): Pt {
-  if (!d) throw new Error("edge path has no d attribute")
-  const matches = [...d.matchAll(/[ML]\s*(-?[\d.]+)[,\s]+(-?[\d.]+)/g)]
-  if (matches.length === 0) throw new Error(`edge path has no points: ${d}`)
-  const end = matches[matches.length - 1]
-  return { x: Number(end[1]), y: Number(end[2]) }
-}
+async function centerOf(locator: Locator): Promise<Pt> {
+  const box = await locator.boundingBox()
+  if (!box) throw new Error("locator has no bounding box")
 
-async function targetPointOf(edge: Locator): Promise<Pt> {
-  return endPointOf(
-    await edge.locator(".react-flow__edge-path").first().getAttribute("d")
-  )
-}
-
-async function storedNodePosition(page: Page, targetId: string): Promise<Pt> {
-  return page.evaluate((targetId) => {
-    const raw = localStorage.getItem("persistenceModelStore")
-    if (!raw) throw new Error("missing persistence model")
-    const parsed = JSON.parse(raw)
-    const id = parsed.state.currentModelId
-    const nodes = parsed.state.models[id]?.model?.nodes ?? []
-    const node = nodes.find((candidate: { id: string }) => {
-      return candidate.id === targetId
-    })
-    if (!node) throw new Error(`missing node ${targetId}`)
-    return node.position as Pt
-  }, targetId)
+  return {
+    x: box.x + box.width / 2,
+    y: box.y + box.height / 2,
+  }
 }
 
 async function storedEdges(page: Page): Promise<
@@ -122,11 +151,6 @@ async function expectFreeformTargetFollowsMovedNode({
   const targetHandle = edge.locator(".edge-endpoint-handle--target")
   const targetGrip = edge.locator(".edge-endpoint-grip--target")
   await expect(targetHandle).toBeVisible()
-  await expect
-    .poll(() =>
-      targetGrip.evaluate((element) => getComputedStyle(element).opacity)
-    )
-    .toBe("1")
   const targetGripBox = await targetGrip.boundingBox()
   if (!targetGripBox)
     throw new Error("target endpoint grip has no bounding box")
@@ -147,17 +171,23 @@ async function expectFreeformTargetFollowsMovedNode({
     initialHandleBox.y + initialHandleBox.height / 2
   )
   await page.mouse.down()
-  await page.mouse.move(targetBox.x + 3, targetBox.y + 24, { steps: 12 })
+  await page.mouse.move(
+    targetBox.x +
+      Math.min(Math.max(targetBox.width * 0.15, 3), targetBox.width - 3),
+    targetBox.y +
+      Math.min(Math.max(targetBox.height * 0.25, 3), targetBox.height - 3),
+    { steps: 12 }
+  )
   await page.mouse.up()
   await page.waitForTimeout(400)
 
-  const targetBefore = await targetPointOf(edge)
-  const nodeBefore = await storedNodePosition(page, targetId)
+  const targetBefore = await centerOf(targetHandle)
+  const nodeBefore = await centerOf(targetNode)
 
   await dragLocatorBy(page, targetNode, 90, 45)
 
-  const targetAfter = await targetPointOf(edge)
-  const nodeAfter = await storedNodePosition(page, targetId)
+  const targetAfter = await centerOf(targetHandle)
+  const nodeAfter = await centerOf(targetNode)
   const nodeDelta = {
     x: nodeAfter.x - nodeBefore.x,
     y: nodeAfter.y - nodeBefore.y,
@@ -179,16 +209,148 @@ const cases = [
     targetId: "32659cdc-bd03-46f3-918c-ee8dbba9c15b",
   },
   {
+    name: "ActivityDiagram",
+    fixture: activityFixture,
+    edgeId: "edge-flow-initial-process",
+    targetId: "770e8400-e29b-41d4-a716-446655440021",
+  },
+  {
+    name: "BPMNDiagram",
+    fixture: bpmnFixture,
+    edgeId: "edge-start-validate",
+    targetId: "cc3d4e5f-a6b7-4c8d-9e0f-1a2b3c4d5e6f",
+  },
+  {
+    name: "BPMNDiagram association flow",
+    fixture: bpmnFixture,
+    edgeId: "edge-annotation-validate",
+    targetId: "cc3d4e5f-a6b7-4c8d-9e0f-1a2b3c4d5e6f",
+  },
+  {
+    name: "BPMNDiagram data association flow",
+    fixture: bpmnFixture,
+    edgeId: "edge-payment-invoice",
+    targetId: "d40e1f2a-b3c4-4d5e-6f7a-8b9c0d1e2f3a",
+  },
+  {
+    name: "BPMNDiagram message flow",
+    fixture: bpmnFixture,
+    edgeId: "edge-subprocess-to-pool-task",
+    targetId: "ee5f6a7b-c8d9-4e0f-1a2b-3c4d5e6f7a8b",
+  },
+  {
+    name: "CommunicationDiagram",
+    fixture: communicationFixture,
+    edgeId: "edge-comm-client-server",
+    targetId: "990e8400-e29b-41d4-a716-446655440041",
+  },
+  {
+    name: "ComponentDiagram",
+    fixture: componentFixture,
+    edgeId: "edge-server-database",
+    targetId: "a87ff679-a2f3-4e71-9bda-d16a21e1a2f3",
+  },
+  {
+    name: "ComponentDiagram provided interface",
+    fixture: componentFixture,
+    edgeId: "edge-client-interface",
+    targetId: "1b4e28ba-2fa1-4d11-a2d3-b8f04f4e5c6d",
+  },
+  {
+    name: "ComponentDiagram required interface",
+    fixture: componentFixture,
+    edgeId: "edge-server-interface",
+    targetId: "1b4e28ba-2fa1-4d11-a2d3-b8f04f4e5c6d",
+  },
+  {
+    name: "ComponentDiagram three-quarter required interface",
+    fixture: componentFixture,
+    edgeId: "edge-three-quarter-interface",
+    targetId: "c2d3e4f5-a6b7-4c8d-9e0f-1a2b3c4d5e60",
+  },
+  {
+    name: "ComponentDiagram quarter required interface",
+    fixture: componentFixture,
+    edgeId: "edge-quarter-interface",
+    targetId: "c2d3e4f5-a6b7-4c8d-9e0f-1a2b3c4d5e61",
+  },
+  {
+    name: "DeploymentDiagram",
+    fixture: deploymentFixture,
+    edgeId: "377c3ef7-083e-42a3-acc3-89786f7f762f",
+    targetId: "f6a7b8c9-d0e1-4f2a-3b4c-5d6e7f809102",
+  },
+  {
+    name: "DeploymentDiagram association",
+    fixture: deploymentFixture,
+    edgeId: "9c143a9c-350d-4f90-bf2e-fa11b8809b25",
+    targetId: "b8c9d0e1-f2a3-4b4c-5d6e-7f8091021324",
+  },
+  {
+    name: "DeploymentDiagram provided interface",
+    fixture: deploymentFixture,
+    edgeId: "edge-deploy-provided",
+    targetId: "int-prov-001",
+  },
+  {
+    name: "DeploymentDiagram required interface",
+    fixture: deploymentFixture,
+    edgeId: "edge-deploy-required",
+    targetId: "int-req-001",
+  },
+  {
+    name: "DeploymentDiagram three-quarter required interface",
+    fixture: deploymentFixture,
+    edgeId: "edge-deploy-3q",
+    targetId: "int-3q-001",
+  },
+  {
+    name: "DeploymentDiagram quarter required interface",
+    fixture: deploymentFixture,
+    edgeId: "edge-deploy-q",
+    targetId: "int-q-001",
+  },
+  {
+    name: "Flowchart",
+    fixture: flowchartFixture,
+    edgeId: "edge-start-init",
+    targetId: "20b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+  },
+  {
     name: "ObjectDiagram",
     fixture: objectFixture,
     edgeId: "edge-link-dog-owner",
     targetId: "660e8400-e29b-41d4-a716-446655440011",
   },
   {
+    name: "PetriNet",
+    fixture: petriNetFixture,
+    edgeId: "edge-p1-t1",
+    targetId: "22222222-2222-4222-a222-222222222222",
+  },
+  {
+    name: "ReachabilityGraph",
+    fixture: reachabilityGraphFixture,
+    edgeId: "edge-200-110",
+    targetId: "aaaa2222-bbbb-4ccc-dddd-eeee22222222",
+  },
+  {
+    name: "SfcDiagram",
+    fixture: sfcFixture,
+    edgeId: "edge-step1-actiontable",
+    targetId: "44dd5ee6-ff7a-4b8c-9d0e-1f2a3b4c5d6e",
+  },
+  {
     name: "SyntaxTree",
     fixture: syntaxTreeFixture,
     edgeId: "edge-expr-term-left",
     targetId: "e1f2a3b4-c5d6-4e7f-8a9b-0c1d2e3f4a5b",
+  },
+  {
+    name: "UseCaseDiagram",
+    fixture: useCaseFixture,
+    edgeId: "edge-assoc-customer-browse",
+    targetId: "880e8400-e29b-41d4-a716-446655440033",
   },
 ]
 

--- a/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-freeform-anchor.spec.ts
@@ -239,3 +239,29 @@ test("a new same-node edge can connect different handles", async ({ page }) => {
     targetHandle: "top",
   })
 })
+
+test("a new same-node edge cannot reconnect to the same handle", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, classNoEdgeFixture)
+  await waitForCanvasReady(page)
+
+  const node = page.locator(`.react-flow__node[data-id="${CLASS_SOURCE}"]`)
+
+  await node.hover()
+  await page.waitForTimeout(120)
+  const rightHandle = node.locator('.react-flow__handle[data-handleid="right"]')
+  const handleBox = await rightHandle.first().boundingBox()
+  if (!handleBox) throw new Error("source handle has no bounding box")
+
+  const x = handleBox.x + handleBox.width / 2
+  const y = handleBox.y + handleBox.height / 2
+  await page.mouse.move(x, y)
+  await page.mouse.down()
+  await page.mouse.move(x + 16, y, { steps: 4 })
+  await page.mouse.move(x, y, { steps: 4 })
+  await page.mouse.up()
+  await page.waitForTimeout(400)
+
+  expect(await storedEdges(page)).toHaveLength(0)
+})

--- a/standalone/webapp/tests/e2e/edge-ghost-preview.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-ghost-preview.spec.ts
@@ -1,0 +1,330 @@
+import { test, expect, type Page } from "@playwright/test"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+import { waitForCanvasReady, openFixtureInLocalEditor } from "../helpers/canvas"
+
+/**
+ * The connection GHOST (preview line rendered by ReconnectConnectionLine while a
+ * connection or reconnection is dragged):
+ *  - a NEW connection stays hidden until the pointer is dragged a short distance
+ *    from the source node (so a click / tiny drag doesn't flash a preview),
+ *    then shows a prominent dashed line;
+ *  - its free end SNAPS onto the freeform border point of the node under the
+ *    pointer, previewing exactly where the edge will attach;
+ *  - reconnecting an endpoint snaps the moved end onto the hovered node too.
+ */
+
+const __d = path.dirname(fileURLToPath(import.meta.url))
+const fx = (n: string) =>
+  JSON.parse(
+    fs.readFileSync(path.join(__d, "..", "fixtures", n), "utf-8")
+  ) as Record<string, unknown>
+
+const A = "95aac2b6-3e6b-4e6d-9201-52a498e6ea20"
+const B = "32659cdc-bd03-46f3-918c-ee8dbba9c15b"
+const EDGE = "edge-inheritance-dog-animal"
+const DEST = "550e8400-e29b-41d4-a716-446655440005"
+
+async function box(page: Page, id: string) {
+  return (await page
+    .locator(`.react-flow__node[data-id="${id}"]`)
+    .boundingBox())!
+}
+
+/** The ghost connection-path: whether it is visibly rendered + its end point in
+ * screen space. */
+async function ghost(page: Page) {
+  return page.evaluate(() => {
+    const p = document.querySelector(
+      "path.react-flow__connection-path"
+    ) as SVGPathElement | null
+    if (!p)
+      return { visible: false, end: null as null | { x: number; y: number } }
+    const d = p.getAttribute("d") ?? ""
+    const opacity = Number(getComputedStyle(p).opacity)
+    const visible = d.length > 0 && opacity > 0.5
+    let end: { x: number; y: number } | null = null
+    const ctm = p.getScreenCTM()
+    if (visible && ctm && p.getTotalLength() > 0) {
+      const q = p.getPointAtLength(p.getTotalLength())
+      const m = new DOMPoint(q.x, q.y).matrixTransform(ctm)
+      end = { x: m.x, y: m.y }
+    }
+    return { visible, end }
+  })
+}
+
+/** Nearest side of a node box to a screen point. */
+function sideOf(
+  b: { x: number; y: number; width: number; height: number },
+  p: { x: number; y: number }
+) {
+  const d = {
+    left: Math.abs(p.x - b.x),
+    right: Math.abs(p.x - (b.x + b.width)),
+    top: Math.abs(p.y - b.y),
+    bottom: Math.abs(p.y - (b.y + b.height)),
+  }
+  return Object.entries(d).sort((x, y) => x[1] - y[1])[0][0]
+}
+/** Distance from a screen point to the nearest edge of a node box (0 = on border). */
+function distToBorder(
+  b: { x: number; y: number; width: number; height: number },
+  p: { x: number; y: number }
+) {
+  const inside =
+    p.x >= b.x && p.x <= b.x + b.width && p.y >= b.y && p.y <= b.y + b.height
+  const dx = Math.min(Math.abs(p.x - b.x), Math.abs(p.x - (b.x + b.width)))
+  const dy = Math.min(Math.abs(p.y - b.y), Math.abs(p.y - (b.y + b.height)))
+  return inside
+    ? Math.min(dx, dy)
+    : Math.hypot(
+        Math.max(0, p.x < b.x ? b.x - p.x : p.x - (b.x + b.width)),
+        Math.max(0, p.y < b.y ? b.y - p.y : p.y - (b.y + b.height))
+      )
+}
+
+test("the new-connection ghost is hidden near the source, then appears after dragging away", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, fx("two-class-no-edge.json"))
+  await waitForCanvasReady(page)
+  const a = await box(page, A)
+  const start = { x: a.x + a.width, y: a.y + a.height / 2 } // right-side handle
+
+  await page.mouse.move(start.x, start.y)
+  await page.mouse.down()
+
+  // Just past the border — still "at" the node: ghost must stay hidden.
+  await page.mouse.move(start.x + 12, start.y, { steps: 3 })
+  expect(
+    (await ghost(page)).visible,
+    "ghost must stay hidden for a tiny drag near the source"
+  ).toBe(false)
+
+  // Dragged well away over empty canvas: ghost must now be visible.
+  await page.mouse.move(start.x + 120, start.y, { steps: 8 })
+  expect(
+    (await ghost(page)).visible,
+    "ghost must appear once dragged away from the source"
+  ).toBe(true)
+
+  await page.mouse.up()
+})
+
+test("the ghost snaps its end onto the target node's border while hovering it", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, fx("two-class-no-edge.json"))
+  await waitForCanvasReady(page)
+  const a = await box(page, A)
+  const b = await box(page, B)
+  const start = { x: a.x + a.width, y: a.y + a.height / 2 }
+
+  await page.mouse.move(start.x, start.y)
+  await page.mouse.down()
+  // Aim deep into B's body from the left — the snap should put the end on B's
+  // LEFT border (facing the source), not float at the cursor inside the body.
+  await page.mouse.move(b.x + b.width / 2, b.y + b.height / 2, { steps: 10 })
+  const g = await ghost(page)
+  await page.mouse.up()
+
+  expect(
+    g.visible && g.end,
+    "ghost must be visible over the target"
+  ).toBeTruthy()
+  expect(
+    distToBorder(b, g.end!),
+    "ghost end must snap onto B's border, not float at the cursor"
+  ).toBeLessThanOrEqual(6)
+})
+
+test("the new-connection ghost previews exactly where the edge attaches (preview must not lie)", async ({
+  page,
+}) => {
+  // The ghost snap and the connection commit resolve the drop target through the
+  // same helper, so the previewed endpoint must equal the committed one.
+  await openFixtureInLocalEditor(page, fx("two-class-no-edge.json"))
+  await waitForCanvasReady(page)
+  const a = await box(page, A)
+  const b = await box(page, B)
+  const start = { x: a.x + a.width, y: a.y + a.height / 2 }
+
+  await page.mouse.move(start.x, start.y)
+  await page.mouse.down()
+  await page.mouse.move(b.x + 10, b.y + b.height / 3, { steps: 12 }) // inside B
+  await page.waitForTimeout(60)
+  const g = await ghost(page)
+  expect(
+    g.visible && g.end,
+    "ghost must be visible over the target"
+  ).toBeTruthy()
+
+  await page.mouse.up()
+  await page.waitForTimeout(150)
+  // Exactly one edge now exists; its target endpoint is where the drop attached.
+  const committedEnd = await page.evaluate(() => {
+    const p = document.querySelector(
+      ".react-flow__edge path.react-flow__edge-path"
+    ) as SVGPathElement | null
+    const ctm = p?.getScreenCTM()
+    if (!p || !ctm) return null
+    const q = p.getPointAtLength(p.getTotalLength())
+    const m = new DOMPoint(q.x, q.y).matrixTransform(ctm)
+    return { x: m.x, y: m.y }
+  })
+  expect(committedEnd, "the drop must create an edge").toBeTruthy()
+  expect(
+    Math.hypot(g.end!.x - committedEnd!.x, g.end!.y - committedEnd!.y),
+    "the ghost end must match where the edge actually attaches"
+  ).toBeLessThanOrEqual(6)
+})
+
+test("reconnecting the target onto a specific side lands on that side", async ({
+  page,
+}) => {
+  for (const aim of ["top", "left", "right"] as const) {
+    await openFixtureInLocalEditor(page, fx("class-diagram.json"))
+    await waitForCanvasReady(page)
+    await page.locator(`.react-flow__edge[data-id="${EDGE}"]`).waitFor()
+    const pb = await page
+      .locator(
+        `.react-flow__edge[data-id="${EDGE}"] path.react-flow__edge-path`
+      )
+      .boundingBox()
+    await page.mouse.click(pb!.x + pb!.width / 2, pb!.y + pb!.height / 2)
+    await page.waitForTimeout(150)
+    const handle = await page
+      .locator(
+        `.react-flow__edge[data-id="${EDGE}"] .edge-endpoint-handle--target`
+      )
+      .boundingBox()
+    const d = await box(page, DEST)
+    const aimPt =
+      aim === "top"
+        ? { x: d.x + d.width / 2, y: d.y }
+        : aim === "left"
+          ? { x: d.x, y: d.y + d.height / 2 }
+          : { x: d.x + d.width, y: d.y + d.height / 2 }
+    await page.mouse.move(
+      handle!.x + handle!.width / 2,
+      handle!.y + handle!.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(aimPt.x, aimPt.y, { steps: 16 })
+    await page.mouse.up()
+    await page.waitForTimeout(150)
+    const end = await page.evaluate((eid) => {
+      const p = document.querySelector(
+        `.react-flow__edge[data-id="${eid}"] path.react-flow__edge-path`
+      ) as SVGPathElement | null
+      const ctm = p?.getScreenCTM()
+      if (!p || !ctm) return null
+      const q = p.getPointAtLength(p.getTotalLength())
+      const m = new DOMPoint(q.x, q.y).matrixTransform(ctm)
+      return { x: m.x, y: m.y }
+    }, EDGE)
+    expect(end, "edge endpoint must be measurable").toBeTruthy()
+    expect(sideOf(d, end!), `reconnect aimed ${aim}`).toBe(aim)
+  }
+})
+
+/** The rendered live edge path: both endpoints (screen), total length, and the
+ * straight-line distance between them (total > straight ⇒ orthogonal, not a
+ * diagonal). `typeClass`/`pathCount` prove it's still the real typed edge with
+ * its decoration, not a bare line. */
+async function livePath(page: Page, edgeId: string) {
+  return page.evaluate((eid) => {
+    const g = document.querySelector(`.react-flow__edge[data-id="${eid}"]`)
+    const p = g?.querySelector(
+      "path.react-flow__edge-path"
+    ) as SVGPathElement | null
+    const ctm = p?.getScreenCTM()
+    if (!p || !ctm || p.getTotalLength() === 0) return null
+    const at = (len: number) => {
+      const q = p.getPointAtLength(len)
+      const m = new DOMPoint(q.x, q.y).matrixTransform(ctm)
+      return { x: m.x, y: m.y }
+    }
+    const total = p.getTotalLength()
+    const s = at(0)
+    const t = at(total)
+    return {
+      source: s,
+      target: t,
+      total,
+      straight: Math.hypot(t.x - s.x, t.y - s.y),
+      typeClass: g?.getAttribute("class") ?? "",
+      pathCount: g?.querySelectorAll("path").length ?? 0,
+    }
+  }, edgeId)
+}
+
+for (const end of ["target", "source"] as const) {
+  test(`dragging the ${end} endpoint into empty space: a step-routed ghost follows the cursor and reverts on release`, async ({
+    page,
+  }) => {
+    await openFixtureInLocalEditor(page, fx("class-diagram.json"))
+    await waitForCanvasReady(page)
+    await page.locator(`.react-flow__edge[data-id="${EDGE}"]`).waitFor()
+
+    const pb = await page
+      .locator(
+        `.react-flow__edge[data-id="${EDGE}"] path.react-flow__edge-path`
+      )
+      .boundingBox()
+    await page.mouse.click(pb!.x + pb!.width / 2, pb!.y + pb!.height / 2)
+    await page.waitForTimeout(150)
+    const before = (await livePath(page, EDGE))!
+    // The edge is the real typed ClassInheritance edge with its triangle drawn.
+    expect(before.typeClass).toContain("ClassInheritance")
+    expect(before.pathCount).toBeGreaterThanOrEqual(2)
+    const movedBefore = end === "target" ? before.target : before.source
+
+    const handle = await page
+      .locator(
+        `.react-flow__edge[data-id="${EDGE}"] .edge-endpoint-handle--${end}`
+      )
+      .boundingBox()
+    await page.mouse.move(
+      handle!.x + handle!.width / 2,
+      handle!.y + handle!.height / 2
+    )
+    await page.mouse.down()
+
+    // A clearly DIAGONAL empty-canvas point, clear of every node so the endpoint
+    // is free (not snapped to a target) and a release there reverts.
+    const p = { x: handle!.x + 240, y: handle!.y + 80 }
+    await page.mouse.move(p.x, p.y, { steps: 10 })
+    await page.waitForTimeout(60)
+    const live = (await livePath(page, EDGE))!
+    const moved = end === "target" ? live.target : live.source
+
+    // Follows the cursor (within a marker/grid offset) AND has genuinely tracked
+    // far from its committed position — a regression that leaves it pinned fails.
+    expect(
+      Math.hypot(moved.x - p.x, moved.y - p.y),
+      `${end} endpoint must follow the cursor in empty space`
+    ).toBeLessThanOrEqual(35)
+    expect(
+      Math.hypot(moved.x - movedBefore.x, moved.y - movedBefore.y),
+      `${end} endpoint must move with the drag, not stay pinned to its node`
+    ).toBeGreaterThan(100)
+    // Step-routed, not a straight diagonal: an orthogonal L-route is longer.
+    expect(
+      live.total,
+      "ghost must be step-routed (longer than a straight line)"
+    ).toBeGreaterThan(live.straight * 1.12)
+
+    // Release over empty canvas: the edge must REVERT (no reconnect).
+    await page.mouse.up()
+    await page.waitForTimeout(150)
+    const after = (await livePath(page, EDGE))!
+    const movedAfter = end === "target" ? after.target : after.source
+    expect(
+      Math.hypot(movedAfter.x - movedBefore.x, movedAfter.y - movedBefore.y),
+      "releasing over empty canvas must revert the endpoint (no false reconnect)"
+    ).toBeLessThanOrEqual(4)
+  })
+}

--- a/standalone/webapp/tests/e2e/edge-ghost-preview.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-ghost-preview.spec.ts
@@ -105,10 +105,11 @@ test("the new-connection ghost is hidden near the source, then appears after dra
 
   // Dragged well away over empty canvas: ghost must now be visible.
   await page.mouse.move(start.x + 120, start.y, { steps: 8 })
-  expect(
-    (await ghost(page)).visible,
-    "ghost must appear once dragged away from the source"
-  ).toBe(true)
+  await expect
+    .poll(async () => (await ghost(page)).visible, {
+      message: "ghost must appear once dragged away from the source",
+    })
+    .toBe(true)
 
   await page.mouse.up()
 })
@@ -127,13 +128,15 @@ test("the ghost snaps its end onto the target node's border while hovering it", 
   // Aim deep into B's body from the left — the snap should put the end on B's
   // LEFT border (facing the source), not float at the cursor inside the body.
   await page.mouse.move(b.x + b.width / 2, b.y + b.height / 2, { steps: 10 })
+  await expect
+    .poll(async () => (await ghost(page)).visible, {
+      message: "ghost must be visible over the target",
+    })
+    .toBe(true)
   const g = await ghost(page)
   await page.mouse.up()
 
-  expect(
-    g.visible && g.end,
-    "ghost must be visible over the target"
-  ).toBeTruthy()
+  expect(g.end, "ghost end must resolve over the target").toBeTruthy()
   expect(
     distToBorder(b, g.end!),
     "ghost end must snap onto B's border, not float at the cursor"
@@ -154,12 +157,13 @@ test("the new-connection ghost previews exactly where the edge attaches (preview
   await page.mouse.move(start.x, start.y)
   await page.mouse.down()
   await page.mouse.move(b.x + 10, b.y + b.height / 3, { steps: 12 }) // inside B
-  await page.waitForTimeout(60)
+  await expect
+    .poll(async () => (await ghost(page)).visible, {
+      message: "ghost must be visible over the target",
+    })
+    .toBe(true)
   const g = await ghost(page)
-  expect(
-    g.visible && g.end,
-    "ghost must be visible over the target"
-  ).toBeTruthy()
+  expect(g.end, "ghost end must resolve over the target").toBeTruthy()
 
   await page.mouse.up()
   await page.waitForTimeout(150)

--- a/standalone/webapp/tests/e2e/edge-handle-zoom.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-handle-zoom.spec.ts
@@ -82,6 +82,53 @@ async function onScreenSize(handle: Locator) {
   }
 }
 
+/** Distance (screen px) from an edge's target endpoint to the centre of its
+ * visible target reconnect grip. */
+async function targetGripOffset(page: Page, id: string): Promise<number> {
+  return page.evaluate((eid) => {
+    const g = document.querySelector(`.react-flow__edge[data-id="${eid}"]`)
+    const p = g?.querySelector(
+      "path.react-flow__edge-path"
+    ) as SVGPathElement | null
+    const grip = g?.querySelector(
+      ".edge-endpoint-grip--target"
+    ) as SVGElement | null
+    const ctm = p?.getScreenCTM()
+    if (!p || !ctm || !grip) return -1
+    const at = p.getPointAtLength(p.getTotalLength())
+    const end = new DOMPoint(at.x, at.y).matrixTransform(ctm)
+    const r = grip.getBoundingClientRect()
+    return Math.hypot(r.x + r.width / 2 - end.x, r.y + r.height / 2 - end.y)
+  }, id)
+}
+
+test("the endpoint reconnect grip stays anchored to the endpoint across zoom", async ({
+  page,
+}) => {
+  // The visible grip hugs the endpoint at any zoom, while the invisible
+  // hit-target stays wide for grabbing — the grip is not centred on that wide
+  // target, which would float it off the endpoint when zoomed out.
+  await openFixtureInLocalEditor(page, classDiagram)
+  await waitForCanvasReady(page)
+  const id = "edge-inheritance-dog-animal"
+
+  await selectEdge(page, id)
+  const atDefault = await targetGripOffset(page, id)
+  expect(atDefault, "grip must be measurable").toBeGreaterThan(0)
+  expect(
+    atDefault,
+    "grip must hug the endpoint at default zoom"
+  ).toBeLessThanOrEqual(16)
+
+  await zoomOutUntil(page, 0.45)
+  await selectEdge(page, id)
+  const zoomedOut = await targetGripOffset(page, id)
+  expect(
+    zoomedOut,
+    "grip must stay hugging the endpoint when zoomed out (not float in the gap)"
+  ).toBeLessThanOrEqual(16)
+})
+
 test("edge handles stay usable when zoomed out and grow when zoomed in", async ({
   page,
 }) => {

--- a/standalone/webapp/tests/e2e/shape-aware-connections.spec.ts
+++ b/standalone/webapp/tests/e2e/shape-aware-connections.spec.ts
@@ -1,0 +1,658 @@
+import { test, expect, type Page } from "@playwright/test"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+import { waitForCanvasReady, openFixtureInLocalEditor } from "../helpers/canvas"
+
+const __d = path.dirname(fileURLToPath(import.meta.url))
+const readFixture = (name: string) =>
+  JSON.parse(fs.readFileSync(path.join(__d, "..", "fixtures", name), "utf-8"))
+const useCaseFixture = readFixture("use-case-diagram.json")
+const activityFixture = readFixture("activity-diagram.json")
+const flowchartFixture = readFixture("flowchart.json")
+
+const BROWSE = "880e8400-e29b-41d4-a716-446655440033" // use-case oval
+const INVENTORY = "880e8400-e29b-41d4-a716-446655440035" // use-case oval
+const ACTIVITY_CONTAINER = "770e8400-e29b-41d4-a716-446655440021" // "Process Order"
+const IO_NODE = "50e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a" // flowchart parallelogram
+
+async function nodeBox(page: Page, id: string) {
+  return (await page
+    .locator(`.react-flow__node[data-id="${id}"]`)
+    .boundingBox())!
+}
+
+/** Screen geometry of a node's inscribed ellipse. */
+async function ovalGeom(page: Page, id: string) {
+  return page.evaluate((nid) => {
+    const r = (
+      document.querySelector(
+        `.react-flow__node[data-id="${nid}"]`
+      ) as HTMLElement
+    ).getBoundingClientRect()
+    return {
+      cx: r.x + r.width / 2,
+      cy: r.y + r.height / 2,
+      rx: r.width / 2,
+      ry: r.height / 2,
+    }
+  }, id)
+}
+
+test("connecting to a use-case oval lands the endpoint on the ellipse curve, not the bbox corner", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, useCaseFixture)
+  await waitForCanvasReady(page)
+
+  // Draw a connection from the Browse oval down to the Inventory oval, aiming at
+  // the Inventory oval's TOP-RIGHT — a point that, on a rectangle, would be the
+  // empty bbox corner OUTSIDE the visible oval.
+  const source = page.locator(`.react-flow__node[data-id="${BROWSE}"]`)
+  await source.hover()
+  await page.waitForTimeout(120)
+  const handle = source
+    .locator('.react-flow__handle[data-handleid="bottom"]')
+    .first()
+  const hb = await handle.boundingBox()
+  const inv = await nodeBox(page, INVENTORY)
+  const aim = { x: inv.x + inv.width - 12, y: inv.y + 12 }
+
+  await page.mouse.move(hb!.x + hb!.width / 2, hb!.y + hb!.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(aim.x, aim.y, { steps: 16 })
+  await page.mouse.up()
+  await page.waitForTimeout(250)
+
+  const g = await ovalGeom(page, INVENTORY)
+  // The endpoint of some edge closest to the Inventory oval's centre.
+  const end = await page.evaluate((geom) => {
+    const paths = Array.from(
+      document.querySelectorAll(".react-flow__edge path.react-flow__edge-path")
+    ) as SVGPathElement[]
+    let best: { x: number; y: number } | null = null
+    let bestD = Infinity
+    for (const p of paths) {
+      const ctm = p.getScreenCTM()
+      if (!ctm || p.getTotalLength() === 0) continue
+      for (const len of [0, p.getTotalLength()]) {
+        const q = p.getPointAtLength(len)
+        const m = new DOMPoint(q.x, q.y).matrixTransform(ctm)
+        const d = Math.hypot(m.x - geom.cx, m.y - geom.cy)
+        if (d < bestD) {
+          bestD = d
+          best = { x: m.x, y: m.y }
+        }
+      }
+    }
+    return best
+  }, g)
+
+  expect(end, "a connection to the oval must exist").toBeTruthy()
+  // On the ellipse, ((x-cx)/rx)² + ((y-cy)/ry)² == 1. The bbox top-right corner
+  // would be ~2. Allow a little slack for the arrow-marker gap.
+  const onEllipse =
+    ((end!.x - g.cx) / g.rx) ** 2 + ((end!.y - g.cy) / g.ry) ** 2
+  expect(onEllipse, "endpoint hugs the oval curve").toBeGreaterThan(0.75)
+  expect(onEllipse, "endpoint is NOT in the empty bbox corner").toBeLessThan(
+    1.4
+  )
+  // And it landed where we aimed (upper-right), not snapped to a side midpoint.
+  expect(end!.x).toBeGreaterThan(g.cx)
+  expect(end!.y).toBeLessThan(g.cy)
+})
+
+test("an edge endpoint can be reconnected onto a container node (e.g. an Activity)", async ({
+  page,
+}) => {
+  // A container/parent node (activity, package, pool, subsystem …) is a valid
+  // freeform reconnect target: an endpoint dragged onto one attaches to its
+  // border instead of reverting.
+  await openFixtureInLocalEditor(page, activityFixture)
+  await waitForCanvasReady(page)
+  const EDGE = "edge-flow-merge-ship"
+  const edgePath = page.locator(
+    `.react-flow__edge[data-id="${EDGE}"] path.react-flow__edge-path`
+  )
+  const pb = await edgePath.boundingBox()
+  await page.mouse.click(pb!.x + pb!.width / 2, pb!.y + pb!.height / 2)
+  await page.waitForTimeout(200)
+
+  const container = await nodeBox(page, ACTIVITY_CONTAINER)
+  const targetEnd = () =>
+    page.evaluate((id) => {
+      const p = document.querySelector(
+        `.react-flow__edge[data-id="${id}"] path.react-flow__edge-path`
+      ) as SVGPathElement | null
+      const ctm = p?.getScreenCTM()
+      if (!p || !ctm) return null
+      const q = p.getPointAtLength(p.getTotalLength())
+      const m = new DOMPoint(q.x, q.y).matrixTransform(ctm)
+      return { x: m.x, y: m.y }
+    }, EDGE)
+
+  const before = await targetEnd()
+  const handle = await page
+    .locator(
+      `.react-flow__edge[data-id="${EDGE}"] .edge-endpoint-handle--target`
+    )
+    .boundingBox()
+  const aim = {
+    x: container.x + container.width * 0.6,
+    y: container.y + container.height - 4,
+  }
+  await page.mouse.move(
+    handle!.x + handle!.width / 2,
+    handle!.y + handle!.height / 2
+  )
+  await page.mouse.down()
+  await page.mouse.move(aim.x, aim.y, { steps: 18 })
+  await page.mouse.up()
+  await page.waitForTimeout(250)
+
+  const after = await targetEnd()
+  expect(before && after).toBeTruthy()
+  // The endpoint moved and now sits on the container's border.
+  expect(
+    Math.hypot(after!.x - before!.x, after!.y - before!.y)
+  ).toBeGreaterThan(20)
+  expect(Math.abs(after!.y - (container.y + container.height))).toBeLessThan(14)
+  expect(after!.x).toBeGreaterThan(container.x)
+  expect(after!.x).toBeLessThan(container.x + container.width)
+})
+
+test("reconnecting onto the input/output parallelogram follows the slanted outline", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, flowchartFixture)
+  await waitForCanvasReady(page)
+  const io = await nodeBox(page, IO_NODE)
+  const EDGE = "edge-decision-print" // its target sits on the IO node's left side
+
+  const targetEnd = () =>
+    page.evaluate((id) => {
+      const p = document.querySelector(
+        `.react-flow__edge[data-id="${id}"] path.react-flow__edge-path`
+      ) as SVGPathElement | null
+      const ctm = p?.getScreenCTM()
+      if (!p || !ctm) return null
+      const q = p.getPointAtLength(p.getTotalLength())
+      const m = new DOMPoint(q.x, q.y).matrixTransform(ctm)
+      return { x: m.x, y: m.y }
+    }, EDGE)
+
+  const reconnectTo = async (y: number) => {
+    const pb = await page
+      .locator(
+        `.react-flow__edge[data-id="${EDGE}"] path.react-flow__edge-path`
+      )
+      .boundingBox()
+    await page.mouse.click(pb!.x + pb!.width / 2, pb!.y + pb!.height / 2)
+    await page.waitForTimeout(150)
+    const handle = await page
+      .locator(
+        `.react-flow__edge[data-id="${EDGE}"] .edge-endpoint-handle--target`
+      )
+      .boundingBox()
+    await page.mouse.move(
+      handle!.x + handle!.width / 2,
+      handle!.y + handle!.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(io.x + 4, y, { steps: 14 })
+    await page.mouse.up()
+    await page.waitForTimeout(200)
+    return targetEnd()
+  }
+
+  // Left edge slants from inset-at-top to flush-at-bottom, so a drop high up
+  // lands further right than one low down — proving a continuous outline, not a
+  // fixed point, and never in the empty bbox corner.
+  const top = await reconnectTo(io.y + 8)
+  const bottom = await reconnectTo(io.y + io.height - 8)
+  expect(top && bottom).toBeTruthy()
+  const insetTop = top!.x - io.x
+  const insetBottom = bottom!.x - io.x
+  expect(insetTop).toBeGreaterThan(insetBottom + 5) // sheared: top is inset more
+  expect(insetBottom).toBeLessThan(6) // flush with the bbox at the bottom
+})
+
+test("a tiny reconnect drag on a straight edge keeps the arrow on the node (no gap)", async ({
+  page,
+}) => {
+  // Regression (the user's report): dragging a straight edge's endpoint a little
+  // way along the edge left a ~15px gap between the arrowhead and the node,
+  // because the drag preview applied the marker padding the committed edge does
+  // not. The tip must stay on the target's border throughout a small drag.
+  await openFixtureInLocalEditor(page, readFixture("two-class-fresh-edge.json"))
+  await waitForCanvasReady(page)
+  const EDGE = "231f7ef5-b43d-4187-8996-f7726ed6e919"
+  const TARGET = "32659cdc-bd03-46f3-918c-ee8dbba9c15b"
+  const tgt = await nodeBox(page, TARGET) // edge enters its LEFT border (tgt.x)
+
+  const tipX = () =>
+    page.evaluate((id) => {
+      const p = document.querySelector(
+        `.react-flow__edge[data-id="${id}"] path.react-flow__edge-path`
+      ) as SVGPathElement | null
+      const ctm = p?.getScreenCTM()
+      if (!p || !ctm) return null
+      const q = p.getPointAtLength(p.getTotalLength())
+      return new DOMPoint(q.x, q.y).matrixTransform(ctm).x
+    }, EDGE)
+
+  const pb = await page
+    .locator(`.react-flow__edge[data-id="${EDGE}"] path.react-flow__edge-path`)
+    .boundingBox()
+  await page.mouse.click(pb!.x + pb!.width / 2, pb!.y + pb!.height / 2)
+  await page.waitForTimeout(200)
+  const handle = await page
+    .locator(
+      `.react-flow__edge[data-id="${EDGE}"] .edge-endpoint-handle--target`
+    )
+    .boundingBox()
+
+  for (const dx of [8, 16]) {
+    await page.mouse.move(
+      handle!.x + handle!.width / 2,
+      handle!.y + handle!.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(
+      handle!.x + handle!.width / 2 - dx,
+      handle!.y + handle!.height / 2,
+      {
+        steps: 5,
+      }
+    )
+    await page.waitForTimeout(100)
+    const gap = (await tipX())! - tgt.x
+    await page.mouse.up()
+    await page.waitForTimeout(100)
+    expect(
+      Math.abs(gap),
+      `tiny drag (${dx}px) must not detach the arrow`
+    ).toBeLessThan(6)
+  }
+})
+
+test("the ghost preview matches where a use-case oval connection lands (no drift)", async ({
+  page,
+}) => {
+  // The oval connects continuously along its curve via the freeform path, so a
+  // new connection must land exactly where the dashed ghost previewed it — not a
+  // few px off at a fixed handle.
+  await openFixtureInLocalEditor(page, useCaseFixture)
+  await waitForCanvasReady(page)
+  const dst = await nodeBox(page, INVENTORY)
+  const before = await page.evaluate(() =>
+    Array.from(document.querySelectorAll(".react-flow__edge")).map((e) =>
+      e.getAttribute("data-id")
+    )
+  )
+  await page.locator(`.react-flow__node[data-id="${BROWSE}"]`).hover()
+  await page.waitForTimeout(150)
+  const h = await page
+    .locator(
+      `.react-flow__node[data-id="${BROWSE}"] .react-flow__handle[data-handleid="bottom"]`
+    )
+    .first()
+    .boundingBox()
+  // A clearly OFF-cardinal aim (upper-left of the oval), where handle-snapping
+  // and the ray projection diverge most.
+  await page.mouse.move(h!.x + h!.width / 2, h!.y + h!.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(dst.x + 22, dst.y + 20, { steps: 18 })
+  await page.waitForTimeout(120)
+  const ghost = await page.evaluate(() => {
+    const p = document.querySelector(
+      "path.react-flow__connection-path"
+    ) as SVGPathElement | null
+    const ctm = p?.getScreenCTM()
+    if (!p || !ctm || p.getTotalLength() === 0) return null
+    const q = p.getPointAtLength(p.getTotalLength())
+    const m = new DOMPoint(q.x, q.y).matrixTransform(ctm)
+    return { x: m.x, y: m.y }
+  })
+  await page.mouse.up()
+  await page.waitForTimeout(300)
+  const commit = await page.evaluate((b) => {
+    const now = Array.from(document.querySelectorAll(".react-flow__edge")).map(
+      (e) => e.getAttribute("data-id")
+    )
+    const id = now.find((x) => !b.includes(x))
+    if (!id) return null
+    const p = document.querySelector(
+      `.react-flow__edge[data-id="${id}"] path.react-flow__edge-path`
+    ) as SVGPathElement | null
+    const ctm = p?.getScreenCTM()
+    if (!p || !ctm) return null
+    const q = p.getPointAtLength(p.getTotalLength())
+    const m = new DOMPoint(q.x, q.y).matrixTransform(ctm)
+    return { x: m.x, y: m.y }
+  }, before)
+  expect(
+    ghost && commit,
+    "a connection must be created with a ghost preview"
+  ).toBeTruthy()
+  // The committed endpoint (nearer the oval) matches the ghost within a couple px.
+  expect(Math.hypot(ghost!.x - commit!.x, ghost!.y - commit!.y)).toBeLessThan(8)
+})
+
+test("connecting to a use-case oval shows a snap circle at the live attach point, at any angle", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, useCaseFixture)
+  await waitForCanvasReady(page)
+  const dst = await nodeBox(page, INVENTORY)
+  const cx = dst.x + dst.width / 2
+  const cy = dst.y + dst.height / 2
+  await page.locator(`.react-flow__node[data-id="${BROWSE}"]`).hover()
+  await page.waitForTimeout(150)
+  const h = await page
+    .locator(
+      `.react-flow__node[data-id="${BROWSE}"] .react-flow__handle[data-handleid="bottom"]`
+    )
+    .first()
+    .boundingBox()
+  // Aim at an OFF-cardinal point (~60°) — the case with no visible handle.
+  const aim = {
+    x: cx + (dst.width / 2) * 0.5 * 0.9,
+    y: cy + (dst.height / 2) * 0.87 * 0.9,
+  }
+  await page.mouse.move(h!.x + h!.width / 2, h!.y + h!.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(aim.x, aim.y, { steps: 16 })
+  await page.waitForTimeout(100)
+  const circle = await page.evaluate(() => {
+    const c = document.querySelector(
+      ".apollon-connection-snap-circle"
+    ) as SVGCircleElement | null
+    const ctm = c?.getScreenCTM()
+    if (!c || !ctm) return null
+    const m = new DOMPoint(
+      c.cx.baseVal.value,
+      c.cy.baseVal.value
+    ).matrixTransform(ctm)
+    return { x: m.x, y: m.y }
+  })
+  expect(
+    circle,
+    "a snap circle must appear off-cardinal on the oval"
+  ).toBeTruthy()
+  await page.mouse.up()
+  await page.waitForTimeout(250)
+  // The committed edge's endpoint on the oval matches where the circle showed.
+  const end = await page.evaluate((c) => {
+    const paths = Array.from(
+      document.querySelectorAll(".react-flow__edge path.react-flow__edge-path")
+    ) as SVGPathElement[]
+    let best: { x: number; y: number } | null = null
+    let bd = Infinity
+    for (const p of paths) {
+      const ctm = p.getScreenCTM()
+      if (!ctm || p.getTotalLength() === 0) continue
+      for (const len of [0, p.getTotalLength()]) {
+        const q = p.getPointAtLength(len)
+        const m = new DOMPoint(q.x, q.y).matrixTransform(ctm)
+        const d = Math.hypot(m.x - c.x, m.y - c.y)
+        if (d < bd) {
+          bd = d
+          best = { x: m.x, y: m.y }
+        }
+      }
+    }
+    return best
+  }, circle)
+  expect(
+    Math.hypot(end!.x - circle!.x, end!.y - circle!.y),
+    "the edge lands where the snap circle showed"
+  ).toBeLessThan(6)
+})
+
+test("a use-case oval connection lands at the aimed angle, including diagonals (no drift)", async ({
+  page,
+}) => {
+  // A diagonal aim lands where aimed at every angle, not pulled toward the
+  // nearest bounding-box side.
+  await openFixtureInLocalEditor(page, useCaseFixture)
+  await waitForCanvasReady(page)
+  const g = await ovalGeom(page, INVENTORY)
+  for (const deg of [45, 135, 225, 315]) {
+    await openFixtureInLocalEditor(page, useCaseFixture)
+    await waitForCanvasReady(page)
+    const before = await page.evaluate(() =>
+      Array.from(document.querySelectorAll(".react-flow__edge")).map((e) =>
+        e.getAttribute("data-id")
+      )
+    )
+    await page.locator(`.react-flow__node[data-id="${BROWSE}"]`).hover()
+    await page.waitForTimeout(120)
+    const h = await page
+      .locator(
+        `.react-flow__node[data-id="${BROWSE}"] .react-flow__handle[data-handleid="bottom"]`
+      )
+      .first()
+      .boundingBox()
+    const th = (deg * Math.PI) / 180
+    const aim = { x: g.cx + g.rx * Math.cos(th), y: g.cy + g.ry * Math.sin(th) }
+    await page.mouse.move(h!.x + h!.width / 2, h!.y + h!.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(aim.x, aim.y, { steps: 14 })
+    await page.mouse.up()
+    await page.waitForTimeout(250)
+    const end = await page.evaluate(
+      ({ b, cx, cy }) => {
+        const now = Array.from(
+          document.querySelectorAll(".react-flow__edge")
+        ).map((e) => e.getAttribute("data-id"))
+        const id = now.find((x) => !b.includes(x))
+        if (!id) return null
+        const p = document.querySelector(
+          `.react-flow__edge[data-id="${id}"] path.react-flow__edge-path`
+        ) as SVGPathElement | null
+        const ctm = p?.getScreenCTM()
+        if (!p || !ctm) return null
+        const pts = [0, p.getTotalLength()].map((l) => {
+          const q = p.getPointAtLength(l)
+          const m = new DOMPoint(q.x, q.y).matrixTransform(ctm)
+          return { x: m.x, y: m.y }
+        })
+        return Math.hypot(pts[0].x - cx, pts[0].y - cy) <
+          Math.hypot(pts[1].x - cx, pts[1].y - cy)
+          ? pts[0]
+          : pts[1]
+      },
+      { b: before, cx: g.cx, cy: g.cy }
+    )
+    expect(end, `edge created aiming ${deg}°`).toBeTruthy()
+    expect(
+      Math.hypot(end!.x - aim.x, end!.y - aim.y),
+      `${deg}° must land at the aimed point, not drift to a cardinal`
+    ).toBeLessThan(8)
+  }
+})
+
+test("reconnecting between close nodes snaps to the nearest, not the top-most", async ({
+  page,
+}) => {
+  // Regression: the drop resolver picked the top-most intersecting node, so with
+  // two nodes close together an endpoint dragged over one could grab its
+  // neighbour just because the neighbour was on top. It must pick the nearest.
+  const base = readFixture("two-class-fresh-edge.json")
+  const B = "32659cdc-bd03-46f3-918c-ee8dbba9c15b" // the edge's target node
+  const C = "cccc0000-0000-0000-0000-000000000003"
+  const cNode = JSON.parse(JSON.stringify(base.nodes[0]))
+  cNode.id = C
+  cNode.position = { x: 785, y: 370 } // B spans 640–800, C spans 785–945 (C on top)
+  cNode.measured = { width: 160, height: 100 }
+  cNode.data.name = "C"
+  const fixture = { ...base, nodes: [...base.nodes, cNode] }
+  const EDGE = base.edges[0].id
+
+  await openFixtureInLocalEditor(page, fixture)
+  await waitForCanvasReady(page)
+  const b = await nodeBox(page, B)
+  const c = await nodeBox(page, C)
+  const pb = await page
+    .locator(`.react-flow__edge[data-id="${EDGE}"] path.react-flow__edge-path`)
+    .boundingBox()
+  await page.mouse.click(pb!.x + pb!.width / 2, pb!.y + pb!.height / 2)
+  await page.waitForTimeout(200)
+  const handle = await page
+    .locator(
+      `.react-flow__edge[data-id="${EDGE}"] .edge-endpoint-handle--target`
+    )
+    .boundingBox()
+  // Drag the endpoint INSIDE B, just left of C's left edge — nearest is B.
+  await page.mouse.move(
+    handle!.x + handle!.width / 2,
+    handle!.y + handle!.height / 2
+  )
+  await page.mouse.down()
+  await page.mouse.move(c.x - 6, b.y + b.height / 2, { steps: 16 })
+  await page.mouse.up()
+  await page.waitForTimeout(200)
+
+  const target = await page.evaluate((eid) => {
+    const raw = localStorage.getItem("persistenceModelStore")
+    if (!raw) return null
+    const p = JSON.parse(raw)
+    const id = p.state.currentModelId
+    return (p.state.models[id]?.model?.edges || []).find(
+      (x: { id: string }) => x.id === eid
+    )?.target
+  }, EDGE)
+  expect(
+    target,
+    "endpoint must snap to the nearer node B, not the top-most C"
+  ).toBe(B)
+})
+
+test("a connection arc is grabbable when approached directly, not only via the body", async ({
+  page,
+}) => {
+  // Regression: arcs protrude past the node box but only armed on node :hover,
+  // so approaching one from OUTSIDE (without first crossing the body) left it
+  // inert — "sometimes I can't grab the handle". Each side's arc must start a
+  // connection when the pointer goes straight to it.
+  const A = "95aac2b6-3e6b-4e6d-9201-52a498e6ea20"
+  const B = "32659cdc-bd03-46f3-918c-ee8dbba9c15b"
+  const edgeCount = () =>
+    page.evaluate(() => {
+      const raw = localStorage.getItem("persistenceModelStore")
+      if (!raw) return 0
+      const p = JSON.parse(raw)
+      const id = p.state.currentModelId
+      return (p.state.models[id]?.model?.edges || []).length
+    })
+  const sideArc = (
+    a: { x: number; y: number; width: number; height: number },
+    side: string
+  ) =>
+    ({
+      top: { x: a.x + a.width / 2, y: a.y - 6 },
+      bottom: { x: a.x + a.width / 2, y: a.y + a.height + 6 },
+      left: { x: a.x - 6, y: a.y + a.height / 2 },
+      right: { x: a.x + a.width + 6, y: a.y + a.height / 2 },
+    })[side]!
+
+  for (const side of ["top", "bottom", "left", "right"]) {
+    await openFixtureInLocalEditor(page, readFixture("two-class-no-edge.json"))
+    await waitForCanvasReady(page)
+    const a = await nodeBox(page, A)
+    const b = await nodeBox(page, B)
+    const arc = sideArc(a, side)
+    const before = await edgeCount()
+    // Go STRAIGHT to the protruding arc — no prior hover over the node body.
+    await page.mouse.move(arc.x, arc.y)
+    await page.waitForTimeout(120)
+    await page.mouse.down()
+    await page.mouse.move(b.x + b.width / 2, b.y + b.height / 2, { steps: 14 })
+    await page.mouse.up()
+    await page.waitForTimeout(150)
+    expect(
+      await edgeCount(),
+      `${side} arc must be grabbable from outside`
+    ).toBe(before + 1)
+  }
+})
+
+test("a selected node's protruding arc does not swallow clicks meant for an overlapping neighbour", async ({
+  page,
+}) => {
+  // A selected node is elevated; its armed arcs must not eat clicks on a node
+  // beneath them. Approaching the neighbour from its own side (not through the
+  // selected node's body) must select the neighbour.
+  const A = "95aac2b6-3e6b-4e6d-9201-52a498e6ea20"
+  const B = "32659cdc-bd03-46f3-918c-ee8dbba9c15b"
+  const fixture = readFixture("two-class-no-edge.json")
+  fixture.nodes[0].position = { x: 400, y: 300 }
+  fixture.nodes[1].position = { x: 520, y: 300 }
+  fixture.nodes[0].measured = { width: 160, height: 100 }
+  fixture.nodes[1].measured = { width: 160, height: 100 }
+  await openFixtureInLocalEditor(page, fixture)
+  await waitForCanvasReady(page)
+  const a = await nodeBox(page, A)
+  const b = await nodeBox(page, B)
+  await page.mouse.click(a.x + 30, a.y + a.height / 2) // select A
+  await page.waitForTimeout(120)
+  await page.mouse.move(b.x + b.width + 80, b.y + b.height / 2) // clear A hover
+  await page.waitForTimeout(120)
+  // Click where A's RIGHT arc overlaps B's body, approaching from B's side.
+  const px = a.x + a.width + 7
+  const py = a.y + a.height / 2
+  await page.mouse.move(px + 60, py)
+  await page.mouse.move(px, py, { steps: 8 })
+  await page.waitForTimeout(120)
+  await page.mouse.down()
+  await page.mouse.up()
+  await page.waitForTimeout(150)
+  const selected = await page.evaluate(() =>
+    document
+      .querySelector(".react-flow__node.selected")
+      ?.getAttribute("data-id")
+  )
+  expect(selected, "click must fall through to the neighbour B").toBe(B)
+})
+
+test("a BPMN annotation is not a connection target", async ({ page }) => {
+  // bpmnAnnotation is mode "none" and its handles are not connectable ENDS, so
+  // neither the freeform drop path nor React Flow's native valid-handle path can
+  // attach an edge to it — while an association SOURCED at it still renders.
+  const SOURCE = "cc3d4e5f-a6b7-4c8d-9e0f-1a2b3c4d5e6f" // a task
+  const ANNOTATION = "c39d0e1f-a2b3-4c4d-5e6f-7a8b9c0d1e2f"
+  await openFixtureInLocalEditor(page, readFixture("bpmn.json"))
+  await waitForCanvasReady(page)
+  const edgeCount = () =>
+    page.evaluate(() => {
+      const raw = localStorage.getItem("persistenceModelStore")
+      if (!raw) return 0
+      const p = JSON.parse(raw)
+      const id = p.state.currentModelId
+      return (p.state.models[id]?.model?.edges || []).length
+    })
+
+  // An existing association anchored to the annotation's handle still renders
+  // (the handles are kept, only their connectable-end is off).
+  await expect(
+    page.locator(`.react-flow__edge[data-id="edge-annotation-validate"]`)
+  ).toBeAttached()
+
+  const before = await edgeCount()
+  const src = await nodeBox(page, SOURCE)
+  const ann = await nodeBox(page, ANNOTATION)
+  // Grab the source task's bottom arc and drag onto the annotation's centre.
+  await page.mouse.move(src.x + src.width / 2, src.y + src.height + 6)
+  await page.waitForTimeout(120)
+  await page.mouse.down()
+  await page.mouse.move(ann.x + ann.width / 2, ann.y + ann.height / 2, {
+    steps: 16,
+  })
+  await page.waitForTimeout(60)
+  await page.mouse.up()
+  await page.waitForTimeout(200)
+  expect(await edgeCount(), "no edge attaches to a BPMN annotation").toBe(
+    before
+  )
+})

--- a/standalone/webapp/tests/e2e/shape-aware-connections.spec.ts
+++ b/standalone/webapp/tests/e2e/shape-aware-connections.spec.ts
@@ -58,23 +58,43 @@ test("connecting to a use-case oval lands the endpoint on the ellipse curve, not
   const inv = await nodeBox(page, INVENTORY)
   const aim = { x: inv.x + inv.width - 12, y: inv.y + 12 }
 
+  const edgeIds = () =>
+    page.evaluate(() =>
+      Array.from(document.querySelectorAll(".react-flow__edge[data-id]")).map(
+        (e) => (e as HTMLElement).dataset.id as string
+      )
+    )
+  const beforeIds = await edgeIds()
+
   await page.mouse.move(hb!.x + hb!.width / 2, hb!.y + hb!.height / 2)
   await page.mouse.down()
   await page.mouse.move(aim.x, aim.y, { steps: 16 })
   await page.mouse.up()
-  await page.waitForTimeout(250)
+
+  // Isolate the edge just drawn — scanning ALL edges would let a pre-existing
+  // edge's endpoint satisfy the assertion even if this connection never formed.
+  let newEdgeId: string | undefined
+  await expect
+    .poll(
+      async () => {
+        newEdgeId = (await edgeIds()).find((cur) => !beforeIds.includes(cur))
+        return newEdgeId
+      },
+      { message: "a connection to the oval must be created" }
+    )
+    .toBeTruthy()
 
   const g = await ovalGeom(page, INVENTORY)
-  // The endpoint of some edge closest to the Inventory oval's centre.
-  const end = await page.evaluate((geom) => {
-    const paths = Array.from(
-      document.querySelectorAll(".react-flow__edge path.react-flow__edge-path")
-    ) as SVGPathElement[]
-    let best: { x: number; y: number } | null = null
-    let bestD = Infinity
-    for (const p of paths) {
-      const ctm = p.getScreenCTM()
-      if (!ctm || p.getTotalLength() === 0) continue
+  // The endpoint of the NEW edge closest to the Inventory oval's centre.
+  const end = await page.evaluate(
+    ({ geom, id }) => {
+      const p = document.querySelector(
+        `.react-flow__edge[data-id="${id}"] path.react-flow__edge-path`
+      ) as SVGPathElement | null
+      const ctm = p?.getScreenCTM()
+      if (!p || !ctm || p.getTotalLength() === 0) return null
+      let best: { x: number; y: number } | null = null
+      let bestD = Infinity
       for (const len of [0, p.getTotalLength()]) {
         const q = p.getPointAtLength(len)
         const m = new DOMPoint(q.x, q.y).matrixTransform(ctm)
@@ -84,11 +104,12 @@ test("connecting to a use-case oval lands the endpoint on the ellipse curve, not
           best = { x: m.x, y: m.y }
         }
       }
-    }
-    return best
-  }, g)
+      return best
+    },
+    { geom: g, id: newEdgeId as string }
+  )
 
-  expect(end, "a connection to the oval must exist").toBeTruthy()
+  expect(end, "the new edge's endpoint must exist").toBeTruthy()
   // On the ellipse, ((x-cx)/rx)² + ((y-cy)/ry)² == 1. The bbox top-right corner
   // would be ~2. Allow a little slack for the arrow-marker gap.
   const onEllipse =
@@ -151,7 +172,8 @@ test("an edge endpoint can be reconnected onto a container node (e.g. an Activit
   await page.waitForTimeout(250)
 
   const after = await targetEnd()
-  expect(before && after).toBeTruthy()
+  expect(before, "endpoint existed before reconnect").toBeTruthy()
+  expect(after, "endpoint exists after reconnect").toBeTruthy()
   // The endpoint moved and now sits on the container's border.
   expect(
     Math.hypot(after!.x - before!.x, after!.y - before!.y)
@@ -570,11 +592,11 @@ test("a connection arc is grabbable when approached directly, not only via the b
     await page.mouse.down()
     await page.mouse.move(b.x + b.width / 2, b.y + b.height / 2, { steps: 14 })
     await page.mouse.up()
-    await page.waitForTimeout(150)
-    expect(
-      await edgeCount(),
-      `${side} arc must be grabbable from outside`
-    ).toBe(before + 1)
+    await expect
+      .poll(edgeCount, {
+        message: `${side} arc must be grabbable from outside`,
+      })
+      .toBe(before + 1)
   }
 })
 


### PR DESCRIPTION
<!-- PR title = Conventional Commit subject (feat/fix/…). Squash-merge: title + body become the commit. See CONTRIBUTING.md. -->

### Summary
Edge endpoints can be placed and reconnected **anywhere along a node's border**, snapping to the grid, with a dedicated drag handle for moving an endpoint's origin/destination. Attachment is **shape-aware** — the endpoint lands on the node's actual visible outline rather than its bounding box:

- **ellipse** — use-case ovals: on the curve, at the angle you aimed
- **parallelogram** — flowchart input/output: along the slanted edge
- **four-center** — event / gateway / interface nodes: the four N/E/S/W points
- **freeform-rect** — default box shapes: anywhere on the border
- **none** — legends, annotations, swimlanes: correctly not a connection target

### Release note

<!-- User-voice; mirrors the changeset summary that becomes the changelog entry verbatim. -->
Place and reconnect edge endpoints anywhere along a node's border, snapping to the grid, with a drag handle for moving an endpoint. Endpoints attach to each node's real shape rather than its bounding box and match the handles a node shows: use-case ovals connect along their curve, the flowchart input/output parallelogram along its slanted outline, and round or diamond nodes — activity start/end, BPMN events and gateways, flowchart decisions, petri places, and component/deployment interfaces — at their four N/E/S/W points. Legends, annotations, and swimlanes are not connection targets, and endpoints can be reconnected onto container nodes (activity, package, pool, subsystem). Drawing a connection shows a dashed preview that lands exactly where the edge will attach, dragging an endpoint across empty canvas follows the cursor instead of snapping back, connection arcs respond as soon as you reach them, and a connection attaches to the nearest node when several sit close together.

### Implementation notes

A single `getConnectionMode(nodeType)` decides the mode; endpoints are stored as a `{side, ratio}` anchor on the bounding rectangle and projected onto the node's real shape at render. The drop resolver, ghost preview, and rendered edge share `pickNearestConnectable` / `distanceToRect` so a preview never promises a target the drop won't honour.

The stack was hardened by a full-scope audit against `main`:
- **Dead code** — removed an always-true feature flag and its dead branches, unused `edgeUtils` exports, and a dead switch fallback (now a `never` exhaustiveness guard).
- **Single source of truth** — the handle-slot map is derived from the `HandleId` enum instead of a hand-copied table.
- **Dedup** — extracted the shared `useFreeformEndpointNode` hook out of both path hooks; shared the nearest-node math.
- **Tests** — fixed a real e2e bug (a test scanned *all* edges instead of the one under test, so a broken connect could pass); converted flaky sleep-then-snapshot assertions to retrying `expect.poll`.

Verified: tsc, lint, format, schema-gen, unit (1238), and the edge e2e suites are green.

Follow-ups (tracked, not blocking): extract the ~120-line endpoint-drag orchestration still shared verbatim by the two path hooks; model connectable sides as a string-literal union to drop the remaining `Position` casts.

### Screenshots / screencasts

https://github.com/user-attachments/assets/9f227238-efe2-42c5-a76d-8557e09298a0

### Checklist

- [ ] Linked to a related issue (if applicable)
- [x] Added a changeset whose summary is written in the user's voice (`pnpm changeset`)
- [x] PR title's Conventional Commit type (`feat`) matches the kind of change
- [x] Tests added or updated
- [x] Ran `pnpm lint && pnpm format:check && pnpm build && pnpm test` locally — green
- [ ] Documentation updated (if applicable)
- [x] Screenshots or screencasts attached