### PR TITLE
fix(library): stop overhanging & hidden hit areas from stealing clicks (node handles, resize, edge toolbar)

### DIFF
--- a/.changeset/fix-edge-toolbar-anchor-click.md
+++ b/.changeset/fix-edge-toolbar-anchor-click.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Clicking empty canvas near an edge no longer selects that edge: the edge's edit/delete toolbar was anchored to an invisible box offset from the line that captured clicks. An edge is now selected only by clicking its actual line.

--- a/.changeset/fix-node-affordance-click-through.md
+++ b/.changeset/fix-node-affordance-click-through.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Selecting a node no longer blocks clicks on a node overlapping it: the selected node's connection points and resize handles stick out past its edges, and they used to swallow clicks meant for the node beneath. They now only capture while you hover the node (which is how you reach for them anyway), so an overlapping node stays selectable everywhere it's visible.

--- a/library/lib/components/toolbars/edgeToolBar/CustomEdgeToolBar.tsx
+++ b/library/lib/components/toolbars/edgeToolBar/CustomEdgeToolBar.tsx
@@ -64,7 +64,12 @@ export const CustomEdgeToolbar: React.FC<CustomEdgeToolbarProps> = ({
         x={toolbarPosition.x + 20 - SHADOW_MARGIN}
         y={toolbarPosition.y + 20 - SHADOW_MARGIN}
         overflow="visible"
-        style={{ overflow: "visible" }}
+        // The foreignObject is ALWAYS present (it anchors the popover) and sits
+        // offset from the edge line, so if it captured the pointer it would select
+        // the edge from an empty region well away from the visible line. Keep the
+        // box transparent to the pointer; the toolbar buttons re-enable themselves
+        // (`.apollon-edge-toolbar > *`). Anchoring is geometric, so it's unaffected.
+        style={{ overflow: "visible", pointerEvents: "none" }}
       >
         {showToolbar && (
           // `.apollon-edge-toolbar` makes only the buttons (not the box body)

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -651,6 +651,7 @@
   background-color: var(--apollon-primary, #3e8acc);
   opacity: 0.4;
   box-sizing: border-box;
+
   /* Off by default; only grabbable while the node is hovered (or in click-to-
      connect guidance mode) — see the hit-area note near the hover rules below. */
   pointer-events: none;
@@ -736,11 +737,13 @@
 .react-flow__handle.connectionindicator {
   pointer-events: none;
 }
+
 .react-flow__node:hover .react-flow__handle,
-.react-flow__node:hover .react-flow__handle.connectionindicator,
-.apollon-editor--connection-guidance .react-flow__handle.connectionindicator {
+.apollon-editor--connection-guidance .react-flow__handle.connectionindicator,
+.react-flow__node:hover .react-flow__handle.connectionindicator {
   pointer-events: all;
 }
+
 /* The arc ::before is armed on hover too, but scoped OUT of guidance mode: its
    selector would otherwise out-specify the guidance "arcs off" rule below and
    re-arm an invisible (opacity:0) arc, swallowing clicks over neighbours — the

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -651,7 +651,9 @@
   background-color: var(--apollon-primary, #3e8acc);
   opacity: 0.4;
   box-sizing: border-box;
-  pointer-events: all;
+  /* Off by default; only grabbable while the node is hovered (or in click-to-
+     connect guidance mode) — see the hit-area note near the hover rules below. */
+  pointer-events: none;
   cursor: crosshair;
 
   /* --arc-scale is set by DefaultNodeWrapper to 1/zoom so the indicator keeps
@@ -711,24 +713,48 @@
   transition: opacity 120ms ease;
 }
 
+/* Hit-area rule (generalises the #791 node-toolbar fix): a node's resize controls
+   and connection handles PROTRUDE past its box — resize handles straddle the
+   corners, connection arcs stick ~14px outside the edge. A selected node is also
+   lifted above its neighbours (`elevateNodesOnSelect`), so if these protruding
+   affordances captured the pointer merely because the node is selected, they would
+   swallow clicks meant for an overlapping node sitting beneath them. So they SHOW
+   when selected but only become pointer-interactive when the node is HOVERED —
+   every gesture that uses them (grab a resize handle, drag out a connection) starts
+   by hovering the node, so nothing is lost, while a selected-not-hovered node lets
+   clicks fall through to whatever it overlaps. */
+.react-flow__node:hover .react-flow__resize-control {
+  pointer-events: all;
+}
 .react-flow__node:hover .react-flow__resize-control,
 .react-flow__node.selected .react-flow__resize-control {
   opacity: 1;
+}
+
+/* React Flow marks every connectable handle `.connectionindicator` and gives it
+   `pointer-events: all` unconditionally; override that so handles follow the
+   hover-gated model above. Click-to-connect guidance mode is exempt (its circle
+   handles are clicked without hovering their node); guidance hides the arcs, so
+   only `.connectionindicator` is re-enabled there, not the arc ::before. */
+.react-flow__handle.connectionindicator {
+  pointer-events: none;
+}
+.react-flow__node:hover .react-flow__handle,
+.react-flow__node:hover .react-flow__handle.connectionindicator,
+.react-flow__node:hover .react-flow__handle.apollon-arc-handle::before,
+.apollon-editor--connection-guidance .react-flow__handle.connectionindicator {
   pointer-events: all;
 }
 
 .react-flow__node:hover .react-flow__handle {
   opacity: 1;
   background-color: transparent;
-  pointer-events: all;
   cursor: crosshair;
 }
 
 .react-flow__node.selected .react-flow__handle {
   opacity: 1;
   background-color: transparent;
-  pointer-events: all;
-  cursor: crosshair;
 }
 
 .apollon-editor--connection-guidance

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -738,8 +738,17 @@
 }
 .react-flow__node:hover .react-flow__handle,
 .react-flow__node:hover .react-flow__handle.connectionindicator,
-.react-flow__node:hover .react-flow__handle.apollon-arc-handle::before,
 .apollon-editor--connection-guidance .react-flow__handle.connectionindicator {
+  pointer-events: all;
+}
+/* The arc ::before is armed on hover too, but scoped OUT of guidance mode: its
+   selector would otherwise out-specify the guidance "arcs off" rule below and
+   re-arm an invisible (opacity:0) arc, swallowing clicks over neighbours — the
+   very bug this fix removes. Guidance drives connections from the circle handle,
+   not the arc, so the arc stays inert there. */
+.apollon-editor:not(.apollon-editor--connection-guidance)
+  .react-flow__node:hover
+  .react-flow__handle.apollon-arc-handle::before {
   pointer-events: all;
 }
 

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -713,16 +713,13 @@
   transition: opacity 120ms ease;
 }
 
-/* Hit-area rule (generalises the #791 node-toolbar fix): a node's resize controls
-   and connection handles PROTRUDE past its box — resize handles straddle the
-   corners, connection arcs stick ~14px outside the edge. A selected node is also
-   lifted above its neighbours (`elevateNodesOnSelect`), so if these protruding
-   affordances captured the pointer merely because the node is selected, they would
-   swallow clicks meant for an overlapping node sitting beneath them. So they SHOW
-   when selected but only become pointer-interactive when the node is HOVERED —
-   every gesture that uses them (grab a resize handle, drag out a connection) starts
-   by hovering the node, so nothing is lost, while a selected-not-hovered node lets
-   clicks fall through to whatever it overlaps. */
+/* Hit-area fix (same idea as the #791 node-toolbar fix). A node's resize controls
+   and connection arcs PROTRUDE past its box, and a selected node is lifted above
+   its neighbours (`elevateNodesOnSelect`), so arming these affordances just because
+   the node is selected makes them swallow clicks meant for an overlapping node
+   beneath them. On a fine pointer we arm them on :hover instead — every gesture
+   that uses them starts by hovering — so a selected-not-hovered node lets clicks
+   fall through. Touch has no :hover; see the coarse-pointer fallback below. */
 .react-flow__node:hover .react-flow__resize-control {
   pointer-events: all;
 }
@@ -761,6 +758,23 @@
   .react-flow__handle.apollon-arc-handle::before {
   opacity: 0;
   pointer-events: none;
+}
+
+/* Coarse-pointer fallback for the hit-area fix above. Touch devices never fire
+   :hover, so the hover-gated rules would leave a selected node's affordances
+   ungrabbable — you could not start a connection or resize with a finger. Arm
+   them on selection instead, matching pre-fix behaviour. (A coarse pointer can't
+   hover to disambiguate an overlap anyway, so it keeps the swallow the fine-pointer
+   path removes.) The arc ::before is excluded in guidance mode so its hidden arcs
+   stay inert while the circle handles drive the connection. */
+@media (hover: none), (pointer: coarse) {
+  .react-flow__node.selected .react-flow__handle.connectionindicator,
+  .react-flow__node.selected .react-flow__resize-control,
+  .apollon-editor:not(.apollon-editor--connection-guidance)
+    .react-flow__node.selected
+    .react-flow__handle.apollon-arc-handle::before {
+    pointer-events: all;
+  }
 }
 
 /* During connection guidance, lift only the source and target nodes (and their

--- a/standalone/webapp/tests/e2e/edge-toolbar-anchor-click-through.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-toolbar-anchor-click-through.spec.ts
@@ -5,13 +5,9 @@ import { fileURLToPath } from "url"
 import { openFixtureInLocalEditor, waitForCanvasReady } from "../helpers/canvas"
 
 /**
- * An edge's edit/delete toolbar is anchored to an SVG <foreignObject> that is
- * ALWAYS present (it positions the popover) and sits OFFSET from the edge line —
- * its box doesn't overlap the visible edge at all. If that box captured the
- * pointer it would select the edge from an empty region ~50px away from the line.
- * The box must be transparent to the pointer: an edge is selected only by clicking
- * its line, while the toolbar's own buttons stay clickable. Same hit-area fix as
- * the node toolbar (#791) and the node handles.
+ * The edge toolbar's <foreignObject> anchor sits offset from the edge line and is
+ * always present, so it must not capture clicks: an edge is selected only by its
+ * line, while the toolbar buttons stay clickable. (Why: CustomEdgeToolBar.tsx.)
  */
 
 const __dirname2 = path.dirname(fileURLToPath(import.meta.url))

--- a/standalone/webapp/tests/e2e/edge-toolbar-anchor-click-through.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-toolbar-anchor-click-through.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect, type Page } from "@playwright/test"
+import fs from "fs"
+import path from "path"
+import { fileURLToPath } from "url"
+import { openFixtureInLocalEditor, waitForCanvasReady } from "../helpers/canvas"
+
+/**
+ * An edge's edit/delete toolbar is anchored to an SVG <foreignObject> that is
+ * ALWAYS present (it positions the popover) and sits OFFSET from the edge line —
+ * its box doesn't overlap the visible edge at all. If that box captured the
+ * pointer it would select the edge from an empty region ~50px away from the line.
+ * The box must be transparent to the pointer: an edge is selected only by clicking
+ * its line, while the toolbar's own buttons stay clickable. Same hit-area fix as
+ * the node toolbar (#791) and the node handles.
+ */
+
+const __dirname2 = path.dirname(fileURLToPath(import.meta.url))
+const classDiagram = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname2, "..", "fixtures", "class-diagram.json"),
+    "utf-8"
+  )
+) as Record<string, unknown>
+
+const EDGE = "edge-inheritance-dog-animal"
+
+const edgeLoc = (page: Page) =>
+  page.locator(`.react-flow__edge[data-id="${EDGE}"]`)
+
+/** Click a point ON the edge's actual line (25% along the path). */
+async function clickEdgeLine(page: Page): Promise<void> {
+  const pt = await page.evaluate((id) => {
+    const p = document
+      .querySelector(`.react-flow__edge[data-id="${id}"]`)
+      ?.querySelector("path.react-flow__edge-path") as SVGPathElement | null
+    const ctm = p?.getScreenCTM()
+    if (!p || !ctm) return null
+    const at = p.getPointAtLength(p.getTotalLength() * 0.25)
+    const s = new DOMPoint(at.x, at.y).matrixTransform(ctm)
+    return { x: s.x, y: s.y }
+  }, EDGE)
+  if (!pt) throw new Error("edge path not found")
+  await page.mouse.click(pt.x, pt.y)
+  await page.waitForTimeout(200)
+}
+
+const selectedEdgeIds = (page: Page) =>
+  page.evaluate(() =>
+    Array.from(document.querySelectorAll(".react-flow__edge.selected")).map(
+      (e) => e.getAttribute("data-id")
+    )
+  )
+
+test("the edge toolbar's offset anchor box does not select the edge", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, classDiagram)
+  await waitForCanvasReady(page)
+
+  // The <foreignObject> anchor is present even while the edge is unselected.
+  const foBox = (await edgeLoc(page)
+    .locator("foreignObject")
+    .first()
+    .boundingBox())!
+  const lineBox = (await edgeLoc(page)
+    .locator(".edge-overlay")
+    .first()
+    .boundingBox())!
+
+  // Sanity: the anchor box really is off the visible line (this is what makes a
+  // click there surprising).
+  const anchorRight = foBox.x + foBox.width
+  expect(anchorRight).toBeLessThanOrEqual(lineBox.x + 1)
+
+  // Click inside the anchor box, well away from the line: must NOT select the edge.
+  await page.mouse.click(foBox.x + 4, foBox.y + 4)
+  await page.waitForTimeout(200)
+  expect(await selectedEdgeIds(page)).toEqual([])
+})
+
+test("clicking the edge line still selects the edge", async ({ page }) => {
+  await openFixtureInLocalEditor(page, classDiagram)
+  await waitForCanvasReady(page)
+
+  await clickEdgeLine(page)
+  expect(await selectedEdgeIds(page)).toEqual([EDGE])
+})
+
+test("the selected edge's toolbar buttons still work (foreignObject stays transparent)", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, classDiagram)
+  await waitForCanvasReady(page)
+
+  await clickEdgeLine(page)
+  expect(await selectedEdgeIds(page)).toEqual([EDGE])
+
+  // The edit (pencil) button sits inside the pointer-events:none foreignObject
+  // and must still receive the click, opening the edit popover.
+  await edgeLoc(page).getByRole("button", { name: "Edit edge" }).click()
+  await page.waitForTimeout(200)
+  await expect(page.locator(".apollon-popover")).toHaveCount(1)
+})

