### PR TITLE
fix(docker): stop running dependency install scripts in the image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,12 +32,7 @@ dist/
 standalone/webapp/android
 standalone/webapp/ios
 
-# Keep the vscode-extension package.json files (pnpm install reads them
-# as workspace manifests), but drop the source.
-vscode-extension/src
-vscode-extension/webview/src
-vscode-extension/webview/dist
-vscode-extension/dist
+vscode-extension/
 
 scripts/
 .changeset/

--- a/standalone/server/Dockerfile
+++ b/standalone/server/Dockerfile
@@ -23,12 +23,17 @@ COPY library/package.json ./library/
 # `pnpm deploy` to walk the library's dependency tree.
 COPY packages/ui/package.json ./packages/ui/
 COPY standalone/server/package.json ./standalone/server/
-COPY standalone/webapp/package.json ./standalone/webapp/
-COPY vscode-extension/package.json ./vscode-extension/
-COPY vscode-extension/webview/package.json ./vscode-extension/webview/
 
+# `<pkg>...` selects the server plus the workspaces it depends on, so the only
+# manifests this stage needs are the ones copied above.
+#
+# `--ignore-scripts` keeps the stage hermetic. The dependency lifecycle scripts
+# reachable from here either download a binary over the network or compile C++
+# against a toolchain this slim image deliberately omits; nothing the server is
+# built from, or runs on, needs either. `pnpm deploy` below still builds any
+# production dependency that genuinely requires it.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile
+    pnpm install --frozen-lockfile --ignore-scripts --filter @tumaet/server...
 
 COPY library ./library
 COPY packages/ui ./packages/ui

--- a/standalone/webapp/Dockerfile
+++ b/standalone/webapp/Dockerfile
@@ -16,17 +16,23 @@ WORKDIR /app
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY library/package.json ./library/
-# The library now depends on the @tumaet/ui workspace package; without it the
-# pnpm install can't link it and `pnpm --filter @tumaet/ui run build:*` no-ops,
-# so the library's tsc -b fails to resolve @tumaet/ui/components/*.
+# The library depends on the @tumaet/ui workspace package; without its manifest
+# pnpm can't link it and `pnpm --filter @tumaet/ui run build:*` no-ops, so the
+# library's tsc -b fails to resolve @tumaet/ui/components/*.
 COPY packages/ui/package.json ./packages/ui/
 COPY standalone/webapp/package.json ./standalone/webapp/
-COPY standalone/server/package.json ./standalone/server/
-COPY vscode-extension/package.json ./vscode-extension/
-COPY vscode-extension/webview/package.json ./vscode-extension/webview/
 
+# `<pkg>...` selects the webapp plus the workspaces it depends on, so the only
+# manifests this stage needs are the ones copied above.
+#
+# `--ignore-scripts` keeps the stage hermetic. Every dependency lifecycle script
+# reachable from here either downloads a binary over the network (sharp, pulled
+# in by @capacitor/assets for mobile icon generation) or compiles C++ against a
+# toolchain this slim image deliberately omits (cpu-features). Nothing the
+# webapp bundle is built from needs either, and a script that reaches the
+# network turns an image build into a coin flip on GitHub Releases being up.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile
+    pnpm install --frozen-lockfile --ignore-scripts --filter @tumaet/webapp...
 
 COPY library ./library
 COPY packages/ui ./packages/ui


### PR DESCRIPTION
The arm64 webapp Docker build failed on #807. It was not caused by that PR — the same commit's amd64 leg passed, and #810 ran the identical install on the identical arch minutes earlier. This fixes the two structural reasons the failure was possible.

## What broke

```
sharp install: prebuild-install warn install Request timed out
sharp install: gyp ERR! find Python  Could not find any Python installation to use
ERROR: process "/bin/sh -c pnpm install --frozen-lockfile" did not complete successfully
```

`sharp@0.32.6` fetches a prebuilt binary from GitHub Releases. The download timed out on the emulated arm64 runner, so `sharp` fell back to `node-gyp rebuild` — and `node:24.15.0-slim` carries neither Python nor a C++ toolchain. The install exited 1 and buildx failed. Re-running the job with no code change made it pass, which is the definition of a build that depends on something it shouldn't.

## Root cause, in two parts

**The builders installed every workspace's dependency tree.** Both Dockerfiles copied every workspace manifest and ran an unfiltered `pnpm install --frozen-lockfile`. So the *webapp* image compiled the *server*'s `testcontainers → dockerode → ssh2 → cpu-features` chain, and the *server* image built `sharp`, which it reaches only through `@capacitor/assets` — the webapp's mobile icon tooling. Neither image has any use for either.

Filtering with `<pkg>...` installs a workspace plus the workspaces it depends on, and nothing else.

**The builders executed dependency lifecycle scripts.** A stage that transpiles TypeScript and bundles JavaScript needs no native addon. Yet on a cold store, five install scripts ran — two of them reaching out to the network, one of them falling back to a compiler that is deliberately absent. `--ignore-scripts` removes the entire class of failure instead of the `sharp` instance of it. The next native dependency someone adds cannot reintroduce it.

`allowBuilds` in `pnpm-workspace.yaml` is untouched: it governs host installs, where `sharp` genuinely is needed to generate app icons.

With the unrelated manifests no longer required, the `.dockerignore` carve-out that existed solely to preserve them goes away, and `vscode-extension/` leaves the build context entirely.

## Verification

Built on `linux/arm64` — the arch that failed — natively, with a **cold pnpm store** (a warm store hides this: pnpm's side-effects cache skips the scripts), and diffed against images built from the parent commit.

| | before | after |
| --- | --- | --- |
| lifecycle scripts executed | 5 (`sharp`, `cpu-features`, `ssh2`, `esbuild`, `@swc/core`) | **0** |
| packages resolved (webapp) | 1390 | 1231 |
| `testcontainers`/`dockerode`/`ssh2`/`cpu-features` in webapp builder | present | **gone** |

Artifacts are unchanged:

- **webapp** — 84 files in `/usr/share/nginx/html`, every `sha256sum` identical.
- **server** — 22504 files, `dist/*.js` hashes identical, and the runtime `node_modules` tree identical. That last one is the important one: it proves no production dependency needed its install script, so skipping them cannot ship a broken runtime.

I also confirmed the reverse, that the baseline really does run those scripts on a cold store, so the comparison isn't measuring a no-op.

## One tradeoff, stated plainly

Because the unrelated manifests are gone, the Docker build no longer validates the lockfile against the `server` (in the webapp image), `vscode-extension`, or `webview` importers. A lockfile drift confined to those workspaces would not be caught *here* — it is still caught by the root `pnpm install --frozen-lockfile` in PR Health Checks, which is where that check belongs. This was already true of `docs/`, which has never been in the build context.

## Not fixed here

Both Dockerfiles install `pnpm@11.1.3` while the root `packageManager` field pins `11.8.0`. That skew is real and shouldn't exist, but it is unrelated to this failure and changing it would invalidate the verification above. Worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)