### PR TITLE
docs: npm install @tumaet/apollon is the whole install command

### DIFF
--- a/.changeset/plain-install-command.md
+++ b/.changeset/plain-install-command.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Correct the install guidance on the npm README: `npm install @tumaet/apollon` is all npm 7+, pnpm 8+, and Bun need (they auto-install the required peers); the explicit peer list is only for Yarn, which never installs peers. Also clarify that the PNG/PDF renderers are optional dependencies that install automatically, not "optional peers" the consumer must add.

--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ This monorepo contains every piece of the Apollon platform:
 ## Use the library
 
 ```sh
-npm install @tumaet/apollon react react-dom @xyflow/react yjs y-protocols
+npm install @tumaet/apollon
 ```
 
-`react`, `react-dom`, `@xyflow/react`, `yjs`, and `y-protocols` are required
-peer dependencies — the editor renders on the host's single React and Yjs
-instance instead of bundling its own. See the
-[library README](./library/README.md) for the full API and per-framework guides.
+npm 7+, pnpm 8+, and Bun pull in the required peer dependencies automatically
+(`react`, `react-dom`, `@xyflow/react`, `yjs`, `y-protocols`) — the editor
+renders on the host's single React and Yjs instance instead of bundling its
+own. Yarn never installs peers, so list them in the install command there. See
+the [library README](./library/README.md) for the full API and per-framework
+guides.
 
 ## Run the stack locally
 