--- a/standalone/webapp/tests/e2e/node-affordance-click-through.spec.ts
+++ b/standalone/webapp/tests/e2e/node-affordance-click-through.spec.ts
@@ -2,17 +2,10 @@ import { test, expect, type Page, type Locator } from "@playwright/test"
 import { openFixtureInLocalEditor, waitForCanvasReady } from "../helpers/canvas"
 
 /**
- * Generalises the node-toolbar click-through fix (#791) to a node's OTHER
- * floating affordances: its connection handles (arcs that stick ~14px past the
- * node edge) and its resize handles (8px squares straddling the corners).
- *
- * Selecting a node lifts it above its neighbours (`elevateNodesOnSelect`). If
- * those protruding affordances captured the pointer just because the node is
- * selected, they'd swallow clicks meant for an overlapping node sitting beneath
- * them — the node becomes unselectable exactly where the affordances overhang it.
- * They must show when selected but only capture while the node is HOVERED (every
- * gesture that uses them starts by hovering the node), so a selected-not-hovered
- * node lets clicks fall through to whatever it overlaps.
+ * A selected node is lifted above its neighbours (`elevateNodesOnSelect`), so its
+ * protruding connection arcs and corner resize handles must not swallow clicks
+ * meant for an overlapping node beneath them. On a fine pointer they capture only
+ * while hovered; on touch, only once selected. (Why: app.css "Hit-area fix".)
  */
 
 // Beta covers Alpha's right third, so Alpha's right-edge connection handles and
