### PR TITLE
fix(ci): release the VS Code extension only when its version changes

### DIFF
--- a/.github/workflows/release-vscode-extension.yml
+++ b/.github/workflows/release-vscode-extension.yml
@@ -33,16 +33,39 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.sha }}
+          # The parent commit too, to read the version this push replaced.
+          fetch-depth: 2
 
       - id: v
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
+          set -euo pipefail
           VERSION=$(node -p "require('./vscode-extension/package.json').version")
           if [[ "$VERSION" == *-* || "$VERSION" == *+* ]]; then
             echo "::error::vscode-extension version $VERSION is not strict SemVer MAJOR.MINOR.PATCH."
             exit 1
           fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          # A release is a version change, and nothing else. This workflow wakes
+          # on any edit to the manifest, which also carries the icon, the
+          # commands and the settings schema — so an unrelated edit would
+          # otherwise ship whatever version happened to be sitting there.
+          # Publishing a version the manifest already held is `workflow_dispatch`,
+          # chosen deliberately.
+          if [ "$EVENT_NAME" = "push" ]; then
+            BEFORE=$(git show "${GITHUB_SHA}^:vscode-extension/package.json" 2>/dev/null \
+              | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version" 2>/dev/null || echo "")
+            if [ "$BEFORE" = "$VERSION" ]; then
+              echo "::notice::vscode-extension stays at $VERSION — the manifest changed, the version did not. Nothing to release."
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              echo "release=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
           MKT=$(curl -s -X POST https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery \
             -H "Content-Type: application/json" -H "Accept: application/json;api-version=7.2-preview.1" \
             -d '{"filters":[{"criteria":[{"filterType":7,"value":"tumaet.apollon-vscode"}]}],"flags":914}' \
@@ -58,7 +81,6 @@ jobs:
           else
             echo "release=true" >> "$GITHUB_OUTPUT"
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build VSIX
@@ -135,6 +157,15 @@ jobs:
     permissions:
       contents: read
     steps:
+      # `.nvmrc` is the one source for the Node version, and this job has no
+      # working tree to read it from. `checkout` cleans the directory, so it has
+      # to precede the artifact download rather than follow it.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: .nvmrc
+          sparse-checkout-cone-mode: false
+
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: vsix
@@ -204,7 +235,13 @@ jobs:
             git tag "$TAG" "$GITHUB_SHA"
             git push origin "refs/tags/$TAG"
           fi
-          VSIX=$(ls *.vsix | head -n1)
+          shopt -s nullglob
+          files=( ./*.vsix )
+          if [[ ${#files[@]} -ne 1 ]]; then
+            echo "::error::Expected exactly 1 VSIX to attach, found ${#files[@]}: ${files[*]}"
+            exit 1
+          fi
+          VSIX="${files[0]}"
           gh release create "$TAG" \
             --title "$TAG" \
             --target "$GITHUB_SHA" \

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,15 @@ GitHub Releases at <https://github.com/ls1intum/Apollon/releases> (tag prefix `a
 
 ## [Unreleased]
 
-First Marketplace release pending. See the linked release workflow for the package state.
+`1.0.0` is pending, and will be the first release cut by the `Release VS Code Extension`
+workflow. It is not the extension's first Marketplace listing: `tumaet.apollon-vscode`
+has been published since 2024-11-18, last at `0.0.17`.
+
+Upgrading from `0.0.17` leaves one trace behind. That version wrote
+`"files.associations": { "*.apollon": "json" }` into global user settings on every
+activation. Nothing writes it now, and nothing removes it either — `.apollon` files still
+open in the Apollon editor, but reopening one as text shows it as JSON rather than under
+this extension's own `apollon` language and file icon. Deleting that line from settings
+restores both.
 
 [Unreleased]: https://github.com/ls1intum/Apollon/compare/main...HEAD


### PR DESCRIPTION
### Summary

Merging #806 fired `Release VS Code Extension` on `main`, which tried to publish `1.0.0` to the VS Marketplace and Open VSX. It failed — [run 29019247178](https://github.com/ls1intum/Apollon/actions/runs/29019247178) — and the failure is the less interesting half of this PR.

**Nothing was published.** The publish job died in `setup-node`, before any credential was read.

### The two faults

**1. The publish job has no working tree.** It downloads the VSIX artifact and never checks the repository out, so `actions/setup-node` with `node-version-file: .nvmrc` fails on a file that isn't there:

```
The specified node version file at: /home/runner/work/Apollon/Apollon/.nvmrc does not exist
```

Fixed with a sparse checkout of `.nvmrc` alone. It has to run *before* `download-artifact`, because `actions/checkout` defaults to `clean: true` and would otherwise delete the `.vsix` it just fetched.

**2. Any edit to `vscode-extension/package.json` was one step from cutting a release.** This is the real bug. The workflow wakes on `paths: [vscode-extension/package.json]`, then decides:

```
publish = manifest version is NOT on the Marketplace
release = no apollon-vscode@<version> GitHub Release exists
```

The manifest has said `1.0.0` since April. The Marketplace is at `0.0.17`. No `apollon-vscode@*` tag or Release has ever existed. So both were unconditionally `true`, for *any* commit touching that file — and the manifest carries the icon, the commands, the categories and the settings schema, none of which are a release. #806 edited three of those and inherited a version bump nobody asked for.

A release is a version change, and nothing else. `check` now compares the manifest's version against the commit the push replaced, and stands down when they match. Publishing a version the manifest already holds is `workflow_dispatch` — chosen deliberately, which is how `1.0.0` should be cut when you decide it's time.

### A correction to #806

That PR's description asserted the extension "has never been published … so there is no installed base holding a stale `files.associations` entry and nothing to migrate." **That was wrong, and I wrote it.** I took `CHANGELOG.md` at its word instead of asking the Marketplace.

`tumaet.apollon-vscode` has been listed since **2024-11-18**, last at `0.0.17`. I downloaded that VSIX and read its bundle: it writes `"files.associations": { "*.apollon": "json" }` into **global** user settings on every activation. So an installed base exists, and it carries that line.

What it means in practice, now that the code writing it is gone:

- `.apollon` files still open in the Apollon editor. The custom editor matches on `filenamePattern`, not on language.
- Reopening one as text shows it as JSON rather than under this extension's own `apollon` language, grammar and file icon.
- Nothing removes the setting. Deleting it restores both.

`CHANGELOG.md` said "First Marketplace release pending"; it now says what is actually true. I've left the stale entry alone rather than have the extension quietly rewrite user settings again — that is the habit #806 removed. **If you'd rather ship a one-time, self-deleting migration that strips `*.apollon` from `files.associations` when it equals `json`, say so and I'll add it** — it is defensible to clean up our own pollution, but it is a settings write, so it should be your call and not mine.

### Verification

`actionlint` is clean on the workflow (it reports two pre-existing `shellcheck` infos on `ls *.vsix` in the release job — both fixed here, so the file now lints green).

The version guard was exercised against real history, in a throwaway worktree:

| Event | Manifest before → after | Outcome |
| --- | --- | --- |
| `push` — the #806 merge (`ecad49ea`) | `1.0.0` → `1.0.0` | `publish=false release=false` — stands down |
| `workflow_dispatch` — same commit | n/a | proceeds to the Marketplace check |
| `push` — a synthesised bump | `1.0.0` → `1.0.1` | proceeds to the Marketplace check |

The first row is the run that failed. With this change it never reaches the publish job.

I could not exercise the `.nvmrc` fix locally — it only fails on a runner with no checkout. It is a three-line, mechanical fix, and the next `workflow_dispatch` (with `dry_run: true`) will confirm the whole path end to end without publishing anything. **That dry run is worth doing before you cut `1.0.0`.**

### Steps for testing

1. Merge. Nothing should happen — this PR does not touch `vscode-extension/package.json`, so the release workflow will not even wake.
2. Push any manifest-only change (e.g. a keyword). The workflow wakes, `check` logs `vscode-extension stays at 1.0.0 — the manifest changed, the version did not`, and every other job is skipped.
3. When you want `1.0.0`: run `Release VS Code Extension` via `workflow_dispatch` with `dry_run: true` to prove the VSIX builds and the publish job survives `setup-node`, then again with `dry_run: false`.

### Checklist

- [ ] Linked to a related issue (if applicable)
- [x] Added a changeset whose summary is written in the user's voice (`pnpm changeset`, [how](https://ls1intum.github.io/Apollon/contributor/development/release-notes/)) — or this PR doesn't touch a Changesets-tracked package (`@tumaet/apollon`, `@tumaet/webapp`, `@tumaet/server`)
- [x] PR title's Conventional Commit type (`feat`/`fix`/…) matches the kind of change — it groups the release note
- [ ] Tests added or updated
- [x] Ran `pnpm lint && pnpm format:check && pnpm build && pnpm test` locally — green
- [x] Documentation updated (if applicable)
- [ ] Screenshots or screencasts attached (if a UI change)

<sub>No changeset: this touches a workflow and the extension's changelog. `apollon-vscode` is on the Changesets ignore list. No tests: GitHub Actions workflows have no test harness in this repo; the version guard was instead exercised directly against the three real cases above.</sub>
