### PR TITLE
fix(library): stop mutating the host page's color-scheme via style.css

### DIFF
--- a/.changeset/light-hosts-stay-light.md
+++ b/.changeset/light-hosts-stay-light.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Stop mutating the host page's color scheme. `style.css` declared `color-scheme: light dark` on `:root`, so any host that imports the editor CSS and leaves its own `html`/`body` backgrounds transparent (the Docusaurus docs site does) rendered a browser-picked dark canvas behind light-themed text for dark-preference visitors. The declaration is now scoped to the editor mount and `[data-theme]` subtrees; host pages keep full control of their document root.

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -12,9 +12,20 @@
    Static CSS = correct first paint, no runtime <style> injection.
    ────────────────────────────────────────────────────────────────────────── */
 
-:root {
-  color-scheme: light dark;
+/* color-scheme is deliberately NOT set on bare :root. This stylesheet ships
+   inside @tumaet/apollon/style.css, so a `:root { color-scheme: light dark }`
+   would mutate every HOST page that imports the editor CSS: a host that leaves
+   html/body transparent (Docusaurus does) then gets a browser-picked DARK
+   canvas behind its light-themed text for dark-preference visitors. Instead,
+   scope it: the editor mount (and any [data-theme] subtree) declares its own
+   scheme so native controls/scrollbars adapt, and the webapp sets the
+   document-root color-scheme at runtime (useThemeStore.applyThemeToDocument). */
+.apollon-editor,
+[data-theme="light"] {
+  color-scheme: light;
+}
 
+:root {
   /* ── Layer 0: device safe area ─────────────────────────────────────────── */
 
   /* The SINGLE declaration of the safe-area insets — every consumer (the editor's


### PR DESCRIPTION
## Problem

After #823 went live, https://ls1intum.github.io/Apollon/ looked broken for dark-preference visitors — dark canvas and dark-flipped colors bleeding into the light-themed page. The trigger is pre-existing (not introduced by #823, which only refreshed text/assets), but it is very visible on the docs homepage.

## Root cause

`packages/ui/src/styles/tokens.css` declared:

```css
:root {
  color-scheme: light dark;
}
```

These tokens ship inside `@tumaet/apollon/style.css`, so **every host page that imports the editor CSS gets its document root's `color-scheme` rewritten** — exactly the "host mutating `:root`" anti-pattern the file's own scoped-theming comment warns against. Two user-visible consequences on hosts that leave `html`/`body` backgrounds transparent (Docusaurus does):

1. **Dark canvas under light pages.** With every background transparent down to `<html>` (verified via `elementsFromPoint` — nothing paints a background), the browser resolves the page canvas from `color-scheme` + visitor preference: dark-preference visitors get a dark canvas behind light-theme text.
2. **Tokens follow the OS, fighting the host's theme toggle.** lightningcss downlevels the declaration into a global `@media (prefers-color-scheme: dark)` helper-variable flip (visible in the deployed `styles.e10633a2.css`), so token-driven colors switch with the OS scheme even while Docusaurus's `data-theme` stays `light`.

## Fix

Scope the declaration instead of mutating the host root:

- `.apollon-editor` and `[data-theme="light"]` subtrees declare `color-scheme: light` (native controls/scrollbars inside the editor still adapt);
- the existing `:root[data-theme="dark"], [data-theme="dark"]` block keeps `color-scheme: dark` (opt-in via attribute — host-controlled);
- the webapp already sets the document-root `color-scheme` at runtime (`useThemeStore` → `applyThemeToDocument`), so it needs nothing.

## Verification

- Rebuilt `library/dist` CSS now contains exactly one scoped `color-scheme: light` (`.apollon-editor, [data-theme=light]`) and one `color-scheme: dark` — no bare `:root` declaration.
- Rebuilt docs bundle contains **zero** `prefers-color-scheme` blocks (the old deployed bundle had the global var-flip block).
- Headless probe of the rebuilt docs site: `html` computed `color-scheme` is now `light`/`dark` following Docusaurus's own `--ifm-color-scheme` (was `light dark` before), `data-theme` toggles correctly per preference, and the full-page renders light-on-light / dark-on-dark.
- Webapp behavior unchanged (root `color-scheme` set at runtime by the theme store); the per-PR visual suite gates the rest.

A patch changeset is included so embedders get the fix on the next release — this bug affects **any** host that imports `@tumaet/apollon/style.css`, not just the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