@@ -162,4 +155,52 @@ test("a hovered node still starts a connection from its handle (not over-correct
   await page.waitForTimeout(300)
 
   await expect(page.locator(".react-flow__edge")).toHaveCount(1)
+})
+
+test.describe("touch / coarse pointer", () => {
+  // Touch devices never fire :hover, so the hover gating above must fall back to
+  // arming affordances on selection — otherwise a finger could never start a
+  // connection or resize. isMobile makes matchMedia report (pointer: coarse) /
+  // (hover: none); it is Chromium-only.
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "isMobile emulation is Chromium-only"
+  )
+  test.use({
+    isMobile: true,
+    hasTouch: true,
+    viewport: { width: 800, height: 900 },
+  })
+
+  test("a selected node keeps its handles grabbable on touch", async ({
+    page,
+  }) => {
+    await openFixtureInLocalEditor(
+      page,
+      OVERLAP_MODEL as Record<string, unknown>
+    )
+    await waitForCanvasReady(page)
+
+    const alpha = node(page, "Alpha")
+    const aBox = (await alpha.boundingBox())!
+    await page.mouse.click(aBox.x + 12, aBox.y + aBox.height / 2)
+    await page.waitForTimeout(200)
+    expect(await selectedNames(page)).toEqual(["Alpha"])
+
+    const pe = await page.evaluate(() => {
+      const sel = document.querySelector(".react-flow__node.selected")
+      const handle = sel?.querySelector(
+        ".react-flow__handle.connectionindicator"
+      )
+      const resize = sel?.querySelector(".react-flow__resize-control")
+      return {
+        coarse: window.matchMedia("(pointer: coarse)").matches,
+        handle: handle ? getComputedStyle(handle).pointerEvents : null,
+        resize: resize ? getComputedStyle(resize).pointerEvents : null,
+      }
+    })
+    expect(pe.coarse).toBe(true)
+    expect(pe.handle).toBe("all")
+    expect(pe.resize).toBe("all")
+  })
 })

