### PR TITLE
fix(library): size class-diagram diamonds to match the inheritance triangle

### DIFF
--- a/.changeset/bigger-class-diamonds.md
+++ b/.changeset/bigger-class-diamonds.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Aggregation and composition diamonds in class diagrams are now large enough to read at a glance. They were drawn with only about 70% of the ink of the inheritance triangle next to them, so the filled/hollow distinction was easy to miss at normal zoom. The diamond now carries at least the triangle's visual weight — matching how draw.io and Mermaid proportion the two — while staying no taller, so it never overhangs a class box further than the triangle already did.

--- a/library/lib/constants.ts
+++ b/library/lib/constants.ts
@@ -219,6 +219,14 @@ export const INTERFACE = Object.freeze({
 // (used a few lines below for BPMN message markers).
 export const MARKER_BASE_SIZE = 18
 const BPMN_MARKER_SIZE = 11
+// Aggregation/composition diamonds run longer than the other class markers so
+// they carry at least the inheritance triangle's visual weight, as in draw.io
+// (24-long diamond vs 16-long triangle) and Mermaid (equal areas). Capped at 24
+// because 24 * RHOMBUS_HEIGHT_FACTOR stays under the triangle's height, so the
+// diamond never overhangs a node border further than the triangle does.
+const RHOMBUS_MARKER_SIZE = 24
+// 1/phi, inside the 0.588-0.706 thickness band those tools use.
+const RHOMBUS_HEIGHT_FACTOR = 0.618
 
 export const EDGES = Object.freeze({
   /** Negative padding extends target point to node boundary (React Flow handles are offset 3px) */
@@ -324,20 +332,20 @@ export interface MarkerConfig {
 const INTERFACE_SOCKET_SIZE = INTERFACE_RADIUS // Must equal INTERFACE.SIZE / 2
 
 export const MARKER_CONFIGS = Object.freeze({
-  // Class diagram markers - golden ratio inspired proportions
+  // Class diagram markers
   "black-rhombus": {
     type: "rhombus",
     filled: true,
-    size: MARKER_BASE_SIZE,
+    size: RHOMBUS_MARKER_SIZE,
     widthFactor: 1.0,
-    heightFactor: 0.618,
+    heightFactor: RHOMBUS_HEIGHT_FACTOR,
   },
   "white-rhombus": {
     type: "rhombus",
     filled: false,
-    size: MARKER_BASE_SIZE,
+    size: RHOMBUS_MARKER_SIZE,
     widthFactor: 1.0,
-    heightFactor: 0.618,
+    heightFactor: RHOMBUS_HEIGHT_FACTOR,
   },
   "white-triangle": {
     type: "triangle",

--- a/library/tests/unit/markerGeometry.test.ts
+++ b/library/tests/unit/markerGeometry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { getMarkerHalfHeight } from "@/components/svgs/edges"
+import { MARKER_CONFIGS } from "@/constants"
+
+// The aggregation/composition diamond and the inheritance triangle sit side by
+// side in a class diagram, so what a reader perceives is their proportions, not
+// their absolute sizes. These pin the relationships that set the diamond's size.
+
+// Both shapes are inscribed in their bounding box, so width * height / 2 is
+// their exact area — a proxy for visual weight.
+const inkArea = (id: keyof typeof MARKER_CONFIGS) => {
+  const { size, widthFactor, heightFactor } = MARKER_CONFIGS[id]
+  return (size * widthFactor * (size * heightFactor)) / 2
+}
+
+const height = (id: keyof typeof MARKER_CONFIGS) => getMarkerHalfHeight(id) * 2
+
+describe("class diagram marker geometry", () => {
+  it("draws both diamonds identically apart from the fill", () => {
+    const { filled: _b, ...black } = MARKER_CONFIGS["black-rhombus"]
+    const { filled: _w, ...white } = MARKER_CONFIGS["white-rhombus"]
+    expect(black).toEqual(white)
+    expect(MARKER_CONFIGS["black-rhombus"].filled).toBe(true)
+    expect(MARKER_CONFIGS["white-rhombus"].filled).toBe(false)
+  })
+
+  it("gives the diamond at least the inheritance triangle's visual weight", () => {
+    // draw.io puts the diamond at ~1.32x the triangle's area, Mermaid at 1.0x.
+    expect(inkArea("black-rhombus")).toBeGreaterThanOrEqual(
+      inkArea("white-triangle")
+    )
+  })
+
+  it("keeps the diamond no taller than the inheritance triangle", () => {
+    // Height is the extent perpendicular to the edge: how far a marker overhangs
+    // the node border it points at.
+    expect(height("black-rhombus")).toBeLessThanOrEqual(
+      height("white-triangle")
+    )
+  })
+
+  it("keeps the diamond's thickness in the band used by reference tools", () => {
+    // draw.io 0.588 (diamondThin), PlantUML 0.667, Mermaid 0.706.
+    const { widthFactor, heightFactor } = MARKER_CONFIGS["black-rhombus"]
+    const aspect = heightFactor / widthFactor
+    expect(aspect).toBeGreaterThanOrEqual(0.588)
+    expect(aspect).toBeLessThanOrEqual(0.706)
+  })
+
+  it("keeps the diamond small enough to render unscaled in the edge-type dropdown", () => {
+    // EdgeTypePreviewIcon shrinks markers whose half-height exceeds 11; only the
+    // node-scale interface socket should need that.
+    expect(getMarkerHalfHeight("black-rhombus")).toBeLessThanOrEqual(11)
+  })
+})


### PR DESCRIPTION
### Summary

The aggregation and composition diamonds in class diagrams were drawn too small. Both share `MARKER_BASE_SIZE` (18) with the inheritance triangle, but their `heightFactor` is 0.618 against the triangle's 0.866 — so the diamond ended up with **~71% of the triangle's ink** while sitting right next to it in the same diagram. It read as the lesser glyph, and the hollow-vs-filled distinction (aggregation vs composition — a real semantic difference) was easy to miss at normal zoom.

This gives the diamond its own length, `RHOMBUS_MARKER_SIZE = 24`, and keeps its 1/φ thickness.

|  | length × height | area | vs. triangle |
|---|---|---|---|
| Inheritance triangle | 18 × 15.59 | 140.3 | — |
| Diamond **before** | 18 × 11.12 | 100.1 | **0.71×** |
| Diamond **after** | 24 × 14.83 | 178.0 | **1.27×** |

Only the two rhombus markers change. Triangles, arrows, BPMN markers, and interface sockets are untouched.

### Release note

Aggregation and composition diamonds in class diagrams are now large enough to read at a glance, instead of being noticeably smaller than the inheritance triangle beside them.

### Implementation notes

**UML specifies no marker dimensions.** OMG UML 2.5.1 defines the *notation* (hollow diamond for shared aggregation, filled for composite) but never its size, so there is no spec number to conform to. The only available anchor is what established tools do, and they disagree — so I measured them from source rather than from screenshots:

| Tool | diamond | triangle | diamond area ÷ triangle area | thickness (h/w) |
|---|---|---|---|---|
| [draw.io](https://github.com/jgraph/drawio/blob/dev/src/main/webapp/js/grapheditor/Sidebar.js) (`endSize=24` diamondThin vs `endSize=16` block) | 24 × 14.12 | 16 × 16 | 1.32× | 0.588 |
| [Mermaid](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/rendering-util/rendering-elements/markers.js) (`M 18,7 L9,13 L1,7 L9,1 Z`) | 17 × 12 | 17 × 12 | 1.00× | 0.706 |
| [PlantUML](https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/svek/extremity/ExtremityDiamond.java) (`xWing=6, yAperture=4`) | 12 × 8 | 19 × 14 | 0.36× | 0.667 |
| Apollon (before) | 18 × 11.12 | 18 × 15.59 | 0.71× | 0.618 |

Two conclusions, and I want to be straight about how firm each is:

- **The thickness was already right.** 0.618 sits inside the 0.588–0.706 band all three tools use. This PR doesn't touch it.
- **The size was not.** Two of three tools give the diamond *at least* the triangle's visual weight; Apollon gave it 0.71×. `1.27×` lands between Mermaid and draw.io.

**PlantUML is a genuine counter-example** — it draws the diamond at 0.36× its triangle, i.e. even smaller than Apollon did. I'm not treating a 2-of-3 majority as proof, but PlantUML's tiny diamond is precisely the look this change moves away from, and the rendered comparison below is the real argument.

**Why 24 and not larger.** 24 × 0.618 = 14.83, which stays under the triangle's 15.59 height. Height is the extent *perpendicular* to the edge — i.e. how far a marker overhangs the class box it points at. Staying under the triangle guarantees this change cannot introduce overhang that the triangle doesn't already produce. At 26 the diamond would become taller than the triangle, so 24 is the ceiling, not an arbitrary pick.

**Tests pin proportions, not pixels.** `library/tests/unit/markerGeometry.test.ts` asserts the diamond is at least as heavy as the triangle, no taller than it, within the thickness band, and still small enough to render unscaled in the edge-type dropdown. Someone retuning `MARKER_BASE_SIZE` later stays free to do so; they just can't silently reintroduce the shrunken diamond. I confirmed the suite fails on the old value before keeping it.

**No visual baselines changed, and that's worth flagging.** I regenerated the Playwright baselines inside the pinned CI container (`mcr.microsoft.com/playwright:v1.61.1-noble`, forced to `linux/amd64` to match `ubuntu-latest` — my machine is arm64) and **nothing changed**: the full-canvas screenshots absorb the marker diff under the suite's `maxDiffPixelRatio: 0.01` tolerance. I then re-ran the unmodified `pnpm test:visual` in that same container against the existing baselines — 40/40 pass. So this PR needs no baseline refresh, but it also means **the visual suite does not actually guard marker geometry**; the new unit test is what covers it.

### Steps for testing

1. Open a class diagram and draw an **aggregation** and a **composition** edge between two classes.
2. Add an **inheritance** edge alongside them. The diamond should now read as comparable in weight to the triangle rather than visibly smaller, and the hollow/filled distinction should be obvious without zooming.
3. Confirm neither diamond overhangs the class border further than the inheritance triangle does.
4. Open the edge-type dropdown — the diamond previews render unscaled and unclipped.
5. Export to SVG / PNG / PDF and confirm the diamonds match the canvas.

### Screenshots / screencasts

Not attached — the change is a pure geometry tweak and reads best live. To see it, follow the testing steps above, or check out this branch against `main` with the `class-diagram` fixture: the aggregation diamond on `Vehicle` and the composition diamond on `Color` are the two markers that move.

### Checklist

- [x] Linked to a related issue (if applicable) — no issue; reported directly
- [x] Added a changeset whose summary is written in the user's voice (`pnpm changeset`, [how](https://ls1intum.github.io/Apollon/contributor/development/release-notes/)) — or this PR doesn't touch a Changesets-tracked package (`@tumaet/apollon`, `@tumaet/webapp`, `@tumaet/server`)
- [x] PR title's Conventional Commit type (`feat`/`fix`/…) matches the kind of change — it groups the release note
- [x] Tests added or updated
- [x] Ran `pnpm lint && pnpm format:check && pnpm build && pnpm test` locally — green (lint: 0 errors, 69 warnings, none in the files this PR touches)
- [ ] Documentation updated (if applicable) — no user-facing docs describe marker sizes
- [ ] Screenshots or screencasts attached (if a UI change) — see the note above
