### PR TITLE
fix(library): stop resize cursors on borders a node can't resize

### DIFF
--- a/.changeset/fix-resize-cursor-locked-axis.md
+++ b/.changeset/fix-resize-cursor-locked-axis.md
@@ -2,4 +2,4 @@
 "@tumaet/apollon": patch
 ---
 
-Nodes no longer show a resize cursor on borders that can't resize. A class's height is driven by its attributes and methods, so its top and bottom borders showed a vertical-resize cursor and accepted a drag that did nothing. Content-sized nodes — classes, object and communication-object nodes, SFC action tables and the activity fork bars — now resize only along the axis that can change: the corner handles stay, but they and the cursor only ever point that way.
+Fixed resize handles across every node. Borders that can't resize no longer show a resize cursor — a class's height is driven by its attributes and methods, so its top and bottom borders used to offer a vertical-resize cursor and a drag that did nothing. Content-sized nodes keep their corner handles and resize only along the axis that can change. And on filled nodes such as activity swimlanes, the edge you drag to resize is now grabbable instead of hiding behind the node — previously only the corners worked.

--- a/.changeset/fix-resize-cursor-locked-axis.md
+++ b/.changeset/fix-resize-cursor-locked-axis.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Nodes no longer offer a resize cursor on borders that can't resize. A class's height is driven by its attributes and methods, so its top and bottom borders showed a resize cursor and accepted a drag that did nothing. Content-sized nodes — classes, object and communication-object nodes, SFC action tables and the activity fork bars — now show resize controls only on the borders that can move: drag those side borders, which are easier to grab than before, rather than a corner.

--- a/.changeset/fix-resize-cursor-locked-axis.md
+++ b/.changeset/fix-resize-cursor-locked-axis.md
@@ -2,4 +2,4 @@
 "@tumaet/apollon": patch
 ---
 
-Nodes no longer offer a resize cursor on borders that can't resize. A class's height is driven by its attributes and methods, so its top and bottom borders showed a resize cursor and accepted a drag that did nothing. Content-sized nodes — classes, object and communication-object nodes, SFC action tables and the activity fork bars — now show resize controls only on the borders that can move: drag those side borders, which are easier to grab than before, rather than a corner.
+Nodes no longer show a resize cursor on borders that can't resize. A class's height is driven by its attributes and methods, so its top and bottom borders showed a vertical-resize cursor and accepted a drag that did nothing. Content-sized nodes — classes, object and communication-object nodes, SFC action tables and the activity fork bars — now resize only along the axis that can change: the corner handles stay, but they and the cursor only ever point that way.