--- a/standalone/webapp/tests/e2e/node-affordance-click-through.spec.ts
+++ b/standalone/webapp/tests/e2e/node-affordance-click-through.spec.ts
@@ -157,6 +157,41 @@ test("a hovered node still starts a connection from its handle (not over-correct
   await expect(page.locator(".react-flow__edge")).toHaveCount(1)
 })
 
+test("hovering an arc during connection guidance keeps it inert (no invisible swallow)", async ({
+  page,
+}) => {
+  // Guidance hides the arcs and connects from the circle handles. The hover rule
+  // that arms the arc ::before must NOT out-specify the guidance "arcs off" rule,
+  // or a hovered node re-arms an invisible (opacity:0) arc that swallows clicks
+  // over its neighbours — the bug this fix removes.
+  await openFixtureInLocalEditor(page, OVERLAP_MODEL as Record<string, unknown>)
+  await waitForCanvasReady(page)
+
+  const arcBeforePE = () =>
+    page.evaluate(() => {
+      const arc = document.querySelector(
+        ".react-flow__node .react-flow__handle.apollon-arc-handle"
+      )
+      return arc ? getComputedStyle(arc, "::before").pointerEvents : null
+    })
+
+  const setGuidance = (on: boolean) =>
+    page.evaluate((g) => {
+      document
+        .querySelector(".apollon-editor")!
+        .classList.toggle("apollon-editor--connection-guidance", g)
+    }, on)
+
+  await node(page, "Alpha").hover()
+  await page.waitForTimeout(120)
+  expect(await arcBeforePE()).toBe("all") // grabbable normally
+
+  await setGuidance(true)
+  await node(page, "Alpha").hover()
+  await page.waitForTimeout(120)
+  expect(await arcBeforePE()).toBe("none") // inert during guidance
+})
+
 test.describe("touch / coarse pointer", () => {
   // Touch devices never fire :hover, so the hover gating above must fall back to
   // arming affordances on selection — otherwise a finger could never start a

--- a/standalone/webapp/tests/e2e/node-affordance-click-through.spec.ts
+++ b/standalone/webapp/tests/e2e/node-affordance-click-through.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect, type Page, type Locator } from "@playwright/test"
+import { openFixtureInLocalEditor, waitForCanvasReady } from "../helpers/canvas"
+
+/**
+ * Generalises the node-toolbar click-through fix (#791) to a node's OTHER
+ * floating affordances: its connection handles (arcs that stick ~14px past the
+ * node edge) and its resize handles (8px squares straddling the corners).
+ *
+ * Selecting a node lifts it above its neighbours (`elevateNodesOnSelect`). If
+ * those protruding affordances captured the pointer just because the node is
+ * selected, they'd swallow clicks meant for an overlapping node sitting beneath
+ * them — the node becomes unselectable exactly where the affordances overhang it.
+ * They must show when selected but only capture while the node is HOVERED (every
+ * gesture that uses them starts by hovering the node), so a selected-not-hovered
+ * node lets clicks fall through to whatever it overlaps.
+ */
+
+// Beta covers Alpha's right third, so Alpha's right-edge connection handles and
+// top-right resize handle land on top of Beta once Alpha is selected+elevated.
+const OVERLAP_MODEL = {
+  id: "e2e-affordance-blocking",
+  type: "ClassDiagram",
+  version: "4.0.0",
+  title: "affordance blocking",
+  assessments: {},
+  edges: [],
+  nodes: [
+    {
+      id: "alpha-0000-0000-0000-000000000001",
+      type: "class",
+      width: 200,
+      height: 120,
+      position: { x: 250, y: 300 },
+      measured: { width: 200, height: 120 },
+      data: { name: "Alpha", attributes: [], methods: [] },
+    },
+    {
+      id: "beta-0000-0000-0000-0000000000002",
+      type: "class",
+      width: 200,
+      height: 120,
+      position: { x: 400, y: 300 }, // overlaps Alpha's right 50px
+      measured: { width: 200, height: 120 },
+      data: { name: "Beta", attributes: [], methods: [] },
+    },
+  ],
+}
+
+const CONNECT_MODEL = {
+  id: "e2e-affordance-connect",
+  type: "ClassDiagram",
+  version: "4.0.0",
+  title: "affordance connect",
+  assessments: {},
+  edges: [],
+  nodes: [
+    {
+      id: "src0-0000-0000-0000-000000000001",
+      type: "class",
+      width: 160,
+      height: 90,
+      position: { x: 220, y: 320 },
+      measured: { width: 160, height: 90 },
+      data: { name: "Src", attributes: [], methods: [] },
+    },
+    {
+      id: "tgt0-0000-0000-0000-000000000002",
+      type: "class",
+      width: 160,
+      height: 90,
+      position: { x: 520, y: 320 },
+      measured: { width: 160, height: 90 },
+      data: { name: "Tgt", attributes: [], methods: [] },
+    },
+  ],
+}
+
+const selectedNames = (page: Page) =>
+  page.evaluate(() =>
+    Array.from(document.querySelectorAll(".react-flow__node.selected")).map(
+      (n) => (n.textContent || "").replace(/\s+/g, " ").trim().slice(0, 5)
+    )
+  )
+
+const node = (page: Page, name: string): Locator =>
+  page.locator(".react-flow__node").filter({ hasText: name })
+
+test("a selected node's connection handles don't block an overlapping node", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, OVERLAP_MODEL as Record<string, unknown>)
+  await waitForCanvasReady(page)
+
+  const alpha = node(page, "Alpha")
+  const aBox = (await alpha.boundingBox())!
+
+  // Select Alpha via its left strip (clear of Beta), then move the pointer away
+  // so Alpha is selected but NOT hovered — the realistic state when you next go
+  // to click a different node.
+  await page.mouse.click(aBox.x + 12, aBox.y + aBox.height / 2)
+  await page.waitForTimeout(200)
+  expect(await selectedNames(page)).toEqual(["Alpha"])
+  await page.mouse.move(aBox.x + aBox.width / 2, aBox.y - 140)
+  await page.waitForTimeout(120)
+
+  // Click a few px PAST Alpha's right edge, over Beta — the strip where Alpha's
+  // right-side connection arcs protrude. It must reach Beta, not Alpha's handle.
+  await page.mouse.click(aBox.x + aBox.width + 5, aBox.y + aBox.height / 2)
+  await page.waitForTimeout(200)
+  expect(await selectedNames(page)).toEqual(["Beta"])
+})
+
+test("a selected node's resize handle doesn't block an overlapping node", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, OVERLAP_MODEL as Record<string, unknown>)
+  await waitForCanvasReady(page)
+
+  const alpha = node(page, "Alpha")
+  const aBox = (await alpha.boundingBox())!
+
+  await page.mouse.click(aBox.x + 12, aBox.y + aBox.height / 2)
+  await page.waitForTimeout(200)
+  expect(await selectedNames(page)).toEqual(["Alpha"])
+  await page.mouse.move(aBox.x + aBox.width / 2, aBox.y - 140)
+  await page.waitForTimeout(120)
+
+  // Alpha's top-right resize handle straddles Alpha's corner and overhangs onto
+  // Beta. Aim at the part of that handle that lies PAST Alpha's right edge (so
+  // it's over Beta, not Alpha's body): unfixed, the handle swallows the click.
+  const rh = (await alpha
+    .locator(".react-flow__resize-control.handle.top.right")
+    .boundingBox())!
+  const overhangX = Math.max(rh.x + rh.width - 1, aBox.x + aBox.width + 1)
+  await page.mouse.click(overhangX, rh.y + rh.height - 1)
+  await page.waitForTimeout(200)
+  expect(await selectedNames(page)).toEqual(["Beta"])
+})
+
+test("a hovered node still starts a connection from its handle (not over-corrected)", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, CONNECT_MODEL as Record<string, unknown>)
+  await waitForCanvasReady(page)
+
+  const src = node(page, "Src")
+  const tgt = node(page, "Tgt")
+
+  // Hover the source so its handles activate, then drag from its right handle
+  // onto the target — the standard connect gesture.
+  await src.hover()
+  await page.waitForTimeout(120)
+  const handle = src
+    .locator('.react-flow__handle[data-handleid="right"]')
+    .first()
+  const hb = (await handle.boundingBox())!
+  const tb = (await tgt.boundingBox())!
+  await page.mouse.move(hb.x + hb.width / 2, hb.y + hb.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(tb.x + tb.width / 2, tb.y + tb.height / 2, { steps: 8 })
+  await page.mouse.up()
+  await page.waitForTimeout(300)
+
+  await expect(page.locator(".react-flow__edge")).toHaveCount(1)
+})


