### PR TITLE
fix(library): pin editor chrome and stop repainting host borders

### DIFF
--- a/.changeset/chrome-stays-at-the-canvas-edge.md
+++ b/.changeset/chrome-stays-at-the-canvas-edge.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Keep the zoom, undo and minimap controls pinned to the bottom of the canvas in embedded editors. An editor mounted below the fold mistook the gap between its bottom edge and the window for an on-screen keyboard and reserved that whole gap as padding, stranding the controls mid-diagram — and scrolling the editor into view never cleared it. The editor now reserves only the part of the canvas a keyboard actually covers.

--- a/.changeset/host-borders-stay-host-borders.md
+++ b/.changeset/host-borders-stay-host-borders.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Stop repainting the host page's borders. Importing the editor's `style.css` reset the border colour of every element on the page, so the host's own inputs, selects, buttons and fieldsets lost the browser's neutral grey and took on the surrounding text colour — near-black on a light page, stark white on a dark one. The reset now applies only to the editor's own controls.

--- a/.github/workflows/pr-health-checks.yml
+++ b/.github/workflows/pr-health-checks.yml
@@ -37,6 +37,7 @@ jobs:
           filters: |
             code:
               - 'library/**'
+              - 'packages/**'
               - 'standalone/**'
               - 'vscode-extension/**'
               - 'docs/**'
@@ -51,6 +52,9 @@ jobs:
               - '.github/actions/**'
             library:
               - 'library/**'
+              # api-extractor bundles @tumaet/ui into the published library, so
+              # a design-system change ships to consumers as a library change.
+              - 'packages/**'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - '.github/workflows/pr-health-checks.yml'

--- a/.github/workflows/pr-health-checks.yml
+++ b/.github/workflows/pr-health-checks.yml
@@ -61,9 +61,12 @@ jobs:
               - '.github/actions/**'
             vscode:
               # The extension bundles the library and typechecks against its
-              # emitted declarations, so a library change can break it.
+              # emitted declarations, so a library change can break it — and
+              # api-extractor inlines @tumaet/ui into those declarations, so a
+              # design-system change reaches the extension the same way.
               - 'vscode-extension/**'
               - 'library/**'
+              - 'packages/**'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - '.github/workflows/pr-health-checks.yml'