--- a/docs/library/api/export.md
+++ b/docs/library/api/export.md
@@ -77,8 +77,9 @@ const { blob, clamped } = await svgToPng(svg, clip, {
 const pdfBlob = await svgToPdf(svg, clip, { title: "diagram" })
 ```
 
-`@resvg/resvg-wasm`, `jspdf` and `svg2pdf.js` are optional dependencies the
-consumer installs (`npm install @resvg/resvg-wasm jspdf svg2pdf.js`); they load
+`@resvg/resvg-wasm`, `jspdf` and `svg2pdf.js` are optional dependencies of
+`@tumaet/apollon`, so a normal install brings them in automatically (install
+them explicitly only under `--omit=optional`); they load
 lazily, so importing the editor never pulls them in. Over-budget diagrams come
 back with `clamped: true` and a reduced `appliedScale`; an over-budget PNG throws
 `RasterTooLargeError`. Inter ships Regular + Bold only, so italics render upright

--- a/docs/library/embedding/angular.md
+++ b/docs/library/embedding/angular.md
@@ -7,9 +7,10 @@ description: Embed Apollon in an Angular host with the imperative ApollonEditor 
 # Angular
 
 Angular never imports React itself — the editor renders its own React tree
-inside the container — but React is a peer the editor uses internally, so you
-install it alongside Apollon:
-`npm install @tumaet/apollon react react-dom @xyflow/react yjs y-protocols`.
+inside the container — but React is a peer the editor uses internally.
+`npm install @tumaet/apollon` brings the peers in automatically on npm 7+,
+pnpm 8+, and Bun; with Yarn list them explicitly
+(`npm install @tumaet/apollon react react-dom @xyflow/react yjs y-protocols`).
 
 ```ts no-check
 import {

--- a/docs/library/embedding/install.md
+++ b/docs/library/embedding/install.md
@@ -11,6 +11,15 @@ Apollon renders on React 19 (`react` / `react-dom` `^19`). On React 18 the
 install fails with an `ERESOLVE` peer error — upgrade your host to React 19 first.
 :::
 
+```sh
+npm install @tumaet/apollon
+```
+
+npm 7+, pnpm 8+, and Bun install the five required peers automatically, so the
+one-liner is all most setups need. Yarn never installs peers; the per-host
+commands below list them explicitly (use them with Yarn, or whenever you want
+to pin the peer versions yourself).
+
 ## React hosts
 
 You already have `react` and `react-dom` — add the remaining peers:
@@ -55,7 +64,8 @@ import "@tumaet/apollon/style.css"
 | `yjs`           | `^13.6.0` | the document model, undo/redo, and live collaboration |
 | `y-protocols`   | `^1.0.6`  | collaboration sync/awareness                          |
 
-npm 7+ auto-installs missing peers; **pnpm and yarn users add them explicitly**.
+npm 7+, pnpm 8+, and Bun auto-install missing required peers; **Yarn never
+does** — add them explicitly there.
 Apollon externalizes every runtime dependency, so a host that already uses React
 or Yjs shares a single instance with the editor instead of a private, possibly
 mismatched copy — no duplicate payload, and no "Invalid hook call" or
@@ -63,8 +73,11 @@ cross-instance-document errors.
 
 ## Optional: PNG / PDF export
 
-SVG and JSON export are built in. For PNG and PDF, install the optional renderers
-and import them from `@tumaet/apollon/export`:
+SVG and JSON export are built in. The PNG/PDF renderers (`@resvg/resvg-wasm`,
+`jspdf`, `svg2pdf.js`) ship as **optional dependencies** of `@tumaet/apollon`,
+so a normal install brings them in automatically; import them from
+`@tumaet/apollon/export`. Add them explicitly only if you install with
+`--omit=optional` (or an optional install was skipped):
 
 ```sh
 npm install @resvg/resvg-wasm jspdf svg2pdf.js

--- a/docs/library/quickstart.md
+++ b/docs/library/quickstart.md
@@ -18,12 +18,13 @@ The `react` / `react-dom` peers are `^19`. On React 18 the install fails with an
 :::
 
 ```sh
-npm install @tumaet/apollon react react-dom @xyflow/react yjs y-protocols
+npm install @tumaet/apollon
 ```
 
-Apollon externalizes its dependencies, so you install them as peers: `react`,
-`react-dom`, `@xyflow/react`, `yjs`, and `y-protocols`. Most package managers add
-them automatically — see [Install](/library/embedding/install).
+Apollon externalizes its dependencies as peers (`react`, `react-dom`,
+`@xyflow/react`, `yjs`, `y-protocols`). npm 7+, pnpm 8+, and Bun install them
+automatically; Yarn never installs peers, so list them explicitly there — see
+[Install](/library/embedding/install).
 
 :::danger The editor MUST have an explicit height
 Apollon renders onto a React Flow canvas, which sizes itself to its parent. If

--- a/docs/library/upgrading.md
+++ b/docs/library/upgrading.md
@@ -55,7 +55,7 @@ npm install @tumaet/apollon \
   yjs y-protocols
 ```
 
-npm 7+ auto-installs missing peers; **pnpm and yarn users must add them
+npm 7+, pnpm 8+, and Bun auto-install missing peers; **Yarn users must add them
 explicitly**. See [Install](/library/embedding/install) for why they're external.
 
 ## React 19 is required

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -113,10 +113,7 @@ function Hero() {
           </Link>
         </div>
         <div className={styles.install}>
-          <CodeBlock language="bash">
-            npm install @tumaet/apollon react react-dom @xyflow/react yjs
-            y-protocols
-          </CodeBlock>
+          <CodeBlock language="bash">npm install @tumaet/apollon</CodeBlock>
         </div>
       </div>
     </header>

--- a/docs/user/overview.md
+++ b/docs/user/overview.md
@@ -54,7 +54,7 @@ versioned and reviewed like any other source.
 you need UML modeling inside an existing application.
 
 ```sh
-npm install @tumaet/apollon react react-dom @xyflow/react yjs y-protocols
+npm install @tumaet/apollon
 ```
 
 | You want to...                                  | Use this           |

--- a/library/README.md
+++ b/library/README.md
@@ -41,10 +41,14 @@ Apollon is the modeling editor behind [Artemis](https://artemis.tum.de/), TUM's 
 ## Install
 
 ```sh
-npm install @tumaet/apollon \
-  react react-dom \
-  @xyflow/react \
-  yjs y-protocols
+npm install @tumaet/apollon
+```
+
+npm 7+, pnpm 8+, and Bun resolve the required peer dependencies automatically.
+Yarn never installs peers — list them explicitly there:
+
+```sh
+npm install @tumaet/apollon react react-dom @xyflow/react yjs y-protocols
 ```
 
 ```ts
@@ -54,7 +58,7 @@ import "@tumaet/apollon/style.css"
 
 Apollon ships **one** build with every runtime dependency left external — the React family (`react`, `react-dom`, `@xyflow/react`), the CRDT singletons (`yjs`, `y-protocols`), and Apollon's own UI deps (`@base-ui/react`, `lucide-react`, `@dnd-kit`, `zustand`, `@chenglou/pretext`), which arrive transitively when you install the package. Your bundler resolves and de-duplicates each one against your app's `node_modules`, and your bundle analyzer / SBOM tooling sees them as the real packages they are — never a copy inlined invisibly into one chunk. This works from any framework with a bundler (Angular, Vue, Svelte, React).
 
-These are the peers you install explicitly:
+The required peers, and what each powers:
 
 | Peer            | Range     | Powers                                                |
 | --------------- | --------- | ----------------------------------------------------- |
@@ -64,7 +68,7 @@ These are the peers you install explicitly:
 | `yjs`           | `^13.6.0` | the document model, undo/redo, and live collaboration |
 | `y-protocols`   | `^1.0.6`  | collaboration sync/awareness                          |
 
-Most package managers install missing peers automatically; the explicit command above is listed for clarity. Keeping these external means a host that already uses React or Yjs shares a single instance with the editor instead of loading a private, possibly mismatched copy — no duplicate payload, and no "Invalid hook call" or cross-instance-document errors.
+Keeping these external means a host that already uses React or Yjs shares a single instance with the editor instead of loading a private, possibly mismatched copy — no duplicate payload, and no "Invalid hook call" or cross-instance-document errors.
 
 ### Non-React hosts (Angular, Vue, Svelte, vanilla)
 
@@ -234,7 +238,7 @@ Any Yjs-compatible transport works: `y-websocket`, `y-webrtc`, BroadcastChannel,
 - **SVG**: `await editor.exportAsSVG(options)` resolves to `{ svg, clip }`. `svgMode: "web"` (the default) keeps CSS variables for theme-adaptive output; `"compat"` inlines them for PDF and Inkscape.
 - **JSON**: `editor.model` returns the `UMLModel`, and assigning it back is round-trip safe. Use `importDiagram(json)` to normalize older v2/v3 models first.
 - **Headless**: `ApollonEditor.exportModelAsSvg(model, options)` renders a model without a mounted editor.
-- **PNG / PDF**: not built in, but the library ships `svgToPng` / `svgToPdf` renderers under [`@tumaet/apollon/export`](https://ls1intum.github.io/Apollon/library/api/export) (PNG via `@resvg/resvg-wasm`, PDF via `svg2pdf.js` + `jspdf`, installed as optional peers). The standalone server in this repo renders server-side instead, with `@napi-rs/canvas` (PNG) and `pdfmake` (PDF).
+- **PNG / PDF**: not built in, but the library ships `svgToPng` / `svgToPdf` renderers under [`@tumaet/apollon/export`](https://ls1intum.github.io/Apollon/library/api/export) (PNG via `@resvg/resvg-wasm`, PDF via `svg2pdf.js` + `jspdf` — optional dependencies that install automatically with the package). The standalone server in this repo renders server-side instead, with `@napi-rs/canvas` (PNG) and `pdfmake` (PDF).
 
 See [Export](https://ls1intum.github.io/Apollon/library/api/export) for the full `ExportOptions`.
 


### PR DESCRIPTION
## What

`npm install @tumaet/apollon` **is** the whole install command on modern package managers — but every quickstart surface led with the five-peer variant, implying the peers must be added by hand. Two claims in the docs were outright wrong. This PR makes the install story accurate and consistent everywhere.

## Facts (verified against `library/package.json` + package-manager docs)

- The package declares five **required peers** (`react`, `react-dom`, `@xyflow/react`, `yjs`, `y-protocols`). [npm 7+ installs missing peer dependencies automatically](https://github.blog/news-insights/product-news/presenting-v7-0-0-of-the-npm-cli/); [pnpm auto-installs them via `auto-install-peers`, default `true` since pnpm 8](https://pnpm.io/npmrc#auto-install-peers); Bun also installs peers. [Yarn never installs peers](https://github.com/orgs/pnpm/discussions/3995).
- The PNG/PDF renderers (`@resvg/resvg-wasm`, `jspdf`, `svg2pdf.js`) are **`optionalDependencies` of `@tumaet/apollon`** — a normal install brings them in automatically. They are not "optional peers" the consumer must install.

## Changes

- **Lead with the one-liner** everywhere: root README, npm README (`library/README.md`), docs landing hero, library quickstart, user-guide overview, install + Angular guides. The explicit five-peer command stays as the Yarn / pin-versions-yourself path.
- **Fix false claims**: `install.md` and `upgrading.md` said "pnpm and yarn users must add them explicitly" — wrong for pnpm 8+.
- **Fix renderer wording** in `install.md`, `api/export.md`, and the npm README: optional dependencies install automatically; the explicit command only matters under `--omit=optional`.
- Patch changeset so the corrected README ships to npmjs.com on the next release.

## Verification

- `pnpm run lint:docs` clean, Prettier clean, docs site builds.
- Peer/optional facts checked against `library/package.json` (`peerDependencies`, `optionalDependencies`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