### PR DESCRIPTION
## Summary

Selecting an element in the editor could make its **invisible or overhanging hit areas steal clicks** meant for something else — the same class of bug fixed for the node toolbar in #791, now on a node's other floating affordances and on edges.

Two symptoms, one root cause (a hit area larger than the thing you can actually see):

1. **A selected node blocked the node beneath it.** A selected node is lifted above its neighbours (`elevateNodesOnSelect`), and its connection arcs (~14 px past the edge) and corner resize handles kept capturing the pointer, so you couldn't click an overlapping node exactly where those affordances overhang it.
2. **An edge selected itself from empty canvas.** The edge edit/delete toolbar is anchored to an always-present `<foreignObject>` sitting ~50 px *off* the edge line. That empty box captured clicks, so clicking blank canvas near an edge selected it. An edge should select only by clicking its line.

The fix gates each affordance so it captures the pointer **only when you're actually about to use it**, and makes the edge toolbar anchor transparent to the pointer while keeping its buttons clickable.

## Release note

Clicking near an edge or an overlapping node now behaves as expected: an edge is selected only by clicking its line, and selecting a node no longer blocks clicks on a node overlapping it.

## Implementation notes

**Node handles & resize controls (`app.css`).** On a fine pointer these are armed (`pointer-events: all`) only while the node is `:hover`ed — every gesture that uses them starts by hovering — so a selected-but-not-hovered node lets clicks fall through. This required explicitly overriding React Flow's unconditional `.connectionindicator { pointer-events: all }`.