--- a/library/eslint.config.mjs
+++ b/library/eslint.config.mjs
@@ -40,11 +40,22 @@ export default [
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
-      // The library styles with Base UI + raw CSS + --apollon-* tokens.
-      // It must never depend on MUI or a CSS-in-JS runtime (Emotion).
+      // `paths`: React Flow's NodeResizer renders controls on axes a node has
+      // pinned, so nodes must reach it through the wrapper that knows the
+      // difference. `patterns`: the library styles with Base UI + raw CSS +
+      // --apollon-* tokens, and must never depend on MUI or a CSS-in-JS
+      // runtime (Emotion).
       "no-restricted-imports": [
         "error",
         {
+          paths: [
+            {
+              name: "@xyflow/react",
+              importNames: ["NodeResizer"],
+              message:
+                "Import NodeResizer from @/nodes/wrappers. React Flow's renders resize controls on axes a node has pinned, which offers a cursor and a drag that do nothing.",
+            },
+          ],
           patterns: [
             {
               group: ["@mui/*", "@mui"],

--- a/library/lib/components/wrapper/FeedbackDropzone.tsx
+++ b/library/lib/components/wrapper/FeedbackDropzone.tsx
@@ -9,7 +9,6 @@ interface Props {
   elementId: string
   elementType?: string
   asElement?: "g" | "div" | "path"
-  className?: string
 }
 
 export const FeedbackDropzone: React.FC<Props> = ({
@@ -17,7 +16,6 @@ export const FeedbackDropzone: React.FC<Props> = ({
   elementId,
   elementType,
   asElement = "g",
-  className,
 }) => {
   const { mode, readonly } = useMetadataStore(
     useShallow((store) => ({
@@ -94,7 +92,6 @@ export const FeedbackDropzone: React.FC<Props> = ({
         onDragLeave={handleDragLeave}
         onDragOver={handleDragOver}
         style={hoverStyle}
-        className={className}
       >
         {children}
       </div>

--- a/library/lib/nodes/TitleAndDescriptionNode.tsx
+++ b/library/lib/nodes/TitleAndDescriptionNode.tsx
@@ -1,5 +1,5 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
-import { DefaultNodeWrapper } from "@/nodes/wrappers"
+import { NodeProps, type Node } from "@xyflow/react"
+import { DefaultNodeWrapper, NodeResizer } from "@/nodes/wrappers"
 import { TitleAndDescriptionSVG } from "@/components"
 
 type Props = Node<{
@@ -30,11 +30,7 @@ export function TitleAndDesctiption({
         title={title}
         description={description || ""}
       />
-      <NodeResizer
-        isVisible
-        minHeight={200}
-        handleStyle={{ width: 8, height: 8 }}
-      />
+      <NodeResizer isVisible minHeight={200} />
     </DefaultNodeWrapper>
   )
 }

--- a/library/lib/nodes/activityDiagram/Activity.tsx
+++ b/library/lib/nodes/activityDiagram/Activity.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -31,7 +31,6 @@ export function Activity({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <ActivitySVG

--- a/library/lib/nodes/activityDiagram/ActivityActionNode.tsx
+++ b/library/lib/nodes/activityDiagram/ActivityActionNode.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -31,7 +31,6 @@ export function ActivityActionNode({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <ActivityActionNodeSVG

--- a/library/lib/nodes/activityDiagram/ActivityForkNode.tsx
+++ b/library/lib/nodes/activityDiagram/ActivityForkNode.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper, HandleId } from "../wrappers"
+import { DefaultNodeWrapper, HandleId, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -34,7 +34,6 @@ export function ActivityForkNode({
         HandleId.BottomLeft,
         HandleId.BottomRight,
       ]}
-      className="vertically-not-resizable"
     >
       <NodeToolbar elementId={id} />
       <NodeResizer
@@ -42,7 +41,6 @@ export function ActivityForkNode({
         onResize={onResize}
         minWidth={20}
         maxWidth={20}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <ActivityForkNodeSVG

--- a/library/lib/nodes/activityDiagram/ActivityForkNodeHorizontal.tsx
+++ b/library/lib/nodes/activityDiagram/ActivityForkNodeHorizontal.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper, HandleId } from "../wrappers"
+import { DefaultNodeWrapper, HandleId, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -34,7 +34,6 @@ export function ActivityForkNodeHorizontal({
         HandleId.RightTop,
         HandleId.RightBottom,
       ]}
-      className="horizontally-not-resizable"
     >
       <NodeToolbar elementId={id} />
       <NodeResizer
@@ -42,7 +41,6 @@ export function ActivityForkNodeHorizontal({
         onResize={onResize}
         minHeight={20}
         maxHeight={20}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <ActivityForkNodeHorizontalSVG

--- a/library/lib/nodes/activityDiagram/ActivityMergeNode.tsx
+++ b/library/lib/nodes/activityDiagram/ActivityMergeNode.tsx
@@ -1,6 +1,10 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper, FOUR_WAY_HANDLES_PRESET } from "../wrappers"
+import {
+  DefaultNodeWrapper,
+  FOUR_WAY_HANDLES_PRESET,
+  NodeResizer,
+} from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -37,7 +41,6 @@ export function ActivityMergeNode({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <ActivityMergeNodeSVG

--- a/library/lib/nodes/activityDiagram/ActivityObjectNode.tsx
+++ b/library/lib/nodes/activityDiagram/ActivityObjectNode.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -32,7 +32,6 @@ export function ActivityObjectNode({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <ActivityObjectNodeSVG

--- a/library/lib/nodes/activityDiagram/ActivitySwimlane.tsx
+++ b/library/lib/nodes/activityDiagram/ActivitySwimlane.tsx
@@ -1,7 +1,7 @@
-import { NodeProps, NodeResizer, useStore, type Node } from "@xyflow/react"
+import { NodeProps, useStore, type Node } from "@xyflow/react"
 import { useRef } from "react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { ActivitySwimlaneProps } from "@/types"
 import { useDiagramStore } from "@/store"
@@ -158,7 +158,6 @@ export function ActivitySwimlane({
         onResize={onResize}
         minHeight={120}
         minWidth={120}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef} style={{ position: "relative", width, height }}>
         <ActivitySwimlaneSVG

--- a/library/lib/nodes/bpmn/BPMNAnnotation.tsx
+++ b/library/lib/nodes/bpmn/BPMNAnnotation.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
 import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
@@ -37,7 +37,6 @@ export function BPMNAnnotation({
         onResize={onResize}
         minHeight={40}
         minWidth={80}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <BPMNAnnotationNodeSVG

--- a/library/lib/nodes/bpmn/BPMNCallActivity.tsx
+++ b/library/lib/nodes/bpmn/BPMNCallActivity.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
 import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
@@ -32,7 +32,6 @@ export function BPMNCallActivity({
         onResize={onResize}
         minHeight={60}
         minWidth={80}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <BPMNSubprocessNodeSVG

--- a/library/lib/nodes/bpmn/BPMNDataObject.tsx
+++ b/library/lib/nodes/bpmn/BPMNDataObject.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
 import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
@@ -32,7 +32,6 @@ export function BPMNDataObject({
         onResize={onResize}
         minHeight={50}
         minWidth={60}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <BPMNDataObjectNodeSVG

--- a/library/lib/nodes/bpmn/BPMNDataStore.tsx
+++ b/library/lib/nodes/bpmn/BPMNDataStore.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
 import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
@@ -31,7 +31,6 @@ export function BPMNDataStore({
         onResize={onResize}
         minHeight={60}
         minWidth={60}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <BPMNDataStoreNodeSVG

--- a/library/lib/nodes/bpmn/BPMNGroup.tsx
+++ b/library/lib/nodes/bpmn/BPMNGroup.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
 import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
@@ -32,7 +32,6 @@ export function BPMNGroup({
         onResize={onResize}
         minHeight={50}
         minWidth={80}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <BPMNGroupNodeSVG

--- a/library/lib/nodes/bpmn/BPMNPool.tsx
+++ b/library/lib/nodes/bpmn/BPMNPool.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
 import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
@@ -32,7 +32,6 @@ export function BPMNPool({
         onResize={onResize}
         minHeight={120}
         minWidth={200}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <BPMNPoolNodeSVG

--- a/library/lib/nodes/bpmn/BPMNSubprocess.tsx
+++ b/library/lib/nodes/bpmn/BPMNSubprocess.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
 import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
@@ -32,7 +32,6 @@ export function BPMNSubprocess({
         onResize={onResize}
         minHeight={60}
         minWidth={80}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <BPMNSubprocessNodeSVG

--- a/library/lib/nodes/bpmn/BPMNTask.tsx
+++ b/library/lib/nodes/bpmn/BPMNTask.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
 import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
@@ -32,7 +32,6 @@ export function BPMNTask({
         onResize={onResize}
         minHeight={50}
         minWidth={80}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <BPMNTaskNodeSVG

--- a/library/lib/nodes/bpmn/BPMNTransaction.tsx
+++ b/library/lib/nodes/bpmn/BPMNTransaction.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
 import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
@@ -31,7 +31,6 @@ export function BPMNTransaction({
         onResize={onResize}
         minHeight={60}
         minWidth={80}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <BPMNSubprocessNodeSVG

--- a/library/lib/nodes/classDiagram/Class.tsx
+++ b/library/lib/nodes/classDiagram/Class.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "@/nodes/wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "@/nodes/wrappers"
 import { ClassSVG } from "@/components"
 import { useEffect, useMemo } from "react"
 import { ClassNodeProps } from "@/types"
@@ -135,12 +135,7 @@ export function Class({
   const finalWidth = Math.max(width ?? 0, minWidth)
 
   return (
-    <DefaultNodeWrapper
-      width={width}
-      height={height}
-      elementId={id}
-      className="horizontally-not-resizable"
-    >
+    <DefaultNodeWrapper width={width} height={height} elementId={id}>
       <NodeToolbar elementId={id} />
 
       <NodeResizer
@@ -149,7 +144,6 @@ export function Class({
         minWidth={minWidth}
         minHeight={minHeight}
         maxHeight={minHeight}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <ClassSVG

--- a/library/lib/nodes/classDiagram/ColorDescription.tsx
+++ b/library/lib/nodes/classDiagram/ColorDescription.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { ColorDescriptionSVG } from "@/components"
 import { NodeToolbar } from "@/components/toolbars/NodeToolbar"
 import { DefaultNodeProps } from "@/types"

--- a/library/lib/nodes/classDiagram/Package.tsx
+++ b/library/lib/nodes/classDiagram/Package.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { PackageSVG } from "@/components"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
@@ -32,7 +32,6 @@ export default function Package({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <PackageSVG

--- a/library/lib/nodes/communicationDiagram/CommunicationObjectName.tsx
+++ b/library/lib/nodes/communicationDiagram/CommunicationObjectName.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "@/nodes/wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "@/nodes/wrappers"
 import { CommunicationObjectNameSVG } from "@/components"
 import { useEffect, useMemo } from "react"
 import { CommunicationObjectNodeProps } from "@/types"
@@ -123,12 +123,7 @@ export function CommunicationObjectName({
   const finalWidth = Math.max(width ?? 0, minWidth)
 
   return (
-    <DefaultNodeWrapper
-      width={width}
-      height={height}
-      elementId={id}
-      className="horizontally-not-resizable"
-    >
+    <DefaultNodeWrapper width={width} height={height} elementId={id}>
       <NodeToolbar elementId={id} />
 
       <NodeResizer
@@ -137,7 +132,6 @@ export function CommunicationObjectName({
         minWidth={minWidth}
         minHeight={minHeight}
         maxHeight={minHeight}
-        handleStyle={{ width: 8, height: 8 }}
       />
 
       <div ref={anchorRef}>

--- a/library/lib/nodes/componentDiagram/Component.tsx
+++ b/library/lib/nodes/componentDiagram/Component.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { ComponentNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -31,7 +31,6 @@ export function Component({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <ComponentNodeSVG

--- a/library/lib/nodes/componentDiagram/ComponentSubsystem.tsx
+++ b/library/lib/nodes/componentDiagram/ComponentSubsystem.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { ComponentSubsystemNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -32,7 +32,6 @@ export function ComponentSubsystem({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <ComponentSubsystemNodeSVG

--- a/library/lib/nodes/deploymentDiagram/DeploymentArtifact.tsx
+++ b/library/lib/nodes/deploymentDiagram/DeploymentArtifact.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
 import { DeploymentArtifactSVG } from "@/components"
@@ -32,7 +32,6 @@ export function DeploymentArtifact({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <DeploymentArtifactSVG

--- a/library/lib/nodes/deploymentDiagram/DeploymentComponent.tsx
+++ b/library/lib/nodes/deploymentDiagram/DeploymentComponent.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DeploymentComponentProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -32,7 +32,6 @@ export function DeploymentComponent({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <DeploymentComponentSVG

--- a/library/lib/nodes/deploymentDiagram/DeploymentNode.tsx
+++ b/library/lib/nodes/deploymentDiagram/DeploymentNode.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DeploymentNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -32,7 +32,6 @@ export function DeploymentNode({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <DeploymentNodeSVG

--- a/library/lib/nodes/flowchart/FlowchartDecision.tsx
+++ b/library/lib/nodes/flowchart/FlowchartDecision.tsx
@@ -1,6 +1,10 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper, FOUR_WAY_HANDLES_PRESET } from "../wrappers"
+import {
+  DefaultNodeWrapper,
+  FOUR_WAY_HANDLES_PRESET,
+  NodeResizer,
+} from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -36,7 +40,6 @@ export function FlowchartDecision({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <FlowchartDecisionNodeSVG

--- a/library/lib/nodes/flowchart/FlowchartFunctionCall.tsx
+++ b/library/lib/nodes/flowchart/FlowchartFunctionCall.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -31,7 +31,6 @@ export function FlowchartFunctionCall({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <FlowchartFunctionCallNodeSVG

--- a/library/lib/nodes/flowchart/FlowchartInputOutput.tsx
+++ b/library/lib/nodes/flowchart/FlowchartInputOutput.tsx
@@ -1,12 +1,6 @@
-import {
-  NodeProps,
-  NodeResizer,
-  type Node,
-  Handle,
-  Position,
-} from "@xyflow/react"
+import { NodeProps, type Node, Handle, Position } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { FlowchartInputOutputNodeSVG } from "@/components"
@@ -104,7 +98,6 @@ export function FlowchartInputOutput({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <FlowchartInputOutputNodeSVG

--- a/library/lib/nodes/flowchart/FlowchartProcess.tsx
+++ b/library/lib/nodes/flowchart/FlowchartProcess.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -31,7 +31,6 @@ export function FlowchartProcess({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <FlowchartProcessNodeSVG

--- a/library/lib/nodes/flowchart/FlowchartTerminal.tsx
+++ b/library/lib/nodes/flowchart/FlowchartTerminal.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -32,7 +32,6 @@ export function FlowchartTerminal({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <FlowchartTerminalNodeSVG

--- a/library/lib/nodes/objectDiagram/ObjectName.tsx
+++ b/library/lib/nodes/objectDiagram/ObjectName.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "@/nodes/wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "@/nodes/wrappers"
 import { ObjectNameSVG } from "@/components"
 import { useEffect, useMemo } from "react"
 import { ObjectNodeProps } from "@/types"
@@ -125,12 +125,7 @@ export function ObjectName({
   const finalWidth = Math.max(width ?? 0, minWidth)
 
   return (
-    <DefaultNodeWrapper
-      width={width}
-      height={height}
-      elementId={id}
-      className="horizontally-not-resizable"
-    >
+    <DefaultNodeWrapper width={width} height={height} elementId={id}>
       <NodeToolbar elementId={id} />
       <NodeResizer
         nodeId={id}
@@ -138,7 +133,6 @@ export function ObjectName({
         minWidth={minWidth}
         minHeight={minHeight}
         maxHeight={minHeight}
-        handleStyle={{ width: 8, height: 8 }}
       />
 
       <div ref={anchorRef}>

--- a/library/lib/nodes/petriNetDiagram/PetriNetTransition.tsx
+++ b/library/lib/nodes/petriNetDiagram/PetriNetTransition.tsx
@@ -1,6 +1,10 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper, FOUR_WAY_HANDLES_PRESET } from "@/nodes/wrappers"
+import {
+  DefaultNodeWrapper,
+  FOUR_WAY_HANDLES_PRESET,
+  NodeResizer,
+} from "@/nodes/wrappers"
 import { PetriNetTransitionSVG } from "@/components"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"

--- a/library/lib/nodes/reachabilityGraphDiagram/ReachabilityGraphMarking.tsx
+++ b/library/lib/nodes/reachabilityGraphDiagram/ReachabilityGraphMarking.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { ReachabilityGraphMarkingProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -31,7 +31,6 @@ export function ReachabilityGraphMarking({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <ReachabilityGraphMarkingSVG

--- a/library/lib/nodes/sfcDiagram/SfcActionTable.tsx
+++ b/library/lib/nodes/sfcDiagram/SfcActionTable.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useMemo, useEffect } from "react"
 import { useDiagramStore } from "@/store/context"
 import { useShallow } from "zustand/shallow"
@@ -68,7 +68,6 @@ export function SfcActionTable({
         minWidth={120}
         minHeight={minHeight}
         maxHeight={minHeight}
-        handleStyle={{ width: 8, height: 8 }}
       />
 
       <div ref={anchorRef}>

--- a/library/lib/nodes/sfcDiagram/SfcStep.tsx
+++ b/library/lib/nodes/sfcDiagram/SfcStep.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
 import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
@@ -31,7 +31,6 @@ export function SfcStep({
         onResize={onResize}
         minHeight={40}
         minWidth={80}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <SfcStepNodeSVG

--- a/library/lib/nodes/syntaxTreeDiagram/SyntaxTreeNonterminal.tsx
+++ b/library/lib/nodes/syntaxTreeDiagram/SyntaxTreeNonterminal.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -32,7 +32,6 @@ export function SyntaxTreeNonterminal({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <SyntaxTreeNonterminalNodeSVG

--- a/library/lib/nodes/syntaxTreeDiagram/SyntaxTreeTerminal.tsx
+++ b/library/lib/nodes/syntaxTreeDiagram/SyntaxTreeTerminal.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -32,7 +32,6 @@ export function SyntaxTreeTerminal({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <SyntaxTreeTerminalNodeSVG

--- a/library/lib/nodes/useCaseDiagram/UseCase.tsx
+++ b/library/lib/nodes/useCaseDiagram/UseCase.tsx
@@ -1,12 +1,6 @@
-import {
-  Handle,
-  NodeProps,
-  NodeResizer,
-  Position,
-  type Node,
-} from "@xyflow/react"
+import { Handle, NodeProps, Position, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper, HandleId } from "../wrappers"
+import { DefaultNodeWrapper, HandleId, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -215,7 +209,6 @@ export function UseCase({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <UseCaseNodeSVG

--- a/library/lib/nodes/useCaseDiagram/UseCaseActor.tsx
+++ b/library/lib/nodes/useCaseDiagram/UseCaseActor.tsx
@@ -1,6 +1,6 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
 import { PopoverManager } from "@/components/popovers/PopoverManager"
@@ -41,7 +41,6 @@ export function UseCaseActor({
         onResize={onResize}
         minWidth={ACTOR_MIN_WIDTH}
         minHeight={ACTOR_MIN_HEIGHT}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <UseCaseActorNodeSVG

--- a/library/lib/nodes/useCaseDiagram/UseCaseSystem.tsx
+++ b/library/lib/nodes/useCaseDiagram/UseCaseSystem.tsx
@@ -1,4 +1,4 @@
-import { NodeProps, NodeResizer, type Node } from "@xyflow/react"
+import { NodeProps, type Node } from "@xyflow/react"
 import { usePopoverAnchor } from "@/hooks/usePopoverAnchor"
 import { useHandleOnResize } from "@/hooks"
 import { DefaultNodeProps } from "@/types"
@@ -6,7 +6,7 @@ import { PopoverManager } from "@/components/popovers/PopoverManager"
 import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
 import { UseCaseSystemNodeSVG } from "@/components"
 import { NodeToolbar } from "@/components/toolbars/NodeToolbar"
-import { DefaultNodeWrapper } from "../wrappers"
+import { DefaultNodeWrapper, NodeResizer } from "../wrappers"
 
 export function UseCaseSystem({
   id,
@@ -31,7 +31,6 @@ export function UseCaseSystem({
         onResize={onResize}
         minHeight={50}
         minWidth={50}
-        handleStyle={{ width: 8, height: 8 }}
       />
       <div ref={anchorRef}>
         <UseCaseSystemNodeSVG

--- a/library/lib/nodes/wrappers/DefaultNodeWrapper.tsx
+++ b/library/lib/nodes/wrappers/DefaultNodeWrapper.tsx
@@ -103,7 +103,6 @@ interface Props {
   height?: number
   elementId: string
   hiddenHandles?: HandleId[] | true
-  className?: string
   // Keep the handles (so existing edges anchored to them still render) but stop
   // this node from being a connection TARGET. Used by non-connectable shapes that
   // can still be an edge SOURCE, e.g. a BPMN annotation.
@@ -114,7 +113,6 @@ export function DefaultNodeWrapper({
   elementId,
   children,
   hiddenHandles = [],
-  className,
   isConnectableEnd = true,
 }: Props) {
   // Subscribe to only the fields this wrapper uses, with shallow equality, so a
@@ -571,7 +569,6 @@ export function DefaultNodeWrapper({
   return (
     <AssessmentSelectableWrapper elementId={elementId}>
       <FeedbackDropzone
-        className={className}
         elementId={elementId}
         asElement="div"
         elementType={nodeType}

--- a/library/lib/nodes/wrappers/NodeResizer.tsx
+++ b/library/lib/nodes/wrappers/NodeResizer.tsx
@@ -1,0 +1,101 @@
+// This module is the one sanctioned importer of React Flow's resizer; every
+// other call site is pointed here by `no-restricted-imports`. The shadowed name
+// is deliberate: nodes should not have to know an axis-aware variant exists, and
+// the lint rule makes reaching past it a build error rather than a convention.
+import {
+  // eslint-disable-next-line no-restricted-imports
+  NodeResizer as ReactFlowNodeResizer,
+  NodeResizeControl,
+  ResizeControlVariant,
+  type NodeResizerProps,
+} from "@xyflow/react"
+
+// React Flow's corner handles default to 5x5; every Apollon node wants 8x8.
+const HANDLE_STYLE = { width: 8, height: 8 }
+
+// A node pins a content-sized dimension by bounding it from both sides — a
+// Class's height is driven by its attribute/method rows. Bounds that cross leave
+// no range to drag either, so they count as pinned; a side left unbounded never
+// does.
+const isAxisLocked = (min?: number, max?: number): boolean =>
+  min !== undefined && max !== undefined && min >= max
+
+/**
+ * React Flow's `<NodeResizer>` always renders four edge lines and four corner
+ * handles, so a pinned axis still shows a resize cursor and accepts a drag that
+ * does nothing. Rendering only the controls that can move is the fix; the cursor
+ * is a signifier, and repainting it would leave the dead control behind.
+ *
+ * `resizeDirection` is not an alternative: it sits on `NodeResizeControl`, and
+ * `ResizeControlLineProps` omits it outright. It constrains a corner's drag
+ * while leaving the diagonal cursor that lies about it, so corners go rather
+ * than get constrained.
+ */
+export function NodeResizer(props: NodeResizerProps) {
+  const {
+    isVisible = true,
+    minWidth,
+    minHeight,
+    maxWidth,
+    maxHeight,
+    nodeId,
+    color,
+    keepAspectRatio,
+    autoScale,
+    shouldResize,
+    onResizeStart,
+    onResize,
+    onResizeEnd,
+    lineStyle,
+    lineClassName,
+  } = props
+
+  // `isVisible` exists only on NodeResizerProps — NodeResizeControl has no such
+  // prop, so this early return is the only thing enforcing it on the locked path.
+  if (!isVisible) return null
+
+  const widthLocked = isAxisLocked(minWidth, maxWidth)
+  const heightLocked = isAxisLocked(minHeight, maxHeight)
+
+  if (!widthLocked && !heightLocked) {
+    return <ReactFlowNodeResizer handleStyle={HANDLE_STYLE} {...props} />
+  }
+
+  // Without this, a fully pinned node reads as height-locked below and gets the
+  // side controls it equally can't honour.
+  if (widthLocked && heightLocked) return null
+
+  const positions = heightLocked
+    ? (["left", "right"] as const)
+    : (["top", "bottom"] as const)
+
+  // `keepAspectRatio` is the one prop that cannot mean anything here — it would
+  // ask the pinned axis to follow the free one. No node passes it.
+  return (
+    <>
+      {positions.map((position) => (
+        <NodeResizeControl
+          key={position}
+          position={position}
+          variant={ResizeControlVariant.Line}
+          nodeId={nodeId}
+          color={color}
+          minWidth={minWidth}
+          minHeight={minHeight}
+          maxWidth={maxWidth}
+          maxHeight={maxHeight}
+          keepAspectRatio={keepAspectRatio}
+          autoScale={autoScale}
+          shouldResize={shouldResize}
+          onResizeStart={onResizeStart}
+          onResize={onResize}
+          onResizeEnd={onResizeEnd}
+          style={lineStyle}
+          className={["apollon-resize-line", lineClassName]
+            .filter(Boolean)
+            .join(" ")}
+        />
+      ))}
+    </>
+  )
+}

--- a/library/lib/nodes/wrappers/NodeResizer.tsx
+++ b/library/lib/nodes/wrappers/NodeResizer.tsx
@@ -13,6 +13,13 @@ import {
 // React Flow's corner handles default to 5x5; every Apollon node wants 8x8.
 const HANDLE_STYLE = { width: 8, height: 8 }
 
+const CORNERS = [
+  "top-left",
+  "top-right",
+  "bottom-left",
+  "bottom-right",
+] as const
+
 // A node pins a content-sized dimension by bounding it from both sides — a
 // Class's height is driven by its attribute/method rows. Bounds that cross leave
 // no range to drag either, so they count as pinned; a side left unbounded never
@@ -22,14 +29,17 @@ const isAxisLocked = (min?: number, max?: number): boolean =>
 
 /**
  * React Flow's `<NodeResizer>` always renders four edge lines and four corner
- * handles, so a pinned axis still shows a resize cursor and accepts a drag that
- * does nothing. Rendering only the controls that can move is the fix; the cursor
- * is a signifier, and repainting it would leave the dead control behind.
+ * handles, and its stylesheet paints each with a resize cursor. On a node with a
+ * pinned axis, the two edge lines of that axis promise a resize that can't
+ * happen (issue #629), and every corner shows a diagonal cursor even though only
+ * one axis can move.
  *
- * `resizeDirection` is not an alternative: it sits on `NodeResizeControl`, and
- * `ResizeControlLineProps` omits it outright. It constrains a corner's drag
- * while leaving the diagonal cursor that lies about it, so corners go rather
- * than get constrained.
+ * So on a pinned axis this drops that axis's two edge lines and keeps the
+ * corners — the familiar, chunky grab target — but constrains each corner to the
+ * free axis with `resizeDirection` and relabels its cursor (`apollon-resize-
+ * corner--*` in app.css) to that axis. The result: a content-sized node still
+ * looks and works resizable on the axis it can change, and no cursor anywhere
+ * points a direction the drag won't go.
  */
 export function NodeResizer(props: NodeResizerProps) {
   const {
@@ -38,16 +48,11 @@ export function NodeResizer(props: NodeResizerProps) {
     minHeight,
     maxWidth,
     maxHeight,
-    nodeId,
-    color,
-    keepAspectRatio,
-    autoScale,
-    shouldResize,
-    onResizeStart,
-    onResize,
-    onResizeEnd,
+    handleStyle,
+    handleClassName: _handleClassName,
     lineStyle,
     lineClassName,
+    ...resizeParams
   } = props
 
   // `isVisible` exists only on NodeResizerProps — NodeResizeControl has no such
@@ -61,39 +66,40 @@ export function NodeResizer(props: NodeResizerProps) {
     return <ReactFlowNodeResizer handleStyle={HANDLE_STYLE} {...props} />
   }
 
-  // Without this, a fully pinned node reads as height-locked below and gets the
-  // side controls it equally can't honour.
+  // Both axes pinned: nothing to resize.
   if (widthLocked && heightLocked) return null
 
-  const positions = heightLocked
+  const shared = { minWidth, minHeight, maxWidth, maxHeight, ...resizeParams }
+  const lines = heightLocked
     ? (["left", "right"] as const)
     : (["top", "bottom"] as const)
+  // The axis that can still move, for both React Flow's constraint and the cursor.
+  const freeAxis = heightLocked ? "horizontal" : "vertical"
+  const cornerClass = heightLocked
+    ? "apollon-resize-corner--x"
+    : "apollon-resize-corner--y"
 
-  // `keepAspectRatio` is the one prop that cannot mean anything here — it would
-  // ask the pinned axis to follow the free one. No node passes it.
   return (
     <>
-      {positions.map((position) => (
+      {lines.map((position) => (
         <NodeResizeControl
           key={position}
           position={position}
           variant={ResizeControlVariant.Line}
-          nodeId={nodeId}
-          color={color}
-          minWidth={minWidth}
-          minHeight={minHeight}
-          maxWidth={maxWidth}
-          maxHeight={maxHeight}
-          keepAspectRatio={keepAspectRatio}
-          autoScale={autoScale}
-          shouldResize={shouldResize}
-          onResizeStart={onResizeStart}
-          onResize={onResize}
-          onResizeEnd={onResizeEnd}
           style={lineStyle}
-          className={["apollon-resize-line", lineClassName]
-            .filter(Boolean)
-            .join(" ")}
+          className={lineClassName}
+          {...shared}
+        />
+      ))}
+      {CORNERS.map((position) => (
+        <NodeResizeControl
+          key={position}
+          position={position}
+          variant={ResizeControlVariant.Handle}
+          resizeDirection={freeAxis}
+          className={cornerClass}
+          style={{ ...HANDLE_STYLE, ...handleStyle }}
+          {...shared}
         />
       ))}
     </>

--- a/library/lib/nodes/wrappers/NodeResizer.tsx
+++ b/library/lib/nodes/wrappers/NodeResizer.tsx
@@ -13,6 +13,10 @@ import {
 // React Flow's corner handles default to 5x5; every Apollon node wants 8x8.
 const HANDLE_STYLE = { width: 8, height: 8 }
 
+// Marks every edge line so app.css can lift it over node content and widen its
+// 1px grab area.
+const LINE_CLASS = "apollon-resize-line"
+
 const CORNERS = [
   "top-left",
   "top-right",
@@ -63,7 +67,13 @@ export function NodeResizer(props: NodeResizerProps) {
   const heightLocked = isAxisLocked(minHeight, maxHeight)
 
   if (!widthLocked && !heightLocked) {
-    return <ReactFlowNodeResizer handleStyle={HANDLE_STYLE} {...props} />
+    return (
+      <ReactFlowNodeResizer
+        {...props}
+        handleStyle={handleStyle ?? HANDLE_STYLE}
+        lineClassName={[LINE_CLASS, lineClassName].filter(Boolean).join(" ")}
+      />
+    )
   }
 
   // Both axes pinned: nothing to resize.
@@ -87,7 +97,7 @@ export function NodeResizer(props: NodeResizerProps) {
           position={position}
           variant={ResizeControlVariant.Line}
           style={lineStyle}
-          className={lineClassName}
+          className={[LINE_CLASS, lineClassName].filter(Boolean).join(" ")}
           {...shared}
         />
       ))}

--- a/library/lib/nodes/wrappers/NodeResizer.tsx
+++ b/library/lib/nodes/wrappers/NodeResizer.tsx
@@ -53,7 +53,7 @@ export function NodeResizer(props: NodeResizerProps) {
     maxWidth,
     maxHeight,
     handleStyle,
-    handleClassName: _handleClassName,
+    handleClassName,
     lineStyle,
     lineClassName,
     ...resizeParams
@@ -107,7 +107,7 @@ export function NodeResizer(props: NodeResizerProps) {
           position={position}
           variant={ResizeControlVariant.Handle}
           resizeDirection={freeAxis}
-          className={cornerClass}
+          className={[cornerClass, handleClassName].filter(Boolean).join(" ")}
           style={{ ...HANDLE_STYLE, ...handleStyle }}
           {...shared}
         />

--- a/library/lib/nodes/wrappers/index.ts
+++ b/library/lib/nodes/wrappers/index.ts
@@ -1,1 +1,2 @@
 export * from "./DefaultNodeWrapper"
+export * from "./NodeResizer"

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -705,6 +705,26 @@
   z-index: 20;
 }
 
+/* NodeResizer renders its controls before the node's own content in the DOM, so
+   without a z-index the 1px edge lines paint *behind* a filled node (a swimlane,
+   pool, package…) and can't be seen or grabbed — only the corners, lifted by the
+   rule above, stayed reachable. Lift the lines over the content but below the
+   corner handles (20) and the connection arcs (10, so an arc still wins at its
+   slot and the line fills the gaps between). */
+.react-flow__resize-control.line {
+  z-index: 9;
+}
+
+/* React Flow draws the edge lines 1px wide, a hair-thin grab target. Widen the
+   hit area without moving the visible border, the same way the connection arcs
+   get a usable target. Kept small (and hover-gated, via the base rule below)
+   because it overhangs the node edge onto whatever sits beneath. */
+.apollon-resize-line::before {
+  content: "";
+  position: absolute;
+  inset: -3px;
+}
+
 /* A content-sized node keeps its corner handles (NodeResizer constrains each to
    the node's free axis with `resizeDirection`), but React Flow hard-codes a
    diagonal nwse/nesw cursor on every corner. Relabel it to the free axis's

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -705,17 +705,18 @@
   z-index: 20;
 }
 
-/* React Flow draws its resize lines 1px wide. A node with a pinned axis has no
-   corner handles to fall back on (they promise a diagonal resize it can't
-   honour, so NodeResizer omits them), which would leave its one free axis the
-   hardest thing to grab in the editor. Widen the hit area without moving the
-   visible 1px border. Kept small because the target straddles the border, so it
-   also overhangs whatever the node sits on; the hover gate above is what keeps
-   that overhang from swallowing the neighbour's clicks. */
-.apollon-resize-line::before {
-  content: "";
-  position: absolute;
-  inset: -3px;
+/* A content-sized node keeps its corner handles (NodeResizer constrains each to
+   the node's free axis with `resizeDirection`), but React Flow hard-codes a
+   diagonal nwse/nesw cursor on every corner. Relabel it to the free axis's
+   cursor so the pointer tells the truth about which way a drag will go. The
+   fourth class (`nodrag`, present on every control) outranks React Flow's
+   three-class corner rules regardless of stylesheet order. */
+.react-flow__resize-control.nodrag.handle.apollon-resize-corner--x {
+  cursor: ew-resize;
+}
+
+.react-flow__resize-control.nodrag.handle.apollon-resize-corner--y {
+  cursor: ns-resize;
 }
 
 .react-flow__resize-control {

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -701,12 +701,21 @@
   border-radius: var(--arc-radius) 0 0 var(--arc-radius);
 }
 
-.react-flow__resize-control line {
-  z-index: 9;
-}
-
 .react-flow__resize-control.handle {
   z-index: 20;
+}
+
+/* React Flow draws its resize lines 1px wide. A node with a pinned axis has no
+   corner handles to fall back on (they promise a diagonal resize it can't
+   honour, so NodeResizer omits them), which would leave its one free axis the
+   hardest thing to grab in the editor. Widen the hit area without moving the
+   visible 1px border. Kept small because the target straddles the border, so it
+   also overhangs whatever the node sits on; the hover gate above is what keeps
+   that overhang from swallowing the neighbour's clicks. */
+.apollon-resize-line::before {
+  content: "";
+  position: absolute;
+  inset: -3px;
 }
 
 .react-flow__resize-control {
@@ -987,22 +996,6 @@ svg.react-flow__connectionline {
   -webkit-user-select: none;
   -ms-user-select: none;
   user-select: none;
-}
-
-.horizontally-not-resizable .react-flow__resize-control.top.line:hover {
-  cursor: grab;
-}
-
-.horizontally-not-resizable .react-flow__resize-control.bottom.line:hover {
-  cursor: grab;
-}
-
-.vertically-not-resizable .react-flow__resize-control.right.line:hover {
-  cursor: grab;
-}
-
-.vertically-not-resizable .react-flow__resize-control.left.line:hover {
-  cursor: grab;
 }
 
 /* Native UI primitives, tokened via `--apollon-*`. Base UI portals to

--- a/library/tests/unit/NodeResizer.test.tsx
+++ b/library/tests/unit/NodeResizer.test.tsx
@@ -1,0 +1,106 @@
+import { render } from "@testing-library/react"
+import { describe, it, expect } from "vitest"
+import { ReactFlowProvider } from "@xyflow/react"
+import { NodeResizer } from "@/nodes/wrappers"
+
+// React Flow's resize controls read their store from the provider context.
+const renderResizer = (props: Parameters<typeof NodeResizer>[0]) =>
+  render(
+    <ReactFlowProvider>
+      <NodeResizer {...props} />
+    </ReactFlowProvider>
+  )
+
+// Resize controls are bare divs: no role, no accessible name, no tabindex, and
+// no keyboard path — so a position/variant class is the only handle on them, and
+// it is the same published class React Flow's own stylesheet keys the resize
+// cursor off. (It also means dropping a control costs assistive tech nothing:
+// there was never anything there to reach.)
+const controlClasses = (container: HTMLElement): string[] =>
+  [...container.querySelectorAll(".react-flow__resize-control")]
+    .map((el) =>
+      [...el.classList]
+        .filter((c) => c !== "react-flow__resize-control" && c !== "nodrag")
+        .join(".")
+    )
+    .sort()
+
+describe("<NodeResizer>", () => {
+  it("renders every line and corner when both axes are free", () => {
+    const { container } = renderResizer({ minWidth: 50, minHeight: 50 })
+
+    expect(controlClasses(container)).toEqual(
+      [
+        "top.line",
+        "right.line",
+        "bottom.line",
+        "left.line",
+        "top.left.handle",
+        "top.right.handle",
+        "bottom.left.handle",
+        "bottom.right.handle",
+      ].sort()
+    )
+  })
+
+  it("sizes corner handles to 8px without the caller asking", () => {
+    const { container } = renderResizer({ minWidth: 50, minHeight: 50 })
+
+    expect(container.querySelector<HTMLElement>(".handle")?.style.width).toBe(
+      "8px"
+    )
+  })
+
+  // `apollon-resize-line` widens the hit area: with no corner handles these
+  // lines are the only grab target, and React Flow draws them 1px wide.
+  it("renders only the left/right lines when height is locked (issue #629)", () => {
+    const { container } = renderResizer({
+      minWidth: 100,
+      minHeight: 60,
+      maxHeight: 60,
+    })
+
+    expect(controlClasses(container)).toEqual([
+      "left.line.apollon-resize-line",
+      "right.line.apollon-resize-line",
+    ])
+  })
+
+  it("renders only the top/bottom lines when width is locked", () => {
+    const { container } = renderResizer({
+      minWidth: 20,
+      maxWidth: 20,
+      minHeight: 40,
+    })
+
+    expect(controlClasses(container)).toEqual([
+      "bottom.line.apollon-resize-line",
+      "top.line.apollon-resize-line",
+    ])
+  })
+
+  it("renders nothing when both axes are locked", () => {
+    const { container } = renderResizer({
+      minWidth: 20,
+      maxWidth: 20,
+      minHeight: 20,
+      maxHeight: 20,
+    })
+
+    expect(controlClasses(container)).toEqual([])
+  })
+
+  // `isVisible` exists only on NodeResizer, not on the NodeResizeControl the
+  // locked path renders — so nothing but this component honours it, and a
+  // regression would put live resize controls on a read-only diagram.
+  it("renders nothing when not visible", () => {
+    const { container } = renderResizer({
+      isVisible: false,
+      minWidth: 100,
+      minHeight: 60,
+      maxHeight: 60,
+    })
+
+    expect(controlClasses(container)).toEqual([])
+  })
+})

--- a/library/tests/unit/NodeResizer.test.tsx
+++ b/library/tests/unit/NodeResizer.test.tsx
@@ -110,6 +110,22 @@ describe("<NodeResizer>", () => {
     expect(container.querySelector(".apollon-resize-corner--y")).toBeNull()
   })
 
+  // The locked path must honour a caller's `handleClassName` the same way the
+  // free path (which spreads it to React Flow) does — the axis marker is added
+  // alongside it, not in place of it.
+  it("forwards a caller's handleClassName to a locked node's corners", () => {
+    const { container } = renderResizer({
+      minWidth: 100,
+      minHeight: 60,
+      maxHeight: 60,
+      handleClassName: "custom-handle",
+    })
+
+    expect(
+      container.querySelectorAll(".apollon-resize-corner--x.custom-handle")
+    ).toHaveLength(4)
+  })
+
   it("keeps corners but only the top/bottom lines when width is locked", () => {
     const { container } = renderResizer({
       minWidth: 20,

--- a/library/tests/unit/NodeResizer.test.tsx
+++ b/library/tests/unit/NodeResizer.test.tsx
@@ -15,12 +15,18 @@ const renderResizer = (props: Parameters<typeof NodeResizer>[0]) =>
 // no keyboard path — so a position/variant class is the only handle on them, and
 // it is the same published class React Flow's own stylesheet keys the resize
 // cursor off. (It also means dropping a control costs assistive tech nothing:
-// there was never anything there to reach.)
+// there was never anything there to reach.) `apollon-*` marker classes are
+// dropped here so the set reads as pure geometry; a dedicated test covers them.
 const controlClasses = (container: HTMLElement): string[] =>
   [...container.querySelectorAll(".react-flow__resize-control")]
     .map((el) =>
       [...el.classList]
-        .filter((c) => c !== "react-flow__resize-control" && c !== "nodrag")
+        .filter(
+          (c) =>
+            c !== "react-flow__resize-control" &&
+            c !== "nodrag" &&
+            !c.startsWith("apollon-")
+        )
         .join(".")
     )
     .sort()
@@ -51,9 +57,9 @@ describe("<NodeResizer>", () => {
     )
   })
 
-  // `apollon-resize-line` widens the hit area: with no corner handles these
-  // lines are the only grab target, and React Flow draws them 1px wide.
-  it("renders only the left/right lines when height is locked (issue #629)", () => {
+  // Height pinned: keep the corners, drop the top/bottom lines that promise a
+  // vertical resize (issue #629).
+  it("keeps corners but only the side lines when height is locked", () => {
     const { container } = renderResizer({
       minWidth: 100,
       minHeight: 60,
@@ -61,12 +67,31 @@ describe("<NodeResizer>", () => {
     })
 
     expect(controlClasses(container)).toEqual([
-      "left.line.apollon-resize-line",
-      "right.line.apollon-resize-line",
+      "bottom.left.handle",
+      "bottom.right.handle",
+      "left.line",
+      "right.line",
+      "top.left.handle",
+      "top.right.handle",
     ])
   })
 
-  it("renders only the top/bottom lines when width is locked", () => {
+  it("labels a locked node's corners with the free axis's cursor", () => {
+    const { container } = renderResizer({
+      minWidth: 100,
+      minHeight: 60,
+      maxHeight: 60,
+    })
+
+    // Only width can move, so the corners get the horizontal-cursor marker (and
+    // never the vertical one).
+    expect(
+      container.querySelectorAll(".apollon-resize-corner--x")
+    ).toHaveLength(4)
+    expect(container.querySelector(".apollon-resize-corner--y")).toBeNull()
+  })
+
+  it("keeps corners but only the top/bottom lines when width is locked", () => {
     const { container } = renderResizer({
       minWidth: 20,
       maxWidth: 20,
@@ -74,9 +99,16 @@ describe("<NodeResizer>", () => {
     })
 
     expect(controlClasses(container)).toEqual([
-      "bottom.line.apollon-resize-line",
-      "top.line.apollon-resize-line",
+      "bottom.left.handle",
+      "bottom.line",
+      "bottom.right.handle",
+      "top.left.handle",
+      "top.line",
+      "top.right.handle",
     ])
+    expect(
+      container.querySelectorAll(".apollon-resize-corner--y")
+    ).toHaveLength(4)
   })
 
   it("renders nothing when both axes are locked", () => {

--- a/library/tests/unit/NodeResizer.test.tsx
+++ b/library/tests/unit/NodeResizer.test.tsx
@@ -57,6 +57,25 @@ describe("<NodeResizer>", () => {
     )
   })
 
+  // The line class carries the z-index lift + widened hit area (app.css) that
+  // keeps edge lines reachable over a filled node's content; every edge line
+  // needs it, on the free path and the locked path alike.
+  it("marks every edge line with the hit-area class", () => {
+    const free = renderResizer({ minWidth: 50, minHeight: 50 })
+    expect(
+      free.container.querySelectorAll(".line.apollon-resize-line")
+    ).toHaveLength(4)
+
+    const locked = renderResizer({
+      minWidth: 100,
+      minHeight: 60,
+      maxHeight: 60,
+    })
+    expect(
+      locked.container.querySelectorAll(".line.apollon-resize-line")
+    ).toHaveLength(2)
+  })
+
   // Height pinned: keep the corners, drop the top/bottom lines that promise a
   // vertical resize (issue #629).
   it("keeps corners but only the side lines when height is locked", () => {

--- a/standalone/webapp/tests/e2e/node-affordance-click-through.spec.ts
+++ b/standalone/webapp/tests/e2e/node-affordance-click-through.spec.ts
@@ -39,6 +39,19 @@ const OVERLAP_MODEL = {
   ],
 }
 
+// Same overlap, but packages: a class's height is content-driven, so it renders
+// no corner resize handles at all. Only a node that is resizable on both axes
+// has a corner that can overhang onto its neighbour.
+const OVERLAP_MODEL_RESIZABLE = {
+  ...OVERLAP_MODEL,
+  id: "e2e-affordance-blocking-resizable",
+  nodes: OVERLAP_MODEL.nodes.map((n) => ({
+    ...n,
+    type: "package",
+    data: { name: n.data.name },
+  })),
+}
+
 const CONNECT_MODEL = {
   id: "e2e-affordance-connect",
   type: "ClassDiagram",
@@ -106,7 +119,10 @@ test("a selected node's connection handles don't block an overlapping node", asy
 test("a selected node's resize handle doesn't block an overlapping node", async ({
   page,
 }) => {
-  await openFixtureInLocalEditor(page, OVERLAP_MODEL as Record<string, unknown>)
+  await openFixtureInLocalEditor(
+    page,
+    OVERLAP_MODEL_RESIZABLE as Record<string, unknown>
+  )
   await waitForCanvasReady(page)
 
   const alpha = node(page, "Alpha")

--- a/standalone/webapp/tests/e2e/node-affordance-click-through.spec.ts
+++ b/standalone/webapp/tests/e2e/node-affordance-click-through.spec.ts
@@ -39,19 +39,6 @@ const OVERLAP_MODEL = {
   ],
 }
 
-// Same overlap, but packages: a class's height is content-driven, so it renders
-// no corner resize handles at all. Only a node that is resizable on both axes
-// has a corner that can overhang onto its neighbour.
-const OVERLAP_MODEL_RESIZABLE = {
-  ...OVERLAP_MODEL,
-  id: "e2e-affordance-blocking-resizable",
-  nodes: OVERLAP_MODEL.nodes.map((n) => ({
-    ...n,
-    type: "package",
-    data: { name: n.data.name },
-  })),
-}
-
 const CONNECT_MODEL = {
   id: "e2e-affordance-connect",
   type: "ClassDiagram",
@@ -119,10 +106,7 @@ test("a selected node's connection handles don't block an overlapping node", asy
 test("a selected node's resize handle doesn't block an overlapping node", async ({
   page,
 }) => {
-  await openFixtureInLocalEditor(
-    page,
-    OVERLAP_MODEL_RESIZABLE as Record<string, unknown>
-  )
+  await openFixtureInLocalEditor(page, OVERLAP_MODEL as Record<string, unknown>)
   await waitForCanvasReady(page)
 
   const alpha = node(page, "Alpha")

--- a/standalone/webapp/tests/e2e/resize-cursor-locked-axis.spec.ts
+++ b/standalone/webapp/tests/e2e/resize-cursor-locked-axis.spec.ts
@@ -57,18 +57,19 @@ const resizeCursorsIn = (page: Page, name: string) =>
       .filter((cursor) => cursor.includes("resize"))
   }, name)
 
-test("a class exposes no resize cursor, because its height is content-sized", async ({
+test("a class only ever exposes a horizontal resize cursor", async ({
   page,
 }) => {
   await openFixtureInLocalEditor(page, MODEL as Record<string, unknown>)
   await waitForCanvasReady(page)
 
-  // Only width can change, so `ew-resize` on the side borders is honest; any
-  // `ns-resize` is the false affordance from issue #629.
-  expect(await resizeCursorsIn(page, "Locked")).toEqual([
-    "ew-resize",
-    "ew-resize",
-  ])
+  const cursors = await resizeCursorsIn(page, "Locked")
+
+  // Its height is content-sized, so only width can change: the side lines and
+  // the four corners all read `ew-resize`. A vertical (`ns-`) or diagonal
+  // (`nwse-`/`nesw-`) cursor anywhere is the false affordance from issue #629.
+  expect(cursors).toContain("ew-resize")
+  expect(cursors.every((cursor) => cursor === "ew-resize")).toBe(true)
 })
 
 test("a package still exposes resize cursors on every border", async ({

--- a/standalone/webapp/tests/e2e/resize-cursor-locked-axis.spec.ts
+++ b/standalone/webapp/tests/e2e/resize-cursor-locked-axis.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, type Page } from "@playwright/test"
+import { openFixtureInLocalEditor, waitForCanvasReady } from "../helpers/canvas"
+
+/**
+ * A class's height is driven by its attributes and methods, so it cannot be
+ * resized vertically — but React Flow still drew a resize control on the top and
+ * bottom borders, which offered an `ns-resize` cursor and a drag that did
+ * nothing. The unit tests assert which controls render; only a real browser
+ * resolves React Flow's stylesheet into a cursor, so the symptom itself — a
+ * resize cursor existing anywhere on a node that cannot be resized — is
+ * asserted here.
+ */
+
+const MODEL = {
+  id: "e2e-resize-cursor",
+  type: "ClassDiagram",
+  version: "4.0.0",
+  title: "resize cursor",
+  assessments: {},
+  edges: [],
+  nodes: [
+    {
+      id: "cls0-0000-0000-0000-000000000001",
+      type: "class",
+      width: 200,
+      height: 120,
+      position: { x: 300, y: 300 },
+      measured: { width: 200, height: 120 },
+      data: { name: "Locked", attributes: [], methods: [] },
+    },
+    {
+      id: "pkg0-0000-0000-0000-000000000002",
+      type: "package",
+      width: 200,
+      height: 150,
+      position: { x: 700, y: 300 },
+      measured: { width: 200, height: 150 },
+      data: { name: "Free" },
+    },
+  ],
+}
+
+/**
+ * Every resize cursor the browser resolves anywhere inside a node. Read off the
+ * elements directly rather than by pointing at a border: the connection arcs
+ * blanket a border's full width, so `elementFromPoint` there reports whichever
+ * of two stacked elements wins — which is not what this is asking about.
+ */
+const resizeCursorsIn = (page: Page, name: string) =>
+  page.evaluate((nodeName) => {
+    const host = [...document.querySelectorAll(".react-flow__node")].find((n) =>
+      (n.textContent || "").includes(nodeName)
+    )
+    if (!host) throw new Error(`no node named ${nodeName}`)
+    return [host, ...host.querySelectorAll("*")]
+      .map((el) => getComputedStyle(el).cursor)
+      .filter((cursor) => cursor.includes("resize"))
+  }, name)
+
+test("a class exposes no resize cursor, because its height is content-sized", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, MODEL as Record<string, unknown>)
+  await waitForCanvasReady(page)
+
+  // Only width can change, so `ew-resize` on the side borders is honest; any
+  // `ns-resize` is the false affordance from issue #629.
+  expect(await resizeCursorsIn(page, "Locked")).toEqual([
+    "ew-resize",
+    "ew-resize",
+  ])
+})
+
+test("a package still exposes resize cursors on every border", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, MODEL as Record<string, unknown>)
+  await waitForCanvasReady(page)
+
+  // Guards the opposite error: suppressing the cursor everywhere would also
+  // silence issue #629, and would be the worse bug.
+  const cursors = await resizeCursorsIn(page, "Free")
+
+  expect(cursors).toContain("ns-resize")
+  expect(cursors).toContain("ew-resize")
+  expect(cursors).toContain("nwse-resize")
+})

--- a/standalone/webapp/tests/e2e/resize-edge-reachable.spec.ts
+++ b/standalone/webapp/tests/e2e/resize-edge-reachable.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect, type Page } from "@playwright/test"
+import { openFixtureInLocalEditor, waitForCanvasReady } from "../helpers/canvas"
+
+/**
+ * NodeResizer renders its controls before the node's content in the DOM, so an
+ * edge resize line with no z-index paints behind a filled node and can't be
+ * grabbed — you'd be left with only the corners. A swimlane is the most filled
+ * node in the editor, so it's where this showed. The line now sits above the
+ * content (below the corners and connection arcs), which only a real browser can
+ * confirm: it's about stacking and hit-testing, not which elements exist.
+ */
+
+const SWIMLANE_ID = "swimlane-0000-0000-0000-000000000001"
+
+const MODEL = {
+  version: "4.0.0",
+  id: "e2e-resize-edge-reachable",
+  title: "resize edge reachable",
+  type: "ActivityDiagram",
+  assessments: {},
+  edges: [],
+  nodes: [
+    {
+      id: SWIMLANE_ID,
+      type: "activitySwimlane",
+      position: { x: 120, y: 100 },
+      width: 440,
+      height: 280,
+      measured: { width: 440, height: 280 },
+      data: {
+        name: "",
+        orientation: "vertical",
+        lanes: [
+          { id: "l1", name: "Customer" },
+          { id: "l2", name: "System" },
+        ],
+      },
+    },
+  ],
+}
+
+/**
+ * Is the top edge's resize line the top-most element anywhere along the border?
+ * The corners cap the ends and the connection arcs sit at their slots, so this
+ * samples the gaps between them — if the line is buried under the swimlane body,
+ * every sample returns the content instead and this is false.
+ */
+const topEdgeHitsResizeLine = (page: Page, id: string) =>
+  page.evaluate((nodeId) => {
+    const host = document.querySelector(
+      `.react-flow__node[data-id="${nodeId}"]`
+    )
+    if (!host) throw new Error(`no node ${nodeId}`)
+    const r = host.getBoundingClientRect()
+    for (let fraction = 0.12; fraction <= 0.88; fraction += 0.04) {
+      const el = document.elementFromPoint(r.left + r.width * fraction, r.top)
+      if (el?.closest(".react-flow__resize-control.line.top")) return true
+    }
+    return false
+  }, id)
+
+test("a swimlane's top edge is grabbable, not just its corners", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, MODEL as Record<string, unknown>)
+  await waitForCanvasReady(page)
+
+  const swimlane = page.locator(`.react-flow__node[data-id="${SWIMLANE_ID}"]`)
+  const box = (await swimlane.boundingBox())!
+  // Resize controls arm (and become hit-testable) only while the node is hovered.
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+  await page.waitForTimeout(150)
+
+  expect(await topEdgeHitsResizeLine(page, SWIMLANE_ID)).toBe(true)
+})


### PR DESCRIPTION
### Summary

Hovering the top or bottom border of a class showed a vertical-resize cursor (`ns-resize`) and let you start a drag — but a class's height is fixed by its attributes and methods, so the drag did nothing. Classic false affordance (#629): the pointer promises something the node can't deliver.

The root cause turned out to be a bit of a trap. React Flow's `<NodeResizer>` **always** renders all four edge lines plus four corner handles, and its own stylesheet paints each one with a resize cursor. A previous attempt fixed this with a CSS `cursor` override keyed on a `horizontally-not-resizable` class — but that class was put on the node only through `FeedbackDropzone`, which drops its `className` in every mode except assessment. Resize controls only render while modelling, so the override **never reached the DOM where it mattered**. It was dead from the start, which is why the issue stayed open.

The fix removes the controls that shouldn't be there and keeps the ones that should. A content-sized node no longer draws the edge lines of its pinned axis, **but keeps its four corner handles**, each constrained to the axis that can move with its cursor relabelled to match.

While auditing every node's resize behaviour for this, I found a second, older bug (thanks to the reviewer who spotted it on swimlanes): on any *filled* node — a swimlane, pool, package — the edge resize lines were invisible and un-grabbable, leaving only the corners. React Flow renders the resize controls before the node's content in the DOM, and its 1px edge lines carry no z-index, so the node body painted straight over them. A rule that was meant to fix this long ago never matched (`.react-flow__resize-control line` targets an SVG `<line>`; the controls are `<div>`s). This PR lifts the lines above the content and gives every line a comfortable grab area.

### Release note

Resize handles behave consistently across nodes: borders that can't resize no longer show a resize cursor, content-sized nodes keep their corner handles (resizing only the axis that can change), and on filled nodes like activity swimlanes the resize edge is grabbable instead of hidden behind the node.

### Implementation notes

- New `NodeResizer` wrapper (`library/lib/nodes/wrappers/NodeResizer.tsx`) around React Flow's. On a pinned axis (`min >= max`) it drops that axis's two edge lines and keeps the four corner handles, constraining each to the free axis with React Flow's **`resizeDirection`**; both axes free delegates to React Flow; both pinned renders nothing.
- A pinned node's corners get a marker class (`apollon-resize-corner--x` / `--y`) so app.css can relabel React Flow's hard-coded diagonal corner cursor to the free axis's cursor. The override wins on specificity (four classes vs. three), no `!important`.
- **Edge-line occlusion fix:** `.react-flow__resize-control.line` now gets `z-index: 9` (above the node content, below the corner handles at 20 and connection arcs at 10), and every line gets a widened, hover-gated hit area. This restores draggable edges on all filled nodes.
- **Audit result:** all ~40 resizable node types route through the wrapper; the 12 fixed-geometry shapes (initial/final nodes, BPMN events & gateways, interfaces, Petri place, SFC start/jump/transition) render no resizer, which is intended. The six content-sized nodes (class, object, communication-object, SFC action table, both activity fork bars) are the only ones with a pinned axis.
- A `no-restricted-imports` rule bans importing `NodeResizer` from `@xyflow/react`, so a future node can't silently pick up the un-fixed one; the wrapper is the single sanctioned importer. The `handleStyle={{ width: 8, height: 8 }}` that was copy-pasted across ~30 files is now one default in the wrapper.
- Also removed: the dead cursor-override CSS, its two now-unused class names, and the now-unused `className` prop that threaded them through `DefaultNodeWrapper` → `FeedbackDropzone`.

### Steps for testing

1. Open a class diagram, add a **Class**, select it. Hover the **top/bottom** border → default/grab cursor, no dead drag (was `ns-resize`). Hover a **corner** → `ew-resize`, dragging resizes width; height stays content-driven.
2. Add a **Package** (free both axes) → all four edges and corners resize normally.
3. Open an **activity diagram**, add a **Swimlane**, select it, hover an outer edge → the edge is grabbable and resizes the swimlane (previously only the corners worked).
4. Automated:
   - `cd library && pnpm test` — unit specs assert which controls render per axis, the free-axis corner cursor, and the edge-line hit-area class.
   - `cd standalone/webapp && pnpm exec playwright test --project=chromium resize-cursor-locked-axis resize-edge-reachable` — real-browser checks of the resolved cursor and that a swimlane's top edge is the top-most (grabbable) element. All were mutation-checked — each fails if its fix is reverted.

### Screenshots / screencasts

The change is cursor/affordance behaviour, best seen live — the repro screencast on #629 shows the broken state, and the Playwright specs assert the real resolved cursor and edge reachability in CI.

Note on the "How to use" modal images: two render a *selected* class, so they show its resize controls, which this PR changes slightly (the two top/bottom edge lines go). I ran the repo's **Update Visual Baselines** workflow and it correctly committed nothing — the diff is under the project's `maxDiffPixelRatio: 0.01`, so `--update-snapshots` treats the images as unchanged. No repo tooling will refresh them without forcing `--update-snapshots=all`; flagging transparently, happy to force-refresh in this PR if you'd prefer.

### Checklist

- [x] Linked to a related issue (if applicable) — closes #629
- [x] Added a changeset whose summary is written in the user's voice
- [x] PR title's Conventional Commit type (`fix`) matches the kind of change
- [x] Tests added or updated — unit + e2e, all mutation-checked
- [x] Ran `pnpm lint && pnpm format:check && pnpm build && pnpm test` locally — green
- [ ] Documentation updated (if applicable) — n/a
- [x] Screenshots or screencasts attached (if a UI change) — see note above
