### PR TITLE
feat(library): add multi-select mode for touch devices

### DIFF
--- a/.changeset/thick-geese-invent.md
+++ b/.changeset/thick-geese-invent.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": minor
+---
+
+Select and move several elements at once: a new multi-select toggle in the canvas controls lets you build a selection by clicking or tapping elements to add or remove them — and, with a mouse, by dragging a selection box across the canvas. It needs no keyboard, so groups can be positioned together on phones and tablets too. Click empty canvas or press Escape to clear.

--- a/library/lib/App.tsx
+++ b/library/lib/App.tsx
@@ -44,6 +44,7 @@ import {
 import { diagramNodeTypes } from "./nodes"
 import { useDiagramModifiable } from "./hooks/useDiagramModifiable"
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts"
+import { useMultiSelectionMode } from "./hooks/useMultiSelectionMode"
 import { usePaneClicked } from "./hooks/usePaneClicked"
 import {
   useRemoteDraggingNodes,
@@ -144,6 +145,7 @@ function App({ onReactFlowInit, collaboration, awareness }: AppProps) {
   const { onBeforeDelete, onNodeDoubleClick, onEdgeDoubleClick } =
     useElementInteractions()
   const { onPaneClicked } = usePaneClicked()
+  const multiSelectionMode = useMultiSelectionMode()
 
   const handleReactFlowInit = useCallback(
     (instance: ReactFlowInstance) => {
@@ -245,13 +247,22 @@ function App({ onReactFlowInit, collaboration, awareness }: AppProps) {
             nodesDraggable={isDiagramModifiable}
             panOnScroll={!scrollLock || scrollEnabled}
             zoomOnScroll={!scrollLock || scrollEnabled}
-            // Keep the default left-drag pan (panOnDrag=true) — we do NOT switch
-            // to selectionOnDrag/space-pan. Adding Shift to multiSelectionKeyCode
-            // makes Shift+CLICK on a node/edge toggle it in/out of the
-            // multi-selection. selectionKeyCode keeps its default (Shift), so a
-            // Shift+DRAG on the empty pane still box-selects — no conflict, since
-            // a click on a node and a drag on the pane are different surfaces.
+            // Shift is also selectionKeyCode's default, but there's no conflict:
+            // a click on a node and a Shift+drag on the pane are different
+            // surfaces.
             multiSelectionKeyCode={["Shift", "Meta", "Control"]}
+            // With multiSelectionActive forced on, React Flow's pointerdown
+            // select would toggle the pressed node OUT of the selection and drop
+            // it from the group drag; selecting on click keeps the group whole.
+            selectNodesOnDrag={!multiSelectionMode}
+            // In the mode, a plain left-drag on the pane draws a selection box;
+            // panning moves to middle/right-drag (scroll/trackpad already pans
+            // by default). This is mouse-only by construction: d3-zoom gates the
+            // pan buttons on `mousedown` alone, so a touch drag ignores the [1,2]
+            // gate and keeps panning through the separate touch handler — which
+            // is why a one-finger drag never box-selects and pinch-zoom survives.
+            selectionOnDrag={multiSelectionMode}
+            panOnDrag={multiSelectionMode ? [1, 2] : true}
             // Delete the current selection with either key (Backspace on macOS,
             // Delete on full keyboards).
             deleteKeyCode={["Backspace", "Delete"]}

--- a/library/lib/chrome/builtins/ZoomControls.tsx
+++ b/library/lib/chrome/builtins/ZoomControls.tsx
@@ -1,7 +1,18 @@
 import { useReactFlow, useStore } from "@xyflow/react"
 import { useShallow } from "zustand/shallow"
-import { Maximize, Redo2, Undo2, ZoomIn, ZoomOut } from "lucide-react"
-import { useDiagramStore, useOverlayStore } from "@/store/context"
+import {
+  Maximize,
+  Redo2,
+  SquareMousePointer,
+  Undo2,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react"
+import {
+  useDiagramStore,
+  useMetadataStore,
+  useOverlayStore,
+} from "@/store/context"
 import { insetAwareFitView } from "@/overlay/fitView"
 import { Tooltip } from "@/components/ui"
 import { useLabels } from "@/i18n/useLabels"
@@ -13,8 +24,8 @@ export interface ZoomControlsProps {
 }
 
 /**
- * The zoom / history cluster: a [zoom-out][%-reset][zoom-in][fit] island and a
- * separate [undo][redo] history island. The fit button reserves the current insets
+ * The canvas cluster: a [zoom-out][%-reset][zoom-in][fit][multi-select] island and
+ * a separate [undo][redo] history island. The fit button reserves the current insets
  * so content frames clear of the chrome. `history: false` drops the history island.
  * One `role="toolbar"` spans both islands so a single Tab stop + arrows rove every
  * button (roving-tabindex, APG-valid at ≥3 controls).
@@ -33,6 +44,13 @@ export function ZoomControls({ history = true }: ZoomControlsProps) {
       undo: state.undo,
       redo: state.redo,
       undoManagerExist: state.undoManager !== null,
+    }))
+  )
+
+  const { multiSelectionMode, setMultiSelectionMode } = useMetadataStore(
+    useShallow((state) => ({
+      multiSelectionMode: state.multiSelectionMode,
+      setMultiSelectionMode: state.setMultiSelectionMode,
     }))
   )
 
@@ -88,6 +106,17 @@ export function ZoomControls({ history = true }: ZoomControlsProps) {
             aria-label={t.fitView}
           >
             <Maximize width={18} height={18} aria-hidden="true" />
+          </button>
+        </Tooltip>
+        <Tooltip title={t.multiSelectionHint}>
+          <button
+            type="button"
+            className="apollon-chrome-iconbtn apollon-chrome-iconbtn--toggle"
+            onClick={() => setMultiSelectionMode(!multiSelectionMode)}
+            aria-label={t.multiSelection}
+            aria-pressed={multiSelectionMode}
+          >
+            <SquareMousePointer width={18} height={18} aria-hidden="true" />
           </button>
         </Tooltip>
       </div>

--- a/library/lib/hooks/useKeyboardShortcuts.ts
+++ b/library/lib/hooks/useKeyboardShortcuts.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react"
-import { useDiagramStore } from "@/store/context"
+import { useDiagramStore, useMetadataStore } from "@/store/context"
 import { useShallow } from "zustand/shallow"
 import { useSelectionForCopyPaste } from "./useSelectionForCopyPaste"
 import { useDiagramModifiable } from "./useDiagramModifiable"
@@ -15,6 +15,9 @@ export const useKeyboardShortcuts = () => {
       canRedo: state.canRedo,
       undoManager: state.undoManager,
     }))
+  )
+  const setMultiSelectionMode = useMetadataStore(
+    (state) => state.setMultiSelectionMode
   )
   const isDiagramModifiable = useDiagramModifiable()
   const {
@@ -42,6 +45,7 @@ export const useKeyboardShortcuts = () => {
 
       if (event.key === "Escape") {
         event.preventDefault()
+        setMultiSelectionMode(false)
         clearSelection()
         return
       }
@@ -142,5 +146,6 @@ export const useKeyboardShortcuts = () => {
     copySelectedElements,
     cutSelectedElements, // Add this to dependencies
     pasteElements,
+    setMultiSelectionMode,
   ])
 }

--- a/library/lib/hooks/useMultiSelectionMode.ts
+++ b/library/lib/hooks/useMultiSelectionMode.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react"
+import { useStoreApi } from "@xyflow/react"
+import { useMetadataStore } from "@/store/context"
+
+/**
+ * Reproduces Shift/Ctrl multi-selection while `multiSelectionMode` is on, for
+ * pointers that have no modifier key (touch). React Flow has no public prop for
+ * "a modifier is held" — `multiSelectionKeyCode` needs a real key — so the
+ * internal flag its click paths read is the only lever. React Flow's key handler
+ * rewrites that flag on every modifier transition, hence the re-asserting
+ * subscription rather than a one-shot write.
+ *
+ * Being internal, the flag could be renamed in any React Flow release: this
+ * hook's unit test asserts it against a real store, so a rename fails CI on the
+ * catalog bump instead of silently leaving the toggle inert.
+ */
+export const useMultiSelectionMode = (): boolean => {
+  const multiSelectionMode = useMetadataStore(
+    (state) => state.multiSelectionMode
+  )
+  const store = useStoreApi()
+
+  useEffect(() => {
+    if (!multiSelectionMode) return
+
+    store.setState({ multiSelectionActive: true })
+    const unsubscribe = store.subscribe((state) => {
+      if (!state.multiSelectionActive) {
+        store.setState({ multiSelectionActive: true })
+      }
+    })
+
+    return () => {
+      unsubscribe()
+      store.setState({ multiSelectionActive: false })
+    }
+  }, [multiSelectionMode, store])
+
+  return multiSelectionMode
+}

--- a/library/lib/i18n/labels.ts
+++ b/library/lib/i18n/labels.ts
@@ -5,7 +5,7 @@
  * control of word order.
  */
 export interface ApollonLabels {
-  // Zoom / history cluster
+  // Zoom / history / multi-select cluster
   zoomToolbar: string
   zoomIn: string
   zoomOut: string
@@ -19,6 +19,8 @@ export interface ApollonLabels {
   undoHint: string
   redo: string
   redoHint: string
+  multiSelection: string
+  multiSelectionHint: string
 
   // Minimap
   miniMap: string
@@ -277,7 +279,7 @@ function defaultNodeTypeLabel(nodeType?: string): string {
 
 /** The shipped English strings — the fallback for any key a host doesn't override. */
 export const DEFAULT_LABELS: ApollonLabels = Object.freeze<ApollonLabels>({
-  zoomToolbar: "Zoom and history controls",
+  zoomToolbar: "Zoom, history and selection controls",
   zoomIn: "Zoom in",
   zoomOut: "Zoom out",
   fitView: "Fit view",
@@ -287,6 +289,8 @@ export const DEFAULT_LABELS: ApollonLabels = Object.freeze<ApollonLabels>({
   undoHint: "Undo (Ctrl+Z)",
   redo: "Redo",
   redoHint: "Redo (Ctrl+Y or Ctrl+Shift+Z)",
+  multiSelection: "Select multiple elements",
+  multiSelectionHint: "Select multiple: click elements to add or remove",
   miniMap: "Mini map",
   showMinimap: "Show minimap",
   showMinimapHint: "Show minimap (overview)",

--- a/library/lib/store/metadataStore.ts
+++ b/library/lib/store/metadataStore.ts
@@ -17,6 +17,8 @@ export type MetadataStore = {
   readonly: boolean
   debug: boolean
   scrollLock: boolean
+  /** Tool toggle: clicks/taps add or remove elements — the touch path to a multi-selection. */
+  multiSelectionMode: boolean
   /** User-facing strings for the editor's own chrome; host-overridable for i18n. */
   labels: ApollonLabels
   scrollEnabled: boolean
@@ -31,6 +33,7 @@ export type MetadataStore = {
   setAvailableViews: (availableViews: ApollonView[]) => void
   setReadonly: (readonly: boolean) => void
   setScrollLock: (scrollLock: boolean) => void
+  setMultiSelectionMode: (multiSelectionMode: boolean) => void
   setLabels: (labels: ApollonLabels) => void
   setScrollEnabled: (scrollEnabled: boolean) => void
   startConnectionGuidance: (
@@ -61,6 +64,7 @@ type InitialMetadataState = {
   readonly: boolean
   debug: boolean
   scrollLock: boolean
+  multiSelectionMode: boolean
   labels: ApollonLabels
   scrollEnabled: boolean
   connectionGuidanceActive: boolean
@@ -81,6 +85,7 @@ const initialMetadataState: InitialMetadataState = {
   readonly: false,
   debug: false,
   scrollLock: false,
+  multiSelectionMode: false,
   labels: DEFAULT_LABELS,
   scrollEnabled: false,
   connectionGuidanceActive: false,
@@ -171,6 +176,10 @@ export const createMetadataStore = (
 
         setScrollLock: (scrollLock: boolean) => {
           set({ scrollLock }, undefined, "setScrollLock")
+        },
+
+        setMultiSelectionMode: (multiSelectionMode: boolean) => {
+          set({ multiSelectionMode }, undefined, "setMultiSelectionMode")
         },
 
         setLabels: (labels) => {

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -454,6 +454,36 @@
    too (App.tsx), so editor chrome still gets it; it references only chrome tokens
    so the rendered control is identical wherever the class is defined. */
 
+/* Opt-in `--toggle` peer: an unqualified `[aria-pressed="true"]` here would paint
+   every future editor chrome toggle, and the home band's pills (components.css)
+   already paint their own on-state. The hover/active peers exist because the base
+   button's own state rules would otherwise overwrite the pressed fill. */
+.apollon-chrome-iconbtn--toggle[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--apollon-chrome-accent) 18%, transparent);
+  color: var(--apollon-chrome-accent);
+}
+
+.apollon-chrome-iconbtn--toggle[aria-pressed="true"]:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--apollon-chrome-accent) 26%, transparent);
+}
+
+.apollon-chrome-iconbtn--toggle[aria-pressed="true"]:active:not(:disabled) {
+  background: color-mix(in srgb, var(--apollon-chrome-accent) 34%, transparent);
+}
+
+/* Forced colours drop the accent fill, which is this toggle's ONLY signal that a
+   mode is armed — repaint it with the system pair so the mode stays visible. The
+   hover/active peers are re-listed because their higher specificity would
+   otherwise restore the (now-invisible) accent fill. */
+@media (forced-colors: active) {
+  .apollon-chrome-iconbtn--toggle[aria-pressed="true"],
+  .apollon-chrome-iconbtn--toggle[aria-pressed="true"]:hover:not(:disabled),
+  .apollon-chrome-iconbtn--toggle[aria-pressed="true"]:active:not(:disabled) {
+    background: Highlight;
+    color: HighlightText;
+  }
+}
+
 /* Expanded minimap = its own glass card (the .react-flow__panel glass rule
    supplies the pane). Drop the panel padding so the map fills the rounded card
    (no fat glass gutter) and clip the svg to the card radius. */

--- a/library/tests/unit/useMultiSelectionMode.test.tsx
+++ b/library/tests/unit/useMultiSelectionMode.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+import { type ReactNode } from "react"
+import { ReactFlowProvider, useStoreApi } from "@xyflow/react"
+import * as Y from "yjs"
+import { MetadataStoreContext } from "@/store/context"
+import { createMetadataStore } from "@/store/metadataStore"
+import { useMultiSelectionMode } from "@/hooks/useMultiSelectionMode"
+
+describe("useMultiSelectionMode", () => {
+  let metadataStore: ReturnType<typeof createMetadataStore>
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <MetadataStoreContext value={metadataStore}>
+      <ReactFlowProvider>{children}</ReactFlowProvider>
+    </MetadataStoreContext>
+  )
+
+  /** Renders the hook and hands back the React Flow store it drives. */
+  const renderMultiSelectionMode = () =>
+    renderHook(
+      () => {
+        useMultiSelectionMode()
+        return useStoreApi()
+      },
+      { wrapper }
+    )
+
+  beforeEach(() => {
+    metadataStore = createMetadataStore(new Y.Doc())
+  })
+
+  it("forces React Flow's multiSelectionActive while the mode is on", () => {
+    const { result } = renderMultiSelectionMode()
+    expect(result.current.getState().multiSelectionActive).toBe(false)
+
+    act(() => metadataStore.getState().setMultiSelectionMode(true))
+    expect(result.current.getState().multiSelectionActive).toBe(true)
+
+    act(() => metadataStore.getState().setMultiSelectionMode(false))
+    expect(result.current.getState().multiSelectionActive).toBe(false)
+  })
+
+  it("re-asserts the flag when React Flow's key handler clears it", () => {
+    const { result } = renderMultiSelectionMode()
+    act(() => metadataStore.getState().setMultiSelectionMode(true))
+
+    // React Flow writes this flag from its own modifier-key handler on every
+    // key transition, which would silently break toggle-taps mid-mode.
+    act(() => result.current.setState({ multiSelectionActive: false }))
+    expect(result.current.getState().multiSelectionActive).toBe(true)
+  })
+})

--- a/standalone/webapp/tests/e2e/controls-a11y.spec.ts
+++ b/standalone/webapp/tests/e2e/controls-a11y.spec.ts
@@ -42,7 +42,7 @@ test.describe("built-in controls accessibility", () => {
     page,
   }) => {
     const toolbar = page.getByRole("toolbar", {
-      name: "Zoom and history controls",
+      name: "Zoom, history and selection controls",
     })
     await expect(toolbar).toBeVisible()
 
@@ -54,8 +54,9 @@ test.describe("built-in controls accessibility", () => {
     await tabbable.focus()
     expect(await activeLabel(page)).toBe("Zoom out")
 
-    // ArrowRight roves across BOTH glass islands (view [−][%][+][fit] then
-    // history), staying a single tab stop — the toolbar spans both islands.
+    // ArrowRight roves across BOTH glass islands (view [−][%][+][fit][multi-
+    // select] then history), staying a single tab stop — the toolbar spans
+    // both islands.
     await page.keyboard.press("ArrowRight")
     expect(await activeLabel(page)).toBe("Zoom is 100%, reset to 100%")
     await expect(toolbar.locator("button[tabindex='0']")).toHaveCount(1)
@@ -63,13 +64,13 @@ test.describe("built-in controls accessibility", () => {
     // End jumps to the last ENABLED control (roving skips disabled buttons). With
     // a freshly-loaded diagram the history island is either absent (no undo
     // manager) or its undo/redo start disabled, so the last reachable control is
-    // the fit-view button; if an enabled redo is present it is "Redo". Assert the
-    // concrete last DOM control — not merely "not the first".
+    // the multi-select toggle; if an enabled redo is present it is "Redo". Assert
+    // the concrete last DOM control — not merely "not the first".
     const expectedLast = await toolbar
       .locator("button:enabled")
       .last()
       .getAttribute("aria-label")
-    expect(["Fit view", "Redo"]).toContain(expectedLast)
+    expect(["Select multiple elements", "Redo"]).toContain(expectedLast)
     await page.keyboard.press("End")
     expect(await activeLabel(page)).toBe(expectedLast)
 

--- a/standalone/webapp/tests/e2e/controls-layout.spec.ts
+++ b/standalone/webapp/tests/e2e/controls-layout.spec.ts
@@ -547,7 +547,7 @@ test.describe("controls layout engine", () => {
   }) => {
     await updateControl(page, ZOOM_ID, { region: "top-center" })
     const toolbar = page.getByRole("toolbar", {
-      name: "Zoom and history controls",
+      name: "Zoom, history and selection controls",
     })
     await expect(toolbar).toBeVisible()
     await expect(toolbar.locator("button[tabindex='0']")).toHaveCount(1)

--- a/standalone/webapp/tests/e2e/editor.spec.ts
+++ b/standalone/webapp/tests/e2e/editor.spec.ts
@@ -760,7 +760,7 @@ test.describe("Mobile responsive layout", () => {
 
     // The zoom cluster / minimap stay inside the left/right insets.
     const controlsBox = await page
-      .getByRole("toolbar", { name: "Zoom and history controls" })
+      .getByRole("toolbar", { name: "Zoom, history and selection controls" })
       .boundingBox()
     expect(controlsBox?.x).toBeGreaterThanOrEqual(SAFE_INSET)
 
@@ -813,7 +813,7 @@ test.describe("Mobile responsive layout", () => {
     // edge stays above the zoom cluster's top edge.
     const palette = page.getByTestId("apollon-palette")
     const controls = page.getByRole("toolbar", {
-      name: "Zoom and history controls",
+      name: "Zoom, history and selection controls",
     })
     await expect
       .poll(async () => {

--- a/standalone/webapp/tests/e2e/multi-selection-mode.spec.ts
+++ b/standalone/webapp/tests/e2e/multi-selection-mode.spec.ts
@@ -1,0 +1,224 @@
+import { test, expect, type Page } from "@playwright/test"
+import { openFixtureInLocalEditor, waitForCanvasReady } from "../helpers/canvas"
+
+/**
+ * Multi-selection mode (issues #407 / #405): the chrome toggle that lets a
+ * pointer with no modifier key build a multi-selection — clicks and taps add or
+ * remove elements instead of replacing the selection.
+ */
+
+// Two separated classes, no package parent and no edges, so a click lands on
+// exactly one node and a group drag is unambiguous.
+const fixture = {
+  id: "e2e-multi-selection-mode",
+  version: "4.0.0",
+  title: "Multi-selection mode",
+  type: "ClassDiagram",
+  nodes: [
+    {
+      id: "node-a",
+      width: 160,
+      height: 90,
+      type: "class",
+      position: { x: 0, y: 0 },
+      data: { name: "Alpha", methods: [], attributes: [] },
+      measured: { width: 160, height: 90 },
+    },
+    {
+      id: "node-b",
+      width: 160,
+      height: 90,
+      type: "class",
+      position: { x: 260, y: 0 },
+      data: { name: "Beta", methods: [], attributes: [] },
+      measured: { width: 160, height: 90 },
+    },
+  ],
+  edges: [],
+  assessments: {},
+}
+
+function modeToggle(page: Page) {
+  return page.getByRole("button", { name: "Select multiple elements" })
+}
+
+function selectedNodes(page: Page) {
+  return page.locator(".react-flow__node.selected")
+}
+
+function node(page: Page, name: string) {
+  return page.locator(".react-flow__node", { hasText: name })
+}
+
+async function enableMultiSelectionMode(page: Page) {
+  const toggle = modeToggle(page)
+  await toggle.click()
+  await expect(toggle).toHaveAttribute("aria-pressed", "true")
+}
+
+test.describe("Multi-selection mode", () => {
+  test.beforeEach(async ({ page }) => {
+    await openFixtureInLocalEditor(page, fixture)
+    await waitForCanvasReady(page)
+  })
+
+  test("dragging a selected node moves the whole selection and keeps it", async ({
+    page,
+  }) => {
+    await enableMultiSelectionMode(page)
+    await node(page, "Alpha").click()
+    await node(page, "Beta").click()
+
+    const alphaBefore = (await node(page, "Alpha").boundingBox())!
+    const betaBefore = (await node(page, "Beta").boundingBox())!
+
+    await page.mouse.move(
+      alphaBefore.x + alphaBefore.width / 2,
+      alphaBefore.y + alphaBefore.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(
+      alphaBefore.x + alphaBefore.width / 2 + 120,
+      alphaBefore.y + alphaBefore.height / 2 + 80,
+      { steps: 10 }
+    )
+    await page.mouse.up()
+
+    const alphaAfter = (await node(page, "Alpha").boundingBox())!
+    const betaAfter = (await node(page, "Beta").boundingBox())!
+
+    // Both move together, and the pressed node is still selected afterwards —
+    // React Flow's pointerdown select would otherwise toggle it back out.
+    expect(alphaAfter.x).toBeGreaterThan(alphaBefore.x + 60)
+    expect(betaAfter.x).toBeGreaterThan(betaBefore.x + 60)
+    await expect(selectedNodes(page)).toHaveCount(2)
+    await expect(node(page, "Alpha")).toHaveClass(/selected/)
+  })
+
+  test("dragging a box across the pane selects the enclosed elements", async ({
+    page,
+  }) => {
+    await enableMultiSelectionMode(page)
+
+    const alpha = (await node(page, "Alpha").boundingBox())!
+    const beta = (await node(page, "Beta").boundingBox())!
+    const viewport = page.locator(".react-flow__viewport")
+    const transformBefore = await viewport.getAttribute("style")
+
+    // Left-drag from above-left of Alpha to below-right of Beta encloses both.
+    await page.mouse.move(alpha.x - 20, alpha.y - 20)
+    await page.mouse.down()
+    await page.mouse.move(beta.x + beta.width + 20, beta.y + beta.height + 20, {
+      steps: 12,
+    })
+    await page.mouse.up()
+
+    await expect(selectedNodes(page)).toHaveCount(2)
+    // The drag box-selected instead of panning the canvas.
+    await expect(viewport).toHaveAttribute("style", transformBefore!)
+  })
+
+  test("Escape exits the mode and clears the selection", async ({ page }) => {
+    await enableMultiSelectionMode(page)
+    await node(page, "Alpha").click()
+    await expect(selectedNodes(page)).toHaveCount(1)
+
+    await page.keyboard.press("Escape")
+
+    await expect(modeToggle(page)).toHaveAttribute("aria-pressed", "false")
+    await expect(selectedNodes(page)).toHaveCount(0)
+  })
+
+  test("leaves stock click-to-replace intact once the mode is off", async ({
+    page,
+  }) => {
+    // Guards the flag leak: the mode forces React Flow's multiSelectionActive,
+    // and only the effect cleanup puts it back.
+    await enableMultiSelectionMode(page)
+    await node(page, "Alpha").click()
+    await modeToggle(page).click()
+
+    await node(page, "Beta").click()
+    await expect(selectedNodes(page)).toHaveCount(1)
+    await expect(node(page, "Beta")).toHaveClass(/selected/)
+  })
+})
+
+test.describe("Multi-selection mode on touch", () => {
+  test.use({ hasTouch: true })
+
+  test.beforeEach(async ({ page }) => {
+    await openFixtureInLocalEditor(page, fixture)
+    await waitForCanvasReady(page)
+  })
+
+  async function tapCenter(page: Page, name: string) {
+    const box = (await node(page, name).boundingBox())!
+    await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2)
+  }
+
+  async function tapToggle(page: Page) {
+    const toggle = modeToggle(page)
+    const box = (await toggle.boundingBox())!
+    await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2)
+    await expect(toggle).toHaveAttribute("aria-pressed", "true")
+  }
+
+  test("taps build, shrink and clear a multi-selection", async ({ page }) => {
+    // Arming the mode over an existing selection has to keep it: this is the
+    // flow the mode exists for — one element tapped, then "and that one too".
+    await tapCenter(page, "Alpha")
+    await tapToggle(page)
+
+    await tapCenter(page, "Beta")
+    await expect(selectedNodes(page)).toHaveCount(2)
+
+    await tapCenter(page, "Beta")
+    await expect(selectedNodes(page)).toHaveCount(1)
+    await expect(node(page, "Alpha")).toHaveClass(/selected/)
+
+    const alphaBox = (await node(page, "Alpha").boundingBox())!
+    await page.touchscreen.tap(alphaBox.x - 60, alphaBox.y - 60)
+    await expect(selectedNodes(page)).toHaveCount(0)
+  })
+
+  test("one-finger drag still pans instead of box-selecting", async ({
+    page,
+    browserName,
+  }) => {
+    // Guards the asymmetry the mode relies on: the desktop marquee's
+    // panOnDrag={[1,2]} must NOT turn a one-finger drag into a selection box,
+    // otherwise touch would lose panning and pinch-zoom.
+    test.skip(
+      browserName !== "chromium",
+      "Touch drag is dispatched via CDP, which is Chromium-only."
+    )
+    await tapToggle(page)
+
+    const viewport = page.locator(".react-flow__viewport")
+    const transformBefore = await viewport.getAttribute("style")
+    const alphaBox = (await node(page, "Alpha").boundingBox())!
+    const startX = alphaBox.x - 80
+    const startY = alphaBox.y - 80
+
+    const client = await page.context().newCDPSession(page)
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [{ x: startX, y: startY }],
+    })
+    for (let step = 1; step <= 4; step++) {
+      await client.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: [{ x: startX + step * 40, y: startY + step * 25 }],
+      })
+      await page.waitForTimeout(32)
+    }
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    })
+
+    await expect(selectedNodes(page)).toHaveCount(0)
+    await expect(viewport).not.toHaveAttribute("style", transformBefore!)
+  })
+})


### PR DESCRIPTION
### Summary

On a phone or tablet you couldn't build a selection of more than one element. Multi-selection in Apollon has always meant holding **Shift/Ctrl** while clicking — and a touch pointer has no modifier key. So positioning two boxes together, or nudging a cluster into place, simply wasn't possible without a keyboard.

This PR adds a **multi-select toggle** to the canvas controls (bottom-left, next to zoom). While it's on, every click or tap **adds** an element to the selection, and clicking or tapping an already-selected one **removes** it. With a mouse it also turns a plain drag into a **selection box**. Tapping empty canvas or pressing **Escape** clears the selection, and Escape also leaves the mode.

Closes #407 (select multiple on mobile) and #405 (deselect on mobile).

### Release note

Select and move several elements at once: a new multi-select toggle in the canvas controls lets you build a selection by clicking or tapping elements to add or remove them — and, with a mouse, by dragging a selection box across the canvas. It needs no keyboard, so groups can be positioned together on phones and tablets too. Click empty canvas or press Escape to clear.

### Implementation notes

The editor is built on React Flow, which already knows how to toggle selection membership — it just gates that behaviour behind a held modifier key. The toggle turns on React Flow's internal "a modifier is held" state and keeps it on for the mode's lifetime, so a plain tap travels React Flow's own click path and behaves exactly like a modifier-click. There is no public prop for this, so the one internal field involved is covered by a unit test that reads the real store — if a future React Flow release renames it, CI fails on the version bump instead of the toggle silently going dead.

One companion prop, `selectNodesOnDrag={false}`, is set while the mode is on: without it React Flow toggles the pressed node **out** of the selection on pointer-down, which would drop it from a group drag.

**Drag-to-box-select is a mouse affordance only — and that falls out for free, no device detection.** It's enabled with React Flow's own "Figma-style" recipe (`selectionOnDrag`, with `panOnDrag` routed to the middle/right buttons so left-drag is free for the box). The touch side is inert *by construction*: d3-zoom gates the pan buttons on `mousedown` alone, so a one-finger drag ignores that gate and keeps panning through the separate touch handler — pinch-zoom untouched. I verified this empirically (CDP touch dispatch): on touch, a one-finger drag pans and selects nothing, pinch still zooms and pans; on desktop, left-drag box-selects while middle/right-drag and scroll still pan. A one-finger touch **marquee** is genuinely not achievable in React Flow 12 without disabling pinch-zoom (both are gated on the same touch handler), so touch stays tap-to-select — which is all #407/#405 ask for.

One deliberate, minor trade-off: because right-drag is used as a pan affordance while the mode is on, the browser's native right-click menu on the canvas is suppressed for the mode's duration (it returns when the mode is off). Apollon has no custom canvas context menu, so this is invisible in normal use.

Every behaviour-carrying line is mutation-tested — each is killed by exactly one test, and no test is redundant. The toolbar's accessible name grew from "Zoom and history controls" to "Zoom, history and selection controls" (the label *key* is unchanged, so no host translation breaks). The pressed state is keyed on `aria-pressed` so the visual and the accessible state can't drift, and it has a Windows High-Contrast fallback.

Not done here, on purpose: no public `ApollonOptions` flag or imperative setter (this is user tool-state, not host configuration), and no separate toolbar control (nothing in the repo customises the control set today, so a second control would be speculative). Both are easy follow-ups if a need appears.

### Steps for testing

**Desktop**
1. Open any diagram with a few elements.
2. Click the multi-select button in the bottom-left controls — it lights up (`aria-pressed`).
3. Click several elements one by one → each is added to the selection; click an already-selected one → it's removed.
4. Drag a box across empty canvas → every enclosed element is selected (the canvas doesn't pan).
5. Drag any selected element → the whole selection moves together.
6. Pan with the scroll wheel / trackpad or a middle-drag; click empty canvas → selection clears; press **Escape** → selection clears **and** the mode turns off.

**Touch** (a real phone/tablet, or browser device-emulation)
7. Tap the toggle, then tap elements to build a selection; tap a selected one to remove it.
8. Confirm one-finger drag still **pans** and two-finger **pinch-zoom** still works while the mode is on.

**Automated**
- `pnpm test` (library unit + hook tests)
- `cd standalone/webapp && pnpm exec playwright test tests/e2e/multi-selection-mode.spec.ts --project=chromium`

### Screenshots / screencasts

**Click / tap to add and remove** — mode armed (toggle lit, bottom-left) → three elements added by clicking → one removed by clicking it again:

| 1 · Mode on | 2 · Clicked to select | 3 · Clicked to remove |
|:--:|:--:|:--:|
| ![Multi-select mode enabled, toggle highlighted](https://raw.githubusercontent.com/ls1intum/Apollon/pr-819-assets/01-armed.png) | ![All three classes selected](https://raw.githubusercontent.com/ls1intum/Apollon/pr-819-assets/02-selected.png) | ![Customer removed by clicking it again](https://raw.githubusercontent.com/ls1intum/Apollon/pr-819-assets/03-removed.png) |

**Drag a selection box (mouse)** — a plain left-drag draws a marquee across the canvas:

![Dragging a selection box across the canvas](https://raw.githubusercontent.com/ls1intum/Apollon/pr-819-assets/04-marquee.png)

### Checklist

- [x] Linked to a related issue (if applicable)
- [x] Added a changeset whose summary is written in the user's voice (`pnpm changeset`, [how](https://ls1intum.github.io/Apollon/contributor/development/release-notes/)) — or this PR doesn't touch a Changesets-tracked package (`@tumaet/apollon`, `@tumaet/webapp`, `@tumaet/server`)
- [x] PR title's Conventional Commit type (`feat`/`fix`/…) matches the kind of change — it groups the release note
- [x] Tests added or updated
- [x] Ran `pnpm lint && pnpm format:check && pnpm build && pnpm test` locally — green
- [ ] Documentation updated (if applicable) — no user-facing docs page covers canvas selection gestures; none added
- [x] Screenshots or screencasts attached (if a UI change)