--- a/docs/src/components/ApollonEmbed/heroModel.json
+++ b/docs/src/components/ApollonEmbed/heroModel.json
@@ -1,0 +1,256 @@
+{
+  "id": "fixture-readme-hero-001",
+  "version": "4.0.0",
+  "title": "Apollon",
+  "type": "ClassDiagram",
+  "nodes": [
+    {
+      "id": "9f1d2a30-0000-4000-8000-000000000001",
+      "width": 220,
+      "height": 130,
+      "type": "class",
+      "position": {
+        "x": 40,
+        "y": 55
+      },
+      "data": {
+        "name": "Diagram",
+        "attributes": [
+          {
+            "id": "hero-a1",
+            "name": "- title: string"
+          },
+          {
+            "id": "hero-a2",
+            "name": "- type: DiagramType"
+          }
+        ],
+        "methods": [
+          {
+            "id": "hero-m1",
+            "name": "+ exportAsSVG(): SVG"
+          }
+        ]
+      },
+      "measured": {
+        "width": 220,
+        "height": 130
+      }
+    },
+    {
+      "id": "9f1d2a30-0000-4000-8000-000000000002",
+      "width": 200,
+      "height": 170,
+      "type": "class",
+      "position": {
+        "x": 50,
+        "y": 330
+      },
+      "data": {
+        "name": "DiagramType",
+        "stereotype": "Enumeration",
+        "attributes": [
+          {
+            "id": "hero-a3",
+            "name": "CLASS"
+          },
+          {
+            "id": "hero-a4",
+            "name": "ACTIVITY"
+          },
+          {
+            "id": "hero-a5",
+            "name": "BPMN"
+          },
+          {
+            "id": "hero-a6",
+            "name": "SFC"
+          }
+        ],
+        "methods": []
+      },
+      "measured": {
+        "width": 200,
+        "height": 170
+      }
+    },
+    {
+      "id": "9f1d2a30-0000-4000-8000-000000000003",
+      "width": 230,
+      "height": 135,
+      "type": "class",
+      "position": {
+        "x": 420,
+        "y": 54.5
+      },
+      "data": {
+        "name": "Element",
+        "stereotype": "Abstract",
+        "attributes": [
+          {
+            "id": "hero-a7",
+            "name": "# id: ID"
+          },
+          {
+            "id": "hero-a8",
+            "name": "# name: string"
+          }
+        ],
+        "methods": [
+          {
+            "id": "hero-m2",
+            "name": "+ moveBy(delta: Point)"
+          }
+        ]
+      },
+      "measured": {
+        "width": 230,
+        "height": 135
+      }
+    },
+    {
+      "id": "9f1d2a30-0000-4000-8000-000000000004",
+      "width": 200,
+      "height": 100,
+      "type": "class",
+      "position": {
+        "x": 285,
+        "y": 330
+      },
+      "data": {
+        "name": "Node",
+        "attributes": [
+          {
+            "id": "hero-a9",
+            "name": "- position: Point"
+          }
+        ],
+        "methods": [
+          {
+            "id": "hero-m3",
+            "name": "+ resize(w, h)"
+          }
+        ]
+      },
+      "measured": {
+        "width": 200,
+        "height": 100
+      }
+    },
+    {
+      "id": "9f1d2a30-0000-4000-8000-000000000005",
+      "width": 200,
+      "height": 100,
+      "type": "class",
+      "position": {
+        "x": 585,
+        "y": 330
+      },
+      "data": {
+        "name": "Edge",
+        "attributes": [
+          {
+            "id": "hero-a10",
+            "name": "- source: Node"
+          },
+          {
+            "id": "hero-a11",
+            "name": "- target: Node"
+          }
+        ],
+        "methods": []
+      },
+      "measured": {
+        "width": 200,
+        "height": 100
+      }
+    },
+    {
+      "id": "9f1d2a30-0000-4000-8000-000000000006",
+      "width": 200,
+      "height": 115,
+      "type": "class",
+      "position": {
+        "x": 810,
+        "y": 59.5
+      },
+      "data": {
+        "name": "Selectable",
+        "stereotype": "Interface",
+        "attributes": [],
+        "methods": [
+          {
+            "id": "hero-m4",
+            "name": "+ select()"
+          },
+          {
+            "id": "hero-m5",
+            "name": "+ deselect()"
+          }
+        ]
+      },
+      "measured": {
+        "width": 200,
+        "height": 115
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "hero-edge-node-element",
+      "source": "9f1d2a30-0000-4000-8000-000000000004",
+      "target": "9f1d2a30-0000-4000-8000-000000000003",
+      "type": "ClassInheritance",
+      "sourceHandle": "top",
+      "targetHandle": "bottom",
+      "data": {
+        "points": []
+      }
+    },
+    {
+      "id": "hero-edge-edge-element",
+      "source": "9f1d2a30-0000-4000-8000-000000000005",
+      "target": "9f1d2a30-0000-4000-8000-000000000003",
+      "type": "ClassInheritance",
+      "sourceHandle": "top",
+      "targetHandle": "bottom",
+      "data": {
+        "points": []
+      }
+    },
+    {
+      "id": "hero-edge-element-selectable",
+      "source": "9f1d2a30-0000-4000-8000-000000000003",
+      "target": "9f1d2a30-0000-4000-8000-000000000006",
+      "type": "ClassRealization",
+      "sourceHandle": "right",
+      "targetHandle": "left",
+      "data": {
+        "points": []
+      }
+    },
+    {
+      "id": "hero-edge-diagram-element",
+      "source": "9f1d2a30-0000-4000-8000-000000000001",
+      "target": "9f1d2a30-0000-4000-8000-000000000003",
+      "type": "ClassComposition",
+      "sourceHandle": "right",
+      "targetHandle": "left",
+      "data": {
+        "points": []
+      }
+    },
+    {
+      "id": "hero-edge-diagram-diagramtype",
+      "source": "9f1d2a30-0000-4000-8000-000000000001",
+      "target": "9f1d2a30-0000-4000-8000-000000000002",
+      "type": "ClassUnidirectional",
+      "sourceHandle": "bottom",
+      "targetHandle": "top",
+      "data": {
+        "points": []
+      }
+    }
+  ],
+  "assessments": {}
+}

--- a/docs/src/components/ApollonEmbed/index.tsx
+++ b/docs/src/components/ApollonEmbed/index.tsx
@@ -1,11 +1,23 @@
 import { Apollon } from "@tumaet/apollon"
+import type { UMLModel } from "@tumaet/apollon"
 import "@tumaet/apollon/style.css"
+import heroModel from "./heroModel.json"
 
 /**
  * The live editor on the docs homepage. Wrap in `<BrowserOnly>` at the call
  * site — the editor touches `window` and would crash Docusaurus's SSR
  * pre-render. Sizing comes from `.apollon-embed-frame` (src/css/custom.css).
+ *
+ * Fit on mount: the editor's own load-time fit pins `minZoom: 1.0`, so it can
+ * pan but never zoom out, and the hero model clips on narrow embeds.
  */
 export default function ApollonEmbed() {
-  return <Apollon className="apollon-embed-frame" />
+  return (
+    <Apollon
+      className="apollon-embed-frame"
+      // Cast only widens `version` back from `string`; the rest is type-checked.
+      defaultModel={heroModel as UMLModel}
+      onMount={(editor) => editor.fitView({ duration: 0 })}
+    />
+  )
 }

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -33,9 +33,15 @@
   color: var(--ifm-color-emphasis-700);
 }
 