**Touch parity (`@media (hover: none), (pointer: coarse)`).** Touch devices never fire `:hover`, so the rules above would leave a selected node's affordances ungrabbable (you couldn't start a connection or resize with a finger — a regression vs. `main`, where `.selected` armed them). A coarse-pointer fallback arms them on selection instead. A pure-touch pointer can't hover to disambiguate an overlap anyway; hybrid devices follow their **primary** pointer.

**Guidance mode stays inert.** Click-to-connect guidance drives connections from the circle handles and hides the arcs. The arc-`::before` hover/coarse rules are scoped `:not(.apollon-editor--connection-guidance)` so they can't out-specify the "arcs off" rule and re-arm an *invisible* arc that would swallow clicks over neighbours.

**Edge toolbar anchor (`CustomEdgeToolBar.tsx`).** The `<foreignObject>` is set `pointer-events: none`; its buttons re-enable via `.apollon-edge-toolbar > *`. Anchoring is geometric, so the popover still positions correctly.

## Steps for testing

1. Overlap two class nodes. Select one (elevating it) and click the other where they overlap — the second selects (previously the first's handles/resize swallowed the click).
2. Click blank canvas a few px beside an edge — nothing selects. Click the edge line — it selects. Select an edge and use its edit/delete buttons — still work.
3. On touch / mobile emulation: select a node and start a connection or resize with a finger — still works.
4. Enter click-to-connect guidance and hover nodes — no invisible arc steals the connection.

## Testing done

- New Playwright specs reproduce each bug (they fail on `main`) and lock in the fix: `node-affordance-click-through.spec.ts` (overlap block, resize block, hover-connect guard, touch grab, guidance-arc inertness) and `edge-toolbar-anchor-click-through.spec.ts` (anchor doesn't select, line still selects, buttons still work).
- Full webapp e2e suite green (139 passed); library lint/build clean; main-entry size unchanged (45.4 kB / 85 kB budget — CSS-only, no JS impact).

## Checklist

- [x] Tested the changes (new e2e + full suite)
- [x] Changesets added (`@tumaet/apollon` patch × 2)
- [x] No new lint errors; bundle size within budget
- [x] No user-facing API change; no migration needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