+/* Bottom-light padding here and in `.demo` pulls the editor toward the fold.
+   Deliberate — don't re-symmetrize. */
 .hero {
-  padding-block: clamp(3.5rem, 7vw, 6rem);
+  padding-block: clamp(3rem, 6vw, 5rem) clamp(1.5rem, 3vw, 2.5rem);
   text-align: center;
+}
+
+.demo {
+  padding-top: clamp(1.5rem, 3vw, 2.5rem);
 }
 
 /* Center the hero children as flex items. Margin-auto centering loses the
@@ -85,6 +91,16 @@
   max-width: 22rem;
   margin-top: 1.75rem;
   text-align: left;
+}
+
+.heroMeta {
+  margin-top: 1.25rem;
+  margin-bottom: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--ifm-color-emphasis-600);
+  max-width: 44ch;
+  text-wrap: pretty;
 }
 
 .demoRow {

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -115,6 +115,11 @@ function Hero() {
         <div className={styles.install}>
           <CodeBlock language="bash">npm install @tumaet/apollon</CodeBlock>
         </div>
+        <p className={styles.heroMeta}>
+          Open source (MIT), built at the Technical University of Munich — the
+          Angular editor in <Link href="https://artemis.tum.de">Artemis</Link>{" "}
+          runs on <code>@tumaet/apollon</code>.
+        </p>
       </div>
     </header>
   )
@@ -225,10 +230,9 @@ const WAYS: LinkCard[] = [
     title: "Embed it",
     body: (
       <>
-        <code>@tumaet/apollon</code> on npm. One build, every framework:{" "}
-        <code>react</code>, <code>react-dom</code>, <code>@xyflow/react</code>,{" "}
-        <code>yjs</code>, and <code>y-protocols</code> are required peers the
-        host shares with the editor.
+        One <code>@tumaet/apollon</code> package on npm, mounted in React,
+        Angular, or plain JavaScript. Your app shares a handful of peer
+        dependencies with the editor — the embedding guide lists them.
       </>
     ),
     to: "/library/",

--- a/library/lib/overlay/OverlayLayer.tsx
+++ b/library/lib/overlay/OverlayLayer.tsx
@@ -124,10 +124,16 @@ function useKeyboardInset(gridRef: RefObject<HTMLDivElement | null>): void {
       host = (grid?.closest(".apollon-canvas") as HTMLElement | null) ?? grid
       if (!host) return
       const keyboardTop = vv.offsetTop + vv.height
-      const overlap = Math.max(
-        0,
-        host.getBoundingClientRect().bottom - keyboardTop
+      // Clamp to the visible viewport: canvas below the fold is not covered by
+      // the keyboard, so the inset can never exceed the keyboard's own height.
+      // Unclamped, an editor mounted below the fold reserved the whole gap to
+      // the window bottom — and `visualViewport` fires no `scroll` for
+      // layout-viewport scrolling, so that value never cleared.
+      const visibleBottom = Math.min(
+        host.getBoundingClientRect().bottom,
+        window.innerHeight
       )
+      const overlap = Math.max(0, visibleBottom - keyboardTop)
       host.style.setProperty("--apollon-keyboard-inset", `${overlap}px`)
     }
     update()

--- a/library/tests/unit/overlayApi.test.tsx
+++ b/library/tests/unit/overlayApi.test.tsx
@@ -546,6 +546,55 @@ describe("useKeyboardInset (OverlayLayer)", () => {
       delete window.visualViewport
     }
   })
+
+  // Only the part of the canvas the keyboard actually covers counts. A canvas
+  // running past the fold must reserve nothing extra — and nothing at all when
+  // no keyboard is up, since no `scroll` fires on layout scroll to clear it.
+  it("reserves at most the keyboard height for a canvas past the fold", () => {
+    const listeners: Record<string, Set<() => void>> = {}
+    const vv = {
+      height: 768, // equal to the layout viewport — no keyboard, no pinch-zoom
+      offsetTop: 0,
+      addEventListener: (type: string, cb: () => void) => {
+        ;(listeners[type] ??= new Set()).add(cb)
+      },
+      removeEventListener: (type: string, cb: () => void) => {
+        listeners[type]?.delete(cb)
+      },
+    }
+    const origInner = Object.getOwnPropertyDescriptor(window, "innerHeight")
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 768,
+    })
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: vv,
+    })
+
+    try {
+      const belowFold = renderLayer(768 + 500)
+      act(() => {
+        listeners.resize?.forEach((cb) => cb())
+      })
+      expect(
+        belowFold.grid.style.getPropertyValue("--apollon-keyboard-inset")
+      ).toBe("0px")
+
+      // A 300px keyboard opens: reserve the keyboard, not the 500px overhang.
+      act(() => {
+        vv.height = 468
+        listeners.resize?.forEach((cb) => cb())
+      })
+      expect(
+        belowFold.grid.style.getPropertyValue("--apollon-keyboard-inset")
+      ).toBe("300px")
+    } finally {
+      if (origInner) Object.defineProperty(window, "innerHeight", origInner)
+      // @ts-expect-error clear the stubbed property (jsdom has none by default)
+      delete window.visualViewport
+    }
+  })
 })
 
 // `<Apollon.SelectionToolbar>` composes a selection-anchored toolbar. Like the

--- a/packages/ui/src/styles/components.css
+++ b/packages/ui/src/styles/components.css
@@ -32,14 +32,19 @@
 
 /* Border-color safety net (Tailwind v4 ships no Preflight border reset, so bare
    `border`/`border-t`/`border-b` utilities inherit `currentColor` = foreground →
-   near-black dividers in light, pure-white in dark). Default every border to the
-   design token so dividers stay subtle and theme-following. Scoped under @layer
-   base so any explicit border-color utility (which Tailwind emits in the
-   `utilities` layer) still wins. */
+   near-black dividers in light, pure-white in dark). Defaults our own borders to
+   the design token where it is defined — the webapp, which loads `theme.css`;
+   in the published bundle the token is absent, so this resolves to `currentColor`
+   and the rule is inert. Scoped under @layer base so any explicit border-color
+   utility (which Tailwind emits in the `utilities` layer) still wins. Scoped to
+   our `[data-slot]` primitives like the box-sizing floor below — an unscoped `*`
+   shipped in `style.css` and repainted every embedding page's form controls.
+   Don't re-widen it. */
 @layer base {
-  *,
-  ::before,
-  ::after {
+  [data-slot],
+  [data-slot] *,
+  [data-slot] ::before,
+  [data-slot] ::after {
     border-color: var(--color-border);
   }
 

--- a/packages/ui/tests/hostLeak.test.ts
+++ b/packages/ui/tests/hostLeak.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+// This file is compiled into the published `@tumaet/apollon` style.css, so any
+// selector that can match host DOM restyles every embedding page — an unscoped
+// `border-color` on `*` repainted host form controls until it was scoped.
+// Anchoring is the invariant; an allowlist catches `input`/`button`/`::selection`
+// that a denylist of known-bad selectors would wave through.
+
+const css = readFileSync(
+  resolve(__dirname, "../src/styles/components.css"),
+  "utf8"
+)
+
+/** Leading compound of every selector in the file, `@layer` nesting included. */
+function leadingCompounds(): string[] {
+  return [...css.replace(/\/\*[\s\S]*?\*\//g, "").matchAll(/([^{}]+)\{/g)]
+    .flatMap((m) => m[1].split(";").pop()!.split(","))
+    .map((s) => s.trim().split(/[\s>+~]/)[0])
+    .filter((s) => s && !s.startsWith("@"))
+}
+
+describe("published CSS cannot restyle host DOM", () => {
+  it("anchors every selector to a [data-slot] or .apollon- element", () => {
+    expect(
+      leadingCompounds().filter((s) => !/\[data-slot|\.apollon-/.test(s))
+    ).toEqual([])
+  })
+})

--- a/standalone/webapp/src/components/playground/theme/ThemeConfigurator.tsx
+++ b/standalone/webapp/src/components/playground/theme/ThemeConfigurator.tsx
@@ -221,7 +221,7 @@ export const ThemeConfigurator = ({
         )}
 
         {activeGroup.note && (
-          <p className="text-muted-foreground m-0 mb-1 rounded-md border border-dashed p-2 text-[11px] leading-snug">
+          <p className="text-muted-foreground border-border m-0 mb-1 rounded-md border border-dashed p-2 text-[11px] leading-snug">
             {activeGroup.note}
           </p>
         )}


### PR DESCRIPTION
### Summary

Two bugs that only appear when Apollon is embedded in someone else's page. Our own docs homepage was the first host to hit both, which is how they surfaced — but they ship to every consumer of `@tumaet/apollon`.

**1. The zoom / undo / minimap controls drifted into the middle of the diagram.**

`useKeyboardInset` measured the distance from the canvas's bottom edge to the bottom of the window and treated it as on-screen-keyboard overlap. That distance is positive for *any* editor mounted below the fold — a docs page, a long form, anything the reader scrolls to — so the editor reserved that entire gap as padding. `visualViewport` emits no `scroll` event for ordinary layout-viewport scrolling ([csswg-drafts#8205](https://github.com/w3c/csswg-drafts/pull/8205)), so the bogus value measured at mount never cleared, even once the editor was fully in view.

The overlap is now clamped to the visible viewport, so it can never exceed the keyboard's own height.

**2. Importing the editor's CSS repainted the host page's borders.**

`components.css` applied a `border-color` reset to `*`. That rule ships inside the published `style.css`, so it reached host DOM — where `--color-border` is undefined. An unresolvable `var()` is invalid at computed-value time, which makes the property behave as `unset`; `border-color` doesn't inherit, so it falls back to its initial `currentColor`. Host inputs, selects, buttons and fieldsets take their border colour from the UA stylesheet, and *any* author rule outranks the UA sheet — so they lost their neutral grey and picked up the surrounding text colour.

Scoped to our own `[data-slot]` primitives, matching the `box-sizing` floor directly beside it. Same class of bug as #824.

Alongside those, the docs homepage gets what it needed to actually demonstrate the product: the live embed is seeded with a real diagram instead of an empty canvas, and the hero is tightened so the editor sits nearer the fold.

### Release note

Two entries, both `@tumaet/apollon` patches:

- Keep the zoom, undo and minimap controls pinned to the bottom of the canvas in embedded editors.
- Stop repainting the host page's borders when the editor's `style.css` is imported.

### Implementation notes

**Why a clamp rather than an "is the keyboard open?" check.** Gating on "the visual viewport is shrunk" looks equivalent and isn't: with a keyboard actually open on a below-the-fold editor it still reserves the whole overhang (800px for a 300px keyboard), and sub-pixel rounding between `clientHeight` and `visualViewport.height` reopens the original bug. Clamping `host.bottom` to the visible viewport bounds the result by construction. The unit test asserts both cases and was checked against both incorrect formulas.

**A dead end worth recording, so nobody re-treads it.** The stranded chrome looks exactly like a CSS Grid `fr` failure, and an earlier attempt at this fix "corrected" grid track sizing in JavaScript. That was wrong: an absolutely-positioned `inset: 0` grid has a *definite* height ([css-sizing-3 §4.1](https://www.w3.org/TR/css-sizing-3/)) and `fr` resolves correctly here. Neutralising the keyboard inset alone makes the centre track fill properly with no grid changes at all. The grid is untouched by this PR.

**CI gap closed.** `packages/**` was missing from every paths-filter, so changes to `@tumaet/ui` triggered no checks at all — even though api-extractor bundles it into the published library (`bundledPackages: ["@tumaet/ui"]`). Without this, the new leak guard could not fire on a PR that only touched the package it guards. It's now in the `code`, `library` **and** `vscode` filters; the last of those came out of review — `vscode-extension-checks` runs `pnpm run build:lib` and typechecks the extension against the declarations api-extractor inlines `@tumaet/ui` into, so a design-system-only PR must not skip it.

**Tests.** Both new guards were mutation-tested rather than assumed: each was re-run against the exact code it replaces and confirmed to fail. The CSS guard is an allowlist (every selector must anchor to `[data-slot]` or `.apollon-`) rather than a denylist of known-bad selectors, because a denylist waves through `input`, `button` and `::selection` — the very selectors that would reproduce this bug.

**Something I removed rather than shipped.** An earlier revision of this branch added a `docs/.browserslistrc` to stop `@csstools/postcss-cascade-layers` rewriting unlayered rules with `:not(#\#)`, which lets Infima's `:root` outrank `custom.css` and renders the brand blue as `#3578e5`. On checking the *production* bundle it turned out that polyfill only runs under `docusaurus start`: the built site already emits zero `:not(#\#)` and renders `#3e8acc` correctly. The file changed production browser targets (including SWC's JS output) to fix a dev-server-only cosmetic difference, so it's gone. The dev/prod divergence is real but harmless and out of scope here; `configurePostCss` is the surgical lever if we ever want to close it.

**Deliberately not done.** The `heroModel.json` fixture is intentionally not shared with the webapp's visual-regression fixture; they are independent artefacts and should be free to diverge, and reaching from docs source into another workspace's `tests/` would be worse. The pre-existing pinch-zoom (`visualViewport.scale`) edge case is unchanged.

**Known limitation.** The keyboard path is covered by unit tests and by the spec, but I have not verified it on physical iOS or Android hardware. That's the one thing I'd want a device (or a second pair of eyes) on before release.

### Steps for testing

1. `pnpm install && pnpm run build:docs && pnpm --filter @tumaet/docs exec docusaurus serve`
2. Open the homepage and scroll the live editor fully into view. The zoom, undo and minimap controls sit flush against the bottom edge of the canvas, and the editor shows a class diagram rather than an empty grid.
3. Scroll to **What you get** — the cards have a blue top accent and light grey sides, not near-black.
4. Confirm the guards actually bite:
   - Re-widen the selector in `packages/ui/src/styles/components.css` back to `*` → `pnpm --filter @tumaet/ui exec vitest run tests/hostLeak` fails.
   - Remove the clamp in `library/lib/overlay/OverlayLayer.tsx` → `pnpm --filter @tumaet/apollon exec vitest run tests/unit/overlayApi` fails.
5. `pnpm lint && pnpm format:check && pnpm build && pnpm test`

### Screenshots / screencasts

**Editor chrome.** The controls sat stranded in the middle of the canvas over an empty diagram; they now sit flush against the bottom edge, with the embed seeded so it actually shows a diagram.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/ls1intum/Apollon/pr-827-assets/1-before-controls-stranded.png" alt="Docs homepage embed with the zoom, undo and minimap controls floating in the middle of an empty canvas" width="420"> | <img src="https://raw.githubusercontent.com/ls1intum/Apollon/pr-827-assets/2-after-controls-pinned.png" alt="Same embed with the controls flush to the bottom edge and a seeded class diagram" width="420"> |

**Host borders.** The same regression inside our own docs: the cards took the editor's `*` border reset and went near-black. They now show the intended blue top accent and light grey sides.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/ls1intum/Apollon/pr-827-assets/3-before-card-borders.png" alt="What you get cards outlined in near-black on all four sides" width="420"> | <img src="https://raw.githubusercontent.com/ls1intum/Apollon/pr-827-assets/4-after-card-borders.png" alt="Same cards with a blue top accent and light grey sides" width="420"> |

<sub>Images live on the <a href="https://github.com/ls1intum/Apollon/tree/pr-827-assets"><code>pr-827-assets</code></a> branch so binaries stay out of the code history; delete it once this is merged.</sub>

### Checklist

- [ ] Linked to a related issue (if applicable)
- [x] Added a changeset whose summary is written in the user's voice (`pnpm changeset`, [how](https://ls1intum.github.io/Apollon/contributor/development/release-notes/)) — or this PR doesn't touch a Changesets-tracked package (`@tumaet/apollon`, `@tumaet/webapp`, `@tumaet/server`)
- [x] PR title's Conventional Commit type (`feat`/`fix`/…) matches the kind of change — it groups the release note
- [x] Tests added or updated
- [x] Ran `pnpm lint && pnpm format:check && pnpm build && pnpm test` locally — green
- [x] Documentation updated (if applicable)
- [x] Screenshots or screencasts attached (if a UI change)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
