### PR TITLE
feat(library): customizable straight edges — waypoints, tidy-tree layout & obstacle routing

### DIFF
--- a/.changeset/customizable-straight-edges.md
+++ b/.changeset/customizable-straight-edges.md
@@ -9,8 +9,9 @@ drag it back onto the line to remove it — so you can route a link cleanly arou
 node by hand. These connections now also attach at the side of each element that faces its
 partner and spread evenly across a shared side when several connect to the same element —
 so they read cleanly instead of stacking on one point or leaving from an arbitrary corner.
-Use-case and petri-net connections additionally bend around a node that sits directly in
-their path, while a clear straight shot stays straight, and your hand-placed waypoints are
-always respected. Syntax trees stay drawn as straight parent-to-child lines and gain a
-one-click "Tidy tree layout" that arranges the nodes hierarchically so the links no longer
-overlap sibling nodes.
+They also bend around any node that sits directly in their path — leaving each element
+squarely rather than sliding out along its side, taking one clear corner instead of a
+staircase of kinks, and keeping their distance from other connections instead of crossing
+or crowding them. A clear straight shot still stays straight, and your hand-placed
+waypoints are always respected. Syntax trees additionally gain a one-click "Tidy tree
+layout" that arranges the nodes hierarchically so the links no longer overlap siblings.

--- a/.changeset/customizable-straight-edges.md
+++ b/.changeset/customizable-straight-edges.md
@@ -6,7 +6,10 @@ Shape and tidy diagonal-line diagrams the same way you already can with orthogon
 edges. Use-case, syntax-tree and petri-net connections now have draggable waypoints —
 grab a segment's midpoint to add a bend, drag a bend to move it, and double-click or
 drag it back onto the line to remove it — so you can route a link cleanly around a
-node by hand. These connections also bend automatically around any node that sits
-directly in their path, while a clear straight shot stays straight, and your hand-placed
-waypoints are always respected. Syntax trees gain a one-click "Tidy tree layout" that
-arranges nodes hierarchically so parent-to-child links no longer overlap sibling nodes.
+node by hand. These connections now also attach at the side of each element that faces its
+partner and spread evenly across a shared side when several connect to the same element —
+so they read cleanly instead of stacking on one point or leaving from an arbitrary corner.
+They bend automatically around any node that sits directly in their path, while a clear
+straight shot stays straight, and your hand-placed waypoints are always respected. Syntax
+trees gain a one-click "Tidy tree layout" that arranges nodes hierarchically so
+parent-to-child links no longer overlap sibling nodes.

--- a/.changeset/customizable-straight-edges.md
+++ b/.changeset/customizable-straight-edges.md
@@ -1,0 +1,12 @@
+---
+"@tumaet/apollon": minor
+---
+
+Shape and tidy diagonal-line diagrams the same way you already can with orthogonal
+edges. Use-case, syntax-tree and petri-net connections now have draggable waypoints —
+grab a segment's midpoint to add a bend, drag a bend to move it, and double-click or
+drag it back onto the line to remove it — so you can route a link cleanly around a
+node by hand. These connections also bend automatically around any node that sits
+directly in their path, while a clear straight shot stays straight, and your hand-placed
+waypoints are always respected. Syntax trees gain a one-click "Tidy tree layout" that
+arranges nodes hierarchically so parent-to-child links no longer overlap sibling nodes.

--- a/.changeset/customizable-straight-edges.md
+++ b/.changeset/customizable-straight-edges.md
@@ -9,7 +9,8 @@ drag it back onto the line to remove it — so you can route a link cleanly arou
 node by hand. These connections now also attach at the side of each element that faces its
 partner and spread evenly across a shared side when several connect to the same element —
 so they read cleanly instead of stacking on one point or leaving from an arbitrary corner.
-They bend automatically around any node that sits directly in their path, while a clear
-straight shot stays straight, and your hand-placed waypoints are always respected. Syntax
-trees gain a one-click "Tidy tree layout" that arranges nodes hierarchically so
-parent-to-child links no longer overlap sibling nodes.
+Use-case and petri-net connections additionally bend around a node that sits directly in
+their path, while a clear straight shot stays straight, and your hand-placed waypoints are
+always respected. Syntax trees stay drawn as straight parent-to-child lines and gain a
+one-click "Tidy tree layout" that arranges the nodes hierarchically so the links no longer
+overlap sibling nodes.

--- a/.changeset/customizable-straight-edges.md
+++ b/.changeset/customizable-straight-edges.md
@@ -4,9 +4,10 @@
 
 Shape and tidy diagonal-line diagrams the same way you already can with orthogonal
 edges. Use-case, syntax-tree and petri-net connections now have draggable waypoints —
-grab a segment's midpoint to add a bend, drag a bend to move it, and double-click or
-drag it back onto the line to remove it — so you can route a link cleanly around a
-node by hand. These connections now also attach at the side of each element that faces its
+drag any bend to move it, drag the faint point on a segment to add one, and
+double-click or drag a bend back onto the line to remove it — so you can route a link
+cleanly around a node by hand. Bends the editor placed itself are draggable too, so
+you can start from its route and adjust it rather than redrawing it. These connections now also attach at the side of each element that faces its
 partner and spread evenly across a shared side when several connect to the same element —
 so they read cleanly instead of stacking on one point or leaving from an arbitrary corner.
 They also bend around any node that sits directly in their path — leaving each element

--- a/library/lib/apollon-editor.tsx
+++ b/library/lib/apollon-editor.tsx
@@ -405,6 +405,23 @@ export class ApollonEditor {
     requestAnimationFrame(attempt)
   }
 
+  /**
+   * Arrange a syntax-tree diagram into a tidy hierarchical layout, so straight
+   * parent→child links no longer overlap sibling nodes (issue #282). Derives the
+   * hierarchy from `SyntaxTreeLink` edges; malformed graphs (forests, cycles,
+   * multi-parent) are laid out where clean and left untouched elsewhere. It is a
+   * single undo step and a no-op on non-syntax-tree diagrams.
+   */
+  public layoutSyntaxTree(): void {
+    if (
+      this.metadataStore.getState().diagramType !== UMLDiagramType.SyntaxTree
+    ) {
+      return
+    }
+    this.diagramStore.getState().layoutSyntaxTree()
+    this.fitView()
+  }
+
   // ---- Canvas overlay / control API -------------------------------------
   // A library-owned overlay engine: host chrome (header, rails, banners) and the
   // editor's own overlays share one measured, inset-aware layout. Controls

--- a/library/lib/chrome/builtins/ZoomControls.tsx
+++ b/library/lib/chrome/builtins/ZoomControls.tsx
@@ -1,6 +1,7 @@
 import { useReactFlow, useStore } from "@xyflow/react"
 import { useShallow } from "zustand/shallow"
 import {
+  ListTree,
   Maximize,
   Redo2,
   SquareMousePointer,
@@ -13,6 +14,8 @@ import {
   useMetadataStore,
   useOverlayStore,
 } from "@/store/context"
+import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
+import { UMLDiagramType } from "@/types"
 import { insetAwareFitView } from "@/overlay/fitView"
 import { ariaKeyshortcuts } from "@/keyboard"
 import { Tooltip } from "@/components/ui"
@@ -48,12 +51,17 @@ export function ZoomControls({ history = true }: ZoomControlsProps) {
     }))
   )
 
-  const { multiSelectionMode, setMultiSelectionMode } = useMetadataStore(
-    useShallow((state) => ({
-      multiSelectionMode: state.multiSelectionMode,
-      setMultiSelectionMode: state.setMultiSelectionMode,
-    }))
-  )
+  const { multiSelectionMode, setMultiSelectionMode, isSyntaxTree } =
+    useMetadataStore(
+      useShallow((state) => ({
+        multiSelectionMode: state.multiSelectionMode,
+        setMultiSelectionMode: state.setMultiSelectionMode,
+        isSyntaxTree: state.diagramType === UMLDiagramType.SyntaxTree,
+      }))
+    )
+  const layoutSyntaxTree = useDiagramStore((state) => state.layoutSyntaxTree)
+  const isModifiable = useDiagramModifiable()
+  const showTidyLayout = isSyntaxTree && isModifiable
 
   const { ref: toolbarRef, onKeyDown: onToolbarKeyDown } =
     useRovingToolbar<HTMLDivElement>()
@@ -124,6 +132,18 @@ export function ZoomControls({ history = true }: ZoomControlsProps) {
             <SquareMousePointer width={18} height={18} aria-hidden="true" />
           </button>
         </Tooltip>
+        {showTidyLayout && (
+          <Tooltip title={t.tidyLayoutHint}>
+            <button
+              type="button"
+              className="apollon-chrome-iconbtn"
+              onClick={() => layoutSyntaxTree()}
+              aria-label={t.tidyLayout}
+            >
+              <ListTree width={18} height={18} aria-hidden="true" />
+            </button>
+          </Tooltip>
+        )}
       </div>
 
       {history && undoManagerExist && (

--- a/library/lib/edges/GenericEdge.tsx
+++ b/library/lib/edges/GenericEdge.tsx
@@ -21,6 +21,7 @@ import type { DiagramEdgeType } from "./types"
 import { Assessment } from "@/typings"
 import type { BendHandle } from "@/utils/geometry/bendHandles"
 import { getSegmentGhostHandles } from "@/utils/geometry/freeWaypoints"
+import { isqrt } from "@/utils/geometry/integerGeometry"
 import { isFreeformEdgeAnchor } from "@/utils/edgeUtils"
 import { CANVAS, EDGES } from "@/constants"
 
@@ -39,6 +40,8 @@ export const getHandleScreenScale = (zoom: number): number => {
   )
   return 1 / Math.min(safeZoom, 1)
 }
+
+const isqrtLength = (dx: number, dy: number): number => isqrt(dx * dx + dy * dy)
 
 const useHandleScreenScale = (): number =>
   getHandleScreenScale(useStore((state) => state.transform[2]))
@@ -511,12 +514,12 @@ export const EdgeBendHandle = ({
 }
 
 /**
- * Draggable free-2D waypoint editing for straight (diagonal) edges. Renders a faint
- * "ghost" handle at every route segment midpoint (dragging one past a threshold
- * materialises a bend) and a solid handle on every existing interior waypoint
- * (drag to move, double-click to remove). Every handle carries a generous invisible
- * hit target so it stays grabbable when zoomed out and on touch. This is the
- * straight-edge analogue of `EdgeBendHandle`, which is orthogonal-only.
+ * Bend editing for straight (diagonal) edges — the counterpart to `EdgeBendHandle`,
+ * and deliberately the SAME affordance: an identically styled `edge-bend-handle`
+ * pill that lies along the segment, hidden until the edge is hovered or selected.
+ * A step edge drags a segment along its one free axis; a straight edge has two, so
+ * these handles carry a `move` cursor and drop a waypoint where they are released.
+ * Existing waypoints get the same pill so the whole row reads as one control set.
  */
 export const EdgeWaypointHandles = ({
   route,
@@ -542,58 +545,80 @@ export const EdgeWaypointHandles = ({
   ) => void
 }) => {
   const screenScale = useHandleScreenScale()
-  const ghosts = getSegmentGhostHandles(route)
+  const segments = getSegmentGhostHandles(route)
   const hit = EDGES.WAYPOINT_HIT_TARGET_PX * screenScale
-  const waypointRadius = EDGES.WAYPOINT_HANDLE_RADIUS_PX * screenScale
-  const ghostRadius = EDGES.WAYPOINT_GHOST_RADIUS_PX * screenScale
+  const shortAxis = 10 * screenScale
+  const radius = 6 * screenScale
+
+  /** A step-edge bend pill, rotated to lie along an arbitrary segment. */
+  const pill = (
+    center: IPoint,
+    longAxis: number,
+    angleDeg: number,
+    className: string
+  ) => (
+    <rect
+      className={className}
+      x={center.x - longAxis / 2}
+      y={center.y - shortAxis / 2}
+      width={longAxis}
+      height={shortAxis}
+      rx={radius}
+      ry={radius}
+      transform={`rotate(${angleDeg} ${center.x} ${center.y})`}
+      pointerEvents="none"
+    />
+  )
 
   return (
     <>
-      {ghosts.map((ghost) => (
-        <g
-          key={`ghost-${ghost.segmentIndex}`}
-          className="edge-waypoint-ghost-group"
-        >
-          <circle
-            className="edge-circle edge-waypoint-ghost"
-            cx={ghost.position.x}
-            cy={ghost.position.y}
-            r={ghostRadius}
-            pointerEvents="none"
-          />
-          <rect
-            className="edge-waypoint-ghost-hit"
-            x={ghost.position.x - hit / 2}
-            y={ghost.position.y - hit / 2}
-            width={hit}
-            height={hit}
-            rx={hit / 2}
-            ry={hit / 2}
-            pointerEvents="all"
-            style={{ cursor: "crosshair", fill: "transparent" }}
-            onPointerDown={(event) =>
-              onGhostPointerDown(event, ghost.segmentIndex)
-            }
-          />
-        </g>
-      ))}
+      {segments.map((segment) => {
+        const a = route[segment.segmentIndex]
+        const b = route[segment.segmentIndex + 1]
+        // Degrees are presentation only — never a routing decision — so the
+        // trigonometry here cannot affect committed geometry.
+        const angle = (Math.atan2(b.y - a.y, b.x - a.x) * 180) / Math.PI
+        const room = isqrtLength(b.x - a.x, b.y - a.y) - 2 * radius
+        const longAxis = Math.min(
+          Math.max(room, EDGES.BEND_HANDLE_MIN_SCREEN_LENGTH_PX * screenScale),
+          EDGES.BEND_HANDLE_SCREEN_LENGTH_PX * screenScale
+        )
+        return (
+          <g key={`segment-${segment.segmentIndex}`}>
+            {pill(
+              segment.position,
+              longAxis,
+              angle,
+              "edge-circle edge-bend-handle"
+            )}
+            <rect
+              x={segment.position.x - hit / 2}
+              y={segment.position.y - hit / 2}
+              width={hit}
+              height={hit}
+              rx={hit / 2}
+              ry={hit / 2}
+              pointerEvents="all"
+              style={{ cursor: "move", fill: "transparent", zIndex: 9999 }}
+              onPointerDown={(event) =>
+                onGhostPointerDown(event, segment.segmentIndex)
+              }
+            />
+          </g>
+        )
+      })}
       {interior.map((point, index) => (
-        <g key={`waypoint-${index}`} className="edge-waypoint-group">
-          <circle
-            className={
-              "edge-circle edge-waypoint-handle" +
+        <g key={`waypoint-${index}`}>
+          {pill(
+            point,
+            shortAxis,
+            0,
+            "edge-circle edge-bend-handle" +
               (selectedWaypointIndex === index
-                ? " edge-waypoint-handle--selected"
+                ? " edge-bend-handle--active"
                 : "")
-            }
-            cx={point.x}
-            cy={point.y}
-            r={waypointRadius}
-            style={{ strokeWidth: FREEFORM_ENDPOINT_GRIP_STROKE * screenScale }}
-            pointerEvents="none"
-          />
+          )}
           <rect
-            className="edge-waypoint-hit"
             x={point.x - hit / 2}
             y={point.y - hit / 2}
             width={hit}
@@ -601,7 +626,7 @@ export const EdgeWaypointHandles = ({
             rx={hit / 2}
             ry={hit / 2}
             pointerEvents="all"
-            style={{ cursor: "move", fill: "transparent" }}
+            style={{ cursor: "move", fill: "transparent", zIndex: 9999 }}
             onPointerDown={(event) => onWaypointPointerDown(event, index)}
             onDoubleClick={() => onWaypointDoubleClick(index)}
           />

--- a/library/lib/edges/GenericEdge.tsx
+++ b/library/lib/edges/GenericEdge.tsx
@@ -20,6 +20,7 @@ import {
 import type { DiagramEdgeType } from "./types"
 import { Assessment } from "@/typings"
 import type { BendHandle } from "@/utils/geometry/bendHandles"
+import { getSegmentGhostHandles } from "@/utils/geometry/freeWaypoints"
 import { isFreeformEdgeAnchor } from "@/utils/edgeUtils"
 import { CANVAS, EDGES } from "@/constants"
 
@@ -278,6 +279,8 @@ export const EdgeEndpointMarkers = ({
   onEndpointPointerDown,
   straight = false,
   bendHandles,
+  sourceNeighbor,
+  targetNeighbor,
 }: {
   sourcePoint: IPoint
   targetPoint: IPoint
@@ -295,6 +298,12 @@ export const EdgeEndpointMarkers = ({
   // The edge's bend handles, so a reconnect target can cap its outward reach at
   // this end's terminal bend handle instead of painting over it.
   bendHandles?: BendHandle[]
+  // The adjacent route vertex just inside each endpoint (route[1] / route[len-2]).
+  // A bent straight edge orients its grip/marker along the TERMINAL segment toward
+  // this point rather than the endpoint-to-endpoint chord. Defaults to the opposite
+  // endpoint, so an unbent 2-point edge is byte-identical to before.
+  sourceNeighbor?: IPoint
+  targetNeighbor?: IPoint
 }) => {
   const screenScale = useHandleScreenScale()
 
@@ -306,11 +315,19 @@ export const EdgeEndpointMarkers = ({
   // rotated to the edge angle — the same "along the edge, away from the node"
   // placement the orthogonal side gives a step edge. Step edges pass no
   // direction and fall back to the side.
+  const sourceAnchorNeighbor = sourceNeighbor ?? targetPoint
+  const targetAnchorNeighbor = targetNeighbor ?? sourcePoint
   const sourceOutward = straight
-    ? { x: targetPoint.x - sourcePoint.x, y: targetPoint.y - sourcePoint.y }
+    ? {
+        x: sourceAnchorNeighbor.x - sourcePoint.x,
+        y: sourceAnchorNeighbor.y - sourcePoint.y,
+      }
     : undefined
   const targetOutward = straight
-    ? { x: sourcePoint.x - targetPoint.x, y: sourcePoint.y - targetPoint.y }
+    ? {
+        x: targetAnchorNeighbor.x - targetPoint.x,
+        y: targetAnchorNeighbor.y - targetPoint.y,
+      }
     : undefined
   const sourceDir = sourceOutward
     ? normalizeDir(sourceOutward)
@@ -490,6 +507,107 @@ export const EdgeBendHandle = ({
       }}
       onPointerDown={onPointerDown}
     />
+  )
+}
+
+/**
+ * Draggable free-2D waypoint editing for straight (diagonal) edges. Renders a faint
+ * "ghost" handle at every route segment midpoint (dragging one past a threshold
+ * materialises a bend) and a solid handle on every existing interior waypoint
+ * (drag to move, double-click to remove). Every handle carries a generous invisible
+ * hit target so it stays grabbable when zoomed out and on touch. This is the
+ * straight-edge analogue of `EdgeBendHandle`, which is orthogonal-only.
+ */
+export const EdgeWaypointHandles = ({
+  route,
+  interior,
+  selectedWaypointIndex,
+  onWaypointPointerDown,
+  onWaypointDoubleClick,
+  onGhostPointerDown,
+}: {
+  /** Full route `[source, ...interior, target]`. */
+  route: IPoint[]
+  /** Interior waypoints only (== `data.points`). */
+  interior: IPoint[]
+  selectedWaypointIndex: number | null
+  onWaypointPointerDown: (
+    event: ReactPointerEvent<SVGRectElement>,
+    index: number
+  ) => void
+  onWaypointDoubleClick: (index: number) => void
+  onGhostPointerDown: (
+    event: ReactPointerEvent<SVGRectElement>,
+    segmentIndex: number
+  ) => void
+}) => {
+  const screenScale = useHandleScreenScale()
+  const ghosts = getSegmentGhostHandles(route)
+  const hit = EDGES.WAYPOINT_HIT_TARGET_PX * screenScale
+  const waypointRadius = EDGES.WAYPOINT_HANDLE_RADIUS_PX * screenScale
+  const ghostRadius = EDGES.WAYPOINT_GHOST_RADIUS_PX * screenScale
+
+  return (
+    <>
+      {ghosts.map((ghost) => (
+        <g
+          key={`ghost-${ghost.segmentIndex}`}
+          className="edge-waypoint-ghost-group"
+        >
+          <circle
+            className="edge-circle edge-waypoint-ghost"
+            cx={ghost.position.x}
+            cy={ghost.position.y}
+            r={ghostRadius}
+            pointerEvents="none"
+          />
+          <rect
+            className="edge-waypoint-ghost-hit"
+            x={ghost.position.x - hit / 2}
+            y={ghost.position.y - hit / 2}
+            width={hit}
+            height={hit}
+            rx={hit / 2}
+            ry={hit / 2}
+            pointerEvents="all"
+            style={{ cursor: "crosshair", fill: "transparent" }}
+            onPointerDown={(event) =>
+              onGhostPointerDown(event, ghost.segmentIndex)
+            }
+          />
+        </g>
+      ))}
+      {interior.map((point, index) => (
+        <g key={`waypoint-${index}`} className="edge-waypoint-group">
+          <circle
+            className={
+              "edge-circle edge-waypoint-handle" +
+              (selectedWaypointIndex === index
+                ? " edge-waypoint-handle--selected"
+                : "")
+            }
+            cx={point.x}
+            cy={point.y}
+            r={waypointRadius}
+            style={{ strokeWidth: FREEFORM_ENDPOINT_GRIP_STROKE * screenScale }}
+            pointerEvents="none"
+          />
+          <rect
+            className="edge-waypoint-hit"
+            x={point.x - hit / 2}
+            y={point.y - hit / 2}
+            width={hit}
+            height={hit}
+            rx={hit / 2}
+            ry={hit / 2}
+            pointerEvents="all"
+            style={{ cursor: "move", fill: "transparent" }}
+            onPointerDown={(event) => onWaypointPointerDown(event, index)}
+            onDoubleClick={() => onWaypointDoubleClick(index)}
+          />
+        </g>
+      ))}
+    </>
   )
 }
 

--- a/library/lib/edges/GenericEdge.tsx
+++ b/library/lib/edges/GenericEdge.tsx
@@ -21,7 +21,6 @@ import type { DiagramEdgeType } from "./types"
 import { Assessment } from "@/typings"
 import type { BendHandle } from "@/utils/geometry/bendHandles"
 import { getSegmentGhostHandles } from "@/utils/geometry/freeWaypoints"
-import { isqrt } from "@/utils/geometry/integerGeometry"
 import { isFreeformEdgeAnchor } from "@/utils/edgeUtils"
 import { CANVAS, EDGES } from "@/constants"
 
@@ -40,8 +39,6 @@ export const getHandleScreenScale = (zoom: number): number => {
   )
   return 1 / Math.min(safeZoom, 1)
 }
-
-const isqrtLength = (dx: number, dy: number): number => isqrt(dx * dx + dy * dy)
 
 const useHandleScreenScale = (): number =>
   getHandleScreenScale(useStore((state) => state.transform[2]))
@@ -514,12 +511,18 @@ export const EdgeBendHandle = ({
 }
 
 /**
- * Bend editing for straight (diagonal) edges — the counterpart to `EdgeBendHandle`,
- * and deliberately the SAME affordance: an identically styled `edge-bend-handle`
- * pill that lies along the segment, hidden until the edge is hovered or selected.
- * A step edge drags a segment along its one free axis; a straight edge has two, so
- * these handles carry a `move` cursor and drop a waypoint where they are released.
- * Existing waypoints get the same pill so the whole row reads as one control set.
+ * Waypoint editing for straight (diagonal) edges.
+ *
+ * A straight edge is not "bent" the way a step edge is — there is no segment to
+ * slide along a fixed axis. It is a polyline through POINTS, and editing it means
+ * picking a point up and putting it somewhere else. So the affordance is a round
+ * handle on the point itself, not the step edge's elongated segment pill, and it
+ * carries a `move` cursor because it travels in two dimensions rather than one.
+ *
+ * Every interior vertex of the rendered route gets one, whether the user placed it
+ * or the router did: dragging an automatic bend is how you take ownership of a route
+ * the solver chose. Segment midpoints additionally carry a faint HALF handle — the
+ * same point affordance, just not real yet — which becomes a waypoint when dragged.
  */
 export const EdgeWaypointHandles = ({
   route,
@@ -531,7 +534,7 @@ export const EdgeWaypointHandles = ({
 }: {
   /** Full route `[source, ...interior, target]`. */
   route: IPoint[]
-  /** Interior waypoints only (== `data.points`). */
+  /** The editable interior vertices — every bend on the rendered route. */
   interior: IPoint[]
   selectedWaypointIndex: number | null
   onWaypointPointerDown: (
@@ -545,93 +548,63 @@ export const EdgeWaypointHandles = ({
   ) => void
 }) => {
   const screenScale = useHandleScreenScale()
-  const segments = getSegmentGhostHandles(route)
+  const midpoints = getSegmentGhostHandles(route)
   const hit = EDGES.WAYPOINT_HIT_TARGET_PX * screenScale
-  const shortAxis = 10 * screenScale
-  const radius = 6 * screenScale
+  const radius = EDGES.WAYPOINT_HANDLE_RADIUS_PX * screenScale
 
-  /** A step-edge bend pill, rotated to lie along an arbitrary segment. */
-  const pill = (
-    center: IPoint,
-    longAxis: number,
-    angleDeg: number,
-    className: string
+  const point = (
+    centre: IPoint,
+    className: string,
+    key: string,
+    onPointerDown: (event: ReactPointerEvent<SVGRectElement>) => void,
+    onDoubleClick?: () => void
   ) => (
-    <rect
-      className={className}
-      x={center.x - longAxis / 2}
-      y={center.y - shortAxis / 2}
-      width={longAxis}
-      height={shortAxis}
-      rx={radius}
-      ry={radius}
-      transform={`rotate(${angleDeg} ${center.x} ${center.y})`}
-      pointerEvents="none"
-    />
+    <g key={key}>
+      <circle
+        className={className}
+        cx={centre.x}
+        cy={centre.y}
+        r={radius}
+        style={{ strokeWidth: FREEFORM_ENDPOINT_GRIP_STROKE * screenScale }}
+        pointerEvents="none"
+      />
+      <rect
+        x={centre.x - hit / 2}
+        y={centre.y - hit / 2}
+        width={hit}
+        height={hit}
+        rx={hit / 2}
+        ry={hit / 2}
+        pointerEvents="all"
+        style={{ cursor: "move", fill: "transparent", zIndex: 9999 }}
+        onPointerDown={onPointerDown}
+        onDoubleClick={onDoubleClick}
+      />
+    </g>
   )
 
   return (
     <>
-      {segments.map((segment) => {
-        const a = route[segment.segmentIndex]
-        const b = route[segment.segmentIndex + 1]
-        // Degrees are presentation only — never a routing decision — so the
-        // trigonometry here cannot affect committed geometry.
-        const angle = (Math.atan2(b.y - a.y, b.x - a.x) * 180) / Math.PI
-        const room = isqrtLength(b.x - a.x, b.y - a.y) - 2 * radius
-        const longAxis = Math.min(
-          Math.max(room, EDGES.BEND_HANDLE_MIN_SCREEN_LENGTH_PX * screenScale),
-          EDGES.BEND_HANDLE_SCREEN_LENGTH_PX * screenScale
+      {midpoints.map((midpoint) =>
+        point(
+          midpoint.position,
+          "edge-circle edge-waypoint-handle edge-waypoint-handle--proposed",
+          `midpoint-${midpoint.segmentIndex}`,
+          (event) => onGhostPointerDown(event, midpoint.segmentIndex)
         )
-        return (
-          <g key={`segment-${segment.segmentIndex}`}>
-            {pill(
-              segment.position,
-              longAxis,
-              angle,
-              "edge-circle edge-bend-handle"
-            )}
-            <rect
-              x={segment.position.x - hit / 2}
-              y={segment.position.y - hit / 2}
-              width={hit}
-              height={hit}
-              rx={hit / 2}
-              ry={hit / 2}
-              pointerEvents="all"
-              style={{ cursor: "move", fill: "transparent", zIndex: 9999 }}
-              onPointerDown={(event) =>
-                onGhostPointerDown(event, segment.segmentIndex)
-              }
-            />
-          </g>
+      )}
+      {interior.map((waypoint, index) =>
+        point(
+          waypoint,
+          "edge-circle edge-waypoint-handle" +
+            (selectedWaypointIndex === index
+              ? " edge-waypoint-handle--active"
+              : ""),
+          `waypoint-${index}`,
+          (event) => onWaypointPointerDown(event, index),
+          () => onWaypointDoubleClick(index)
         )
-      })}
-      {interior.map((point, index) => (
-        <g key={`waypoint-${index}`}>
-          {pill(
-            point,
-            shortAxis,
-            0,
-            "edge-circle edge-bend-handle" +
-              (selectedWaypointIndex === index
-                ? " edge-bend-handle--active"
-                : "")
-          )}
-          <rect
-            x={point.x - hit / 2}
-            y={point.y - hit / 2}
-            width={hit}
-            height={hit}
-            rx={hit / 2}
-            ry={hit / 2}
-            pointerEvents="all"
-            style={{ cursor: "move", fill: "transparent", zIndex: 9999 }}
-            onPointerDown={(event) => onWaypointPointerDown(event, index)}
-            onDoubleClick={() => onWaypointDoubleClick(index)}
-          />
-        </g>
-      ))}
+      )}
     </>
   )
 }

--- a/library/lib/edges/edgeTypes/PetriNetEdge.tsx
+++ b/library/lib/edges/edgeTypes/PetriNetEdge.tsx
@@ -3,6 +3,7 @@ import {
   BaseEdgeProps,
   CommonEdgeElements,
   EdgeEndpointMarkers,
+  EdgeWaypointHandles,
 } from "../GenericEdge"
 import { EdgeMiddleLabels } from "../labelTypes/EdgeMiddleLabels"
 import { useEdgeConfig } from "@/hooks/useEdgeConfig"
@@ -59,11 +60,19 @@ export const PetriNetEdge = ({
     strokeDashArray,
     sourcePoint,
     targetPoint,
+    sourceNeighbor,
+    targetNeighbor,
+    route,
+    interior,
+    selectedWaypointIndex,
     sourcePosition: renderSourcePosition,
     targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
     handleEndpointPointerDown,
+    handleWaypointPointerDown,
+    handleGhostPointerDown,
+    handleWaypointDoubleClick,
   } = useStraightPathEdge({
     id,
     type,
@@ -118,11 +127,24 @@ export const PetriNetEdge = ({
             style={{ opacity: 0.4 }}
           />
 
+          {isDiagramModifiable && (
+            <EdgeWaypointHandles
+              route={route}
+              interior={interior}
+              selectedWaypointIndex={selectedWaypointIndex}
+              onWaypointPointerDown={handleWaypointPointerDown}
+              onWaypointDoubleClick={handleWaypointDoubleClick}
+              onGhostPointerDown={handleGhostPointerDown}
+            />
+          )}
+
           <EdgeEndpointMarkers
             sourcePoint={sourcePoint}
             targetPoint={targetPoint}
             sourcePosition={renderSourcePosition}
             targetPosition={renderTargetPosition}
+            sourceNeighbor={sourceNeighbor}
+            targetNeighbor={targetNeighbor}
             isDiagramModifiable={isDiagramModifiable}
             canEditEndpoint={canEditEndpoint}
             onEndpointPointerDown={handleEndpointPointerDown}

--- a/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
+++ b/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
@@ -3,6 +3,7 @@ import {
   BaseEdgeProps,
   CommonEdgeElements,
   EdgeEndpointMarkers,
+  EdgeWaypointHandles,
 } from "../GenericEdge"
 import { useStraightPathEdge } from "@/hooks/useStraightPathEdge"
 import { useDiagramStore, usePopoverStore } from "@/store/context"
@@ -51,11 +52,19 @@ export const SyntaxTreeEdge = ({
     strokeDashArray,
     sourcePoint,
     targetPoint,
+    sourceNeighbor,
+    targetNeighbor,
+    route,
+    interior,
+    selectedWaypointIndex,
     sourcePosition: renderSourcePosition,
     targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
     handleEndpointPointerDown,
+    handleWaypointPointerDown,
+    handleGhostPointerDown,
+    handleWaypointDoubleClick,
   } = useStraightPathEdge({
     id,
     type,
@@ -104,11 +113,24 @@ export const SyntaxTreeEdge = ({
             style={{ opacity: 0.4 }}
           />
 
+          {isDiagramModifiable && (
+            <EdgeWaypointHandles
+              route={route}
+              interior={interior}
+              selectedWaypointIndex={selectedWaypointIndex}
+              onWaypointPointerDown={handleWaypointPointerDown}
+              onWaypointDoubleClick={handleWaypointDoubleClick}
+              onGhostPointerDown={handleGhostPointerDown}
+            />
+          )}
+
           <EdgeEndpointMarkers
             sourcePoint={sourcePoint}
             targetPoint={targetPoint}
             sourcePosition={renderSourcePosition}
             targetPosition={renderTargetPosition}
+            sourceNeighbor={sourceNeighbor}
+            targetNeighbor={targetNeighbor}
             isDiagramModifiable={isDiagramModifiable}
             canEditEndpoint={canEditEndpoint}
             onEndpointPointerDown={handleEndpointPointerDown}

--- a/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
@@ -3,6 +3,7 @@ import {
   BaseEdgeProps,
   CommonEdgeElements,
   EdgeEndpointMarkers,
+  EdgeWaypointHandles,
 } from "../GenericEdge"
 import { EdgeMiddleLabels } from "../labelTypes/EdgeMiddleLabels"
 import { EdgeIncludeExtendLabel } from "../labelTypes/EdgeIncludeExtendLabel"
@@ -64,11 +65,19 @@ export const UseCaseEdge = ({
     strokeDashArray,
     sourcePoint,
     targetPoint,
+    sourceNeighbor,
+    targetNeighbor,
+    route,
+    interior,
+    selectedWaypointIndex,
     sourcePosition: renderSourcePosition,
     targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
     handleEndpointPointerDown,
+    handleWaypointPointerDown,
+    handleGhostPointerDown,
+    handleWaypointDoubleClick,
   } = useStraightPathEdge({
     id,
     type,
@@ -123,11 +132,24 @@ export const UseCaseEdge = ({
             style={{ opacity: 0.4 }}
           />
 
+          {isDiagramModifiable && (
+            <EdgeWaypointHandles
+              route={route}
+              interior={interior}
+              selectedWaypointIndex={selectedWaypointIndex}
+              onWaypointPointerDown={handleWaypointPointerDown}
+              onWaypointDoubleClick={handleWaypointDoubleClick}
+              onGhostPointerDown={handleGhostPointerDown}
+            />
+          )}
+
           <EdgeEndpointMarkers
             sourcePoint={sourcePoint}
             targetPoint={targetPoint}
             sourcePosition={renderSourcePosition}
             targetPosition={renderTargetPosition}
+            sourceNeighbor={sourceNeighbor}
+            targetNeighbor={targetNeighbor}
             isDiagramModifiable={isDiagramModifiable}
             canEditEndpoint={canEditEndpoint}
             onEndpointPointerDown={handleEndpointPointerDown}

--- a/library/lib/hooks/useStraightPathEdge.ts
+++ b/library/lib/hooks/useStraightPathEdge.ts
@@ -353,21 +353,15 @@ export const useStraightPathEdge = ({
     () => [sourceEndpoint, ...interiorPoints, targetEndpoint],
     [sourceEndpoint, interiorPoints, targetEndpoint]
   )
-  // Prefer the solver's committed route (which also carries any automatic
-  // obstacle-avoidance bends) whenever its endpoints still match the current
-  // adjusted endpoints; otherwise fall back to the analytic base polyline.
-  const centralRouteMatchesEndpoints =
-    centralRoute !== undefined &&
-    centralRoute.length >= 2 &&
-    centralRoute[0].x === sourceEndpoint.x &&
-    centralRoute[0].y === sourceEndpoint.y &&
-    centralRoute[centralRoute.length - 1].x === targetEndpoint.x &&
-    centralRoute[centralRoute.length - 1].y === targetEndpoint.y
+  // The solver's committed route is the source of truth: its endpoints are the
+  // facing-side attachment sites the port assignment chose (not the drawn handle),
+  // and it carries any automatic obstacle-avoidance bends. Fall back to the analytic
+  // base polyline only before the first solve lands (never painted after that).
   const renderPoints = useMemo<IPoint[]>(
     () =>
       dragPreviewPoints ??
-      (centralRouteMatchesEndpoints ? centralRoute! : basePoints),
-    [basePoints, centralRoute, centralRouteMatchesEndpoints, dragPreviewPoints]
+      (centralRoute && centralRoute.length >= 2 ? centralRoute : basePoints),
+    [basePoints, centralRoute, dragPreviewPoints]
   )
   const renderSourcePosition =
     dragPreviewPositions?.sourcePosition ?? resolvedSourcePosition
@@ -474,8 +468,8 @@ export const useStraightPathEdge = ({
       setEndpointPreviewCommit(null)
 
       const ownerDocument = event.currentTarget.ownerDocument
-      const currentSourceEndpoint = sourceEndpoint
-      const currentTargetEndpoint = targetEndpoint
+      const currentSourceEndpoint = sourcePoint
+      const currentTargetEndpoint = targetPoint
 
       const resolveDragCommit = (
         clientX: number,
@@ -678,8 +672,8 @@ export const useStraightPathEdge = ({
       ownerDocument.addEventListener("pointercancel", handlePointerCancel)
     },
     [
-      sourceEndpoint,
-      targetEndpoint,
+      sourcePoint,
+      targetPoint,
       interiorPoints,
       data,
       findFreeformEndpointNode,
@@ -699,17 +693,52 @@ export const useStraightPathEdge = ({
     ]
   )
 
-  const persistInterior = useCallback(
-    (nextInterior: IPoint[]) => {
+  // Persist the interior waypoints. A bend customises the whole visible route,
+  // including the facing-side attachment sites the port assignment chose, so on the
+  // first bend the endpoints are pinned to `pinSource`/`pinTarget` (when still
+  // automatic) — otherwise a newly-bent edge would snap its endpoints back to the
+  // drawn handle. Mirrors the step-edge bend-commit behaviour.
+  const commitWaypoints = useCallback(
+    (nextInterior: IPoint[], pinSource: IPoint, pinTarget: IPoint) => {
       setEdges((edges) =>
-        edges.map((edge) =>
-          edge.id === id
-            ? { ...edge, data: { ...edge.data, points: nextInterior } }
-            : edge
-        )
+        edges.map((edge) => {
+          if (edge.id !== id) return edge
+          const nextData: Record<string, unknown> = {
+            ...((edge.data ?? {}) as Record<string, unknown>),
+            points: nextInterior,
+          }
+          if (nextInterior.length > 0) {
+            if (!isFreeformEdgeAnchor(sourceAnchor) && sourceRect) {
+              const anchor = getEdgeAnchorFromPoint(
+                sourceNode?.type,
+                pinSource,
+                sourceRect
+              )
+              if (anchor) nextData.sourceAnchor = anchor
+            }
+            if (!isFreeformEdgeAnchor(targetAnchor) && targetRect) {
+              const anchor = getEdgeAnchorFromPoint(
+                targetNode?.type,
+                pinTarget,
+                targetRect
+              )
+              if (anchor) nextData.targetAnchor = anchor
+            }
+          }
+          return { ...edge, data: nextData }
+        })
       )
     },
-    [id, setEdges]
+    [
+      id,
+      setEdges,
+      sourceAnchor,
+      targetAnchor,
+      sourceRect,
+      targetRect,
+      sourceNode?.type,
+      targetNode?.type,
+    ]
   )
 
   // Shared drag routine for both an existing waypoint and a freshly materialised
@@ -728,12 +757,18 @@ export const useStraightPathEdge = ({
       const ownerDocument = pointerTarget.ownerDocument
       dragInteriorRef.current = startInterior
       dragMovedRef.current = false
+      // The endpoints the drag pivots around are the CURRENTLY RENDERED attachment
+      // sites (the solver's facing-side ports), captured at gesture start — not the
+      // drawn handle — so the route and the pinned commit keep the edge attached
+      // exactly where it is on screen.
+      const routeSource = sourcePoint
+      const routeTarget = targetPoint
 
       // Drive the preview through state; the existing layout effect republishes it
       // as an authoritative live override so neighbouring step edges reflow around
       // the dragged diagonal, and clears it when the drag ends.
       const publish = (interior: IPoint[]) => {
-        setDragPreviewPoints([sourceEndpoint, ...interior, targetEndpoint])
+        setDragPreviewPoints([routeSource, ...interior, routeTarget])
       }
       // Seed the preview so the edge does not flicker to its committed shape on the
       // first frame (the inserted point starts on the segment).
@@ -774,14 +809,14 @@ export const useStraightPathEdge = ({
         setDragPreviewPoints(null)
         // Drag-to-collinear removes redundant bends (incl. the dragged one).
         const pruned = pruneCollinearWaypoints([
-          sourceEndpoint,
+          routeSource,
           ...dragInteriorRef.current,
-          targetEndpoint,
+          routeTarget,
         ])
         // Only persist when the geometry actually changed (a click that never
         // moved must not freeze a fresh point into the model).
         if (dragMovedRef.current || pruned.length !== interiorPoints.length) {
-          persistInterior(pruned)
+          commitWaypoints(pruned, routeSource, routeTarget)
         }
         setSelectedWaypointIndex(null)
         teardown()
@@ -795,10 +830,10 @@ export const useStraightPathEdge = ({
     },
     [
       interiorPoints.length,
-      persistInterior,
+      commitWaypoints,
       screenToFlowPosition,
-      sourceEndpoint,
-      targetEndpoint,
+      sourcePoint,
+      targetPoint,
     ]
   )
 
@@ -880,16 +915,18 @@ export const useStraightPathEdge = ({
 
   const handleWaypointDoubleClick = useCallback(
     (index: number) => {
-      persistInterior(
+      commitWaypoints(
         pruneCollinearWaypoints([
-          sourceEndpoint,
+          sourcePoint,
           ...removeWaypoint(interiorPoints, index),
-          targetEndpoint,
-        ])
+          targetPoint,
+        ]),
+        sourcePoint,
+        targetPoint
       )
       setSelectedWaypointIndex(null)
     },
-    [interiorPoints, persistInterior, sourceEndpoint, targetEndpoint]
+    [interiorPoints, commitWaypoints, sourcePoint, targetPoint]
   )
 
   return {

--- a/library/lib/hooks/useStraightPathEdge.ts
+++ b/library/lib/hooks/useStraightPathEdge.ts
@@ -435,6 +435,14 @@ export const useStraightPathEdge = ({
 
   const sourcePoint = renderPoints[0]
   const targetPoint = renderPoints[renderPoints.length - 1]
+  // Every bend on the RENDERED route is editable, not only the authored ones. An
+  // automatic detour is a perfectly good starting point for a hand-placed route:
+  // dragging one of its bends is how the user takes ownership of it, exactly as
+  // dragging a computed step edge freezes its path into manual points.
+  const editableWaypoints = useMemo<IPoint[]>(
+    () => renderPoints.slice(1, -1),
+    [renderPoints]
+  )
   const sourceNeighbor = renderPoints[1]
   const targetNeighbor = renderPoints[renderPoints.length - 2]
   // Always: a straight edge has no bend handles, so a minimum-length gate would
@@ -815,7 +823,7 @@ export const useStraightPathEdge = ({
         ])
         // Only persist when the geometry actually changed (a click that never
         // moved must not freeze a fresh point into the model).
-        if (dragMovedRef.current || pruned.length !== interiorPoints.length) {
+        if (dragMovedRef.current || pruned.length !== startInterior.length) {
           commitWaypoints(pruned, routeSource, routeTarget)
         }
         setSelectedWaypointIndex(null)
@@ -828,13 +836,7 @@ export const useStraightPathEdge = ({
       ownerDocument.addEventListener("pointerup", handlePointerUp)
       ownerDocument.addEventListener("pointercancel", handlePointerCancel)
     },
-    [
-      interiorPoints.length,
-      commitWaypoints,
-      screenToFlowPosition,
-      sourcePoint,
-      targetPoint,
-    ]
+    [commitWaypoints, screenToFlowPosition, sourcePoint, targetPoint]
   )
 
   const handleWaypointPointerDown = useCallback(
@@ -848,10 +850,10 @@ export const useStraightPathEdge = ({
         event.pointerId,
         event.currentTarget,
         index,
-        interiorPoints
+        editableWaypoints
       )
     },
-    [beginWaypointDrag, interiorPoints]
+    [beginWaypointDrag, editableWaypoints]
   )
 
   // A ghost midpoint materialises a new waypoint only once the pointer has moved
@@ -890,7 +892,7 @@ export const useStraightPathEdge = ({
         if (!exceedsDragThreshold(origin, flowPoint)) return
         cleanup()
         const seeded = insertWaypoint(
-          interiorPoints,
+          editableWaypoints,
           segmentIndex,
           snapPoint(flowPoint)
         )
@@ -910,7 +912,7 @@ export const useStraightPathEdge = ({
       ownerDocument.addEventListener("pointerup", handleEnd)
       ownerDocument.addEventListener("pointercancel", handleEnd)
     },
-    [beginWaypointDrag, interiorPoints, screenToFlowPosition]
+    [beginWaypointDrag, editableWaypoints, screenToFlowPosition]
   )
 
   const handleWaypointDoubleClick = useCallback(
@@ -918,7 +920,7 @@ export const useStraightPathEdge = ({
       commitWaypoints(
         pruneCollinearWaypoints([
           sourcePoint,
-          ...removeWaypoint(interiorPoints, index),
+          ...removeWaypoint(editableWaypoints, index),
           targetPoint,
         ]),
         sourcePoint,
@@ -926,7 +928,7 @@ export const useStraightPathEdge = ({
       )
       setSelectedWaypointIndex(null)
     },
-    [interiorPoints, commitWaypoints, sourcePoint, targetPoint]
+    [editableWaypoints, commitWaypoints, sourcePoint, targetPoint]
   )
 
   return {
@@ -942,7 +944,7 @@ export const useStraightPathEdge = ({
     sourceNeighbor,
     targetNeighbor,
     route: renderPoints,
-    interior: interiorPoints,
+    interior: editableWaypoints,
     selectedWaypointIndex,
     isDiagramModifiable,
     canEditEndpoint,

--- a/library/lib/hooks/useStraightPathEdge.ts
+++ b/library/lib/hooks/useStraightPathEdge.ts
@@ -34,6 +34,14 @@ import { useDiagramModifiable } from "./useDiagramModifiable"
 import { IPoint } from "../edges/Connection"
 import { BaseEdgeProps } from "../edges/GenericEdge"
 import { computeToolbarPosition } from "@/utils/geometry/bendHandles"
+import {
+  exceedsDragThreshold,
+  insertWaypoint,
+  moveWaypoint,
+  pruneCollinearWaypoints,
+  removeWaypoint,
+  snapPoint,
+} from "@/utils/geometry/freeWaypoints"
 import { getMidSegment } from "@/utils/geometry/edgeLabelLayout"
 import { useEdgeLineJumps, buildEdgePath } from "./useEdgeLineJumps"
 import {
@@ -51,6 +59,10 @@ export interface StraightPathEdgeData {
   sourcePoint: IPoint
   targetPoint: IPoint
 }
+
+/** Stable empty interior list so an unbent edge keeps a constant reference and
+ * does not churn the downstream route memos every render. */
+const EMPTY_POINTS: IPoint[] = []
 
 type EndpointType = "source" | "target"
 
@@ -85,6 +97,10 @@ export const useStraightPathEdge = ({
   const endpointDragCommitRef = useRef<StraightEndpointDragCommit | null>(null)
   const activePointerCancelRef = useRef<(() => void) | null>(null)
   const activePointerTeardownRef = useRef<(() => void) | null>(null)
+  // Per-gesture waypoint-drag state. Refs (not a captured object) keep the drag
+  // closures React-Compiler-safe, mirroring useStepPathEdge's drag refs.
+  const dragInteriorRef = useRef<IPoint[]>([])
+  const dragMovedRef = useRef(false)
   const isDiagramModifiable = useDiagramModifiable()
   const setLiveEdgeOverride = useMetadataStore(
     (state) => state.setLiveEdgeOverride
@@ -100,9 +116,17 @@ export const useStraightPathEdge = ({
   } | null>(null)
   const [endpointPreviewCommit, setEndpointPreviewCommit] =
     useState<StraightEndpointDragCommit | null>(null)
+  const [selectedWaypointIndex, setSelectedWaypointIndex] = useState<
+    number | null
+  >(null)
   const centralRoute = useEdgeGeometryStore(
     (state) => state.previewById[id] ?? state.geometryById[id]
   )
+  // Interior waypoints authored on this edge (JointJS "vertices" model): the route
+  // is [source, ...interior, target]. Never includes the endpoints.
+  const interiorPoints: IPoint[] = Array.isArray(data?.points)
+    ? (data.points as IPoint[])
+    : EMPTY_POINTS
 
   useEffect(
     () => () => {
@@ -307,42 +331,43 @@ export const useStraightPathEdge = ({
     sourceConnectionPointPadding
   )
 
-  const basePoints = useMemo<IPoint[]>(
-    () => [
-      {
-        x: adjustedSourceCoordinates.sourceX,
-        y: adjustedSourceCoordinates.sourceY,
-      },
-      {
-        x: adjustedTargetCoordinates.targetX,
-        y: adjustedTargetCoordinates.targetY,
-      },
-    ],
-    [
-      adjustedSourceCoordinates.sourceX,
-      adjustedSourceCoordinates.sourceY,
-      adjustedTargetCoordinates.targetX,
-      adjustedTargetCoordinates.targetY,
-    ]
+  const sourceEndpoint = useMemo<IPoint>(
+    () => ({
+      x: adjustedSourceCoordinates.sourceX,
+      y: adjustedSourceCoordinates.sourceY,
+    }),
+    [adjustedSourceCoordinates.sourceX, adjustedSourceCoordinates.sourceY]
   )
-  const centralPreviewMatchesCommit =
-    dragPreviewPoints !== null &&
-    endpointPreviewCommit !== null &&
+  const targetEndpoint = useMemo<IPoint>(
+    () => ({
+      x: adjustedTargetCoordinates.targetX,
+      y: adjustedTargetCoordinates.targetY,
+    }),
+    [adjustedTargetCoordinates.targetX, adjustedTargetCoordinates.targetY]
+  )
+  // The synchronous truth: source → interior waypoints → target. Used as the
+  // fallback before the solver's route lands and whenever the solver route is
+  // stale (its endpoints no longer match, e.g. mid node-move) so the edge never
+  // detaches from its nodes.
+  const basePoints = useMemo<IPoint[]>(
+    () => [sourceEndpoint, ...interiorPoints, targetEndpoint],
+    [sourceEndpoint, interiorPoints, targetEndpoint]
+  )
+  // Prefer the solver's committed route (which also carries any automatic
+  // obstacle-avoidance bends) whenever its endpoints still match the current
+  // adjusted endpoints; otherwise fall back to the analytic base polyline.
+  const centralRouteMatchesEndpoints =
     centralRoute !== undefined &&
     centralRoute.length >= 2 &&
-    (endpointPreviewCommit.endpoint === "source"
-      ? centralRoute[0].x === endpointPreviewCommit.sourceEndpoint.x &&
-        centralRoute[0].y === endpointPreviewCommit.sourceEndpoint.y
-      : centralRoute[centralRoute.length - 1].x ===
-          endpointPreviewCommit.targetEndpoint.x &&
-        centralRoute[centralRoute.length - 1].y ===
-          endpointPreviewCommit.targetEndpoint.y)
+    centralRoute[0].x === sourceEndpoint.x &&
+    centralRoute[0].y === sourceEndpoint.y &&
+    centralRoute[centralRoute.length - 1].x === targetEndpoint.x &&
+    centralRoute[centralRoute.length - 1].y === targetEndpoint.y
   const renderPoints = useMemo<IPoint[]>(
     () =>
-      centralPreviewMatchesCommit
-        ? [centralRoute[0], centralRoute[centralRoute.length - 1]]
-        : (dragPreviewPoints ?? basePoints),
-    [basePoints, centralPreviewMatchesCommit, centralRoute, dragPreviewPoints]
+      dragPreviewPoints ??
+      (centralRouteMatchesEndpoints ? centralRoute! : basePoints),
+    [basePoints, centralRoute, centralRouteMatchesEndpoints, dragPreviewPoints]
   )
   const renderSourcePosition =
     dragPreviewPositions?.sourcePosition ?? resolvedSourcePosition
@@ -376,12 +401,21 @@ export const useStraightPathEdge = ({
   // export-stable.
   const { point: pathMiddlePosition, isHorizontal: isMiddlePathHorizontal } =
     useMemo(
-      () => getMidSegment(renderPoints, renderPoints[0], renderPoints[1]),
+      () =>
+        getMidSegment(
+          renderPoints,
+          renderPoints[0],
+          renderPoints[renderPoints.length - 1]
+        ),
       [renderPoints]
     )
 
+  // A bent edge (interior waypoints or a bridged crossing) draws its polyline via
+  // buildEdgePath; a plain 2-point edge keeps calculateStraightPath so the marker
+  // padding / include-extend gap on its single segment is byte-identical to before.
+  const isPolyline = renderPoints.length > 2 || lineJumps.length > 0
   const currentPath = useMemo(() => {
-    if (lineJumps.length > 0) return buildEdgePath(renderPoints, lineJumps)
+    if (isPolyline) return buildEdgePath(renderPoints, lineJumps)
     return calculateStraightPath(
       renderPoints[0].x,
       renderPoints[0].y,
@@ -389,12 +423,13 @@ export const useStraightPathEdge = ({
       renderPoints[1].y,
       type
     )
-  }, [renderPoints, type, lineJumps])
+  }, [renderPoints, type, lineJumps, isPolyline])
 
   const overlayPath = useMemo(() => {
     // When bridging, the arc'd path is the hit target too, so the selectable
     // stroke matches exactly what's drawn.
     if (lineJumps.length > 0) return currentPath
+    if (renderPoints.length > 2) return buildEdgePath(renderPoints, [])
     return calculateOverlayPath(
       renderPoints[0].x,
       renderPoints[0].y,
@@ -404,7 +439,10 @@ export const useStraightPathEdge = ({
     )
   }, [renderPoints, type, currentPath, lineJumps])
 
-  const [sourcePoint, targetPoint] = renderPoints
+  const sourcePoint = renderPoints[0]
+  const targetPoint = renderPoints[renderPoints.length - 1]
+  const sourceNeighbor = renderPoints[1]
+  const targetNeighbor = renderPoints[renderPoints.length - 2]
   // Always: a straight edge has no bend handles, so a minimum-length gate would
   // leave short ones with no editable affordance at all.
   const canEditEndpoint = true
@@ -436,8 +474,8 @@ export const useStraightPathEdge = ({
       setEndpointPreviewCommit(null)
 
       const ownerDocument = event.currentTarget.ownerDocument
-      const currentSourceEndpoint = basePoints[0]
-      const currentTargetEndpoint = basePoints[1]
+      const currentSourceEndpoint = sourceEndpoint
+      const currentTargetEndpoint = targetEndpoint
 
       const resolveDragCommit = (
         clientX: number,
@@ -544,7 +582,12 @@ export const useStraightPathEdge = ({
         endpointDragCommitRef.current = commit
         setEndpointPreviewCommit(commit)
         if (commit) {
-          setDragPreviewPoints([commit.sourceEndpoint, commit.targetEndpoint])
+          // Reconnecting an endpoint preserves authored interior waypoints.
+          setDragPreviewPoints([
+            commit.sourceEndpoint,
+            ...interiorPoints,
+            commit.targetEndpoint,
+          ])
           setDragPreviewPositions({
             sourcePosition: commit.sourcePosition,
             targetPosition: commit.targetPosition,
@@ -558,8 +601,8 @@ export const useStraightPathEdge = ({
         const flowPoint = screenToFlowPosition({ x: e.clientX, y: e.clientY })
         setDragPreviewPoints(
           endpoint === "source"
-            ? [flowPoint, currentTargetEndpoint]
-            : [currentSourceEndpoint, flowPoint]
+            ? [flowPoint, ...interiorPoints, currentTargetEndpoint]
+            : [currentSourceEndpoint, ...interiorPoints, flowPoint]
         )
         setDragPreviewPositions(null)
       }
@@ -635,7 +678,9 @@ export const useStraightPathEdge = ({
       ownerDocument.addEventListener("pointercancel", handlePointerCancel)
     },
     [
-      basePoints,
+      sourceEndpoint,
+      targetEndpoint,
+      interiorPoints,
       data,
       findFreeformEndpointNode,
       getIntersectingNodes,
@@ -654,6 +699,199 @@ export const useStraightPathEdge = ({
     ]
   )
 
+  const persistInterior = useCallback(
+    (nextInterior: IPoint[]) => {
+      setEdges((edges) =>
+        edges.map((edge) =>
+          edge.id === id
+            ? { ...edge, data: { ...edge.data, points: nextInterior } }
+            : edge
+        )
+      )
+    },
+    [id, setEdges]
+  )
+
+  // Shared drag routine for both an existing waypoint and a freshly materialised
+  // one. `startInterior` is the interior array the drag operates on; `index` is the
+  // waypoint being moved. The live route is published so neighbouring step edges
+  // reflow around the dragged diagonal, and only pointer-up commits `data.points`.
+  const beginWaypointDrag = useCallback(
+    (
+      pointerId: number,
+      pointerTarget: SVGRectElement,
+      index: number,
+      startInterior: IPoint[]
+    ) => {
+      if (!pointerTarget.hasPointerCapture(pointerId))
+        pointerTarget.setPointerCapture(pointerId)
+      const ownerDocument = pointerTarget.ownerDocument
+      dragInteriorRef.current = startInterior
+      dragMovedRef.current = false
+
+      // Drive the preview through state; the existing layout effect republishes it
+      // as an authoritative live override so neighbouring step edges reflow around
+      // the dragged diagonal, and clears it when the drag ends.
+      const publish = (interior: IPoint[]) => {
+        setDragPreviewPoints([sourceEndpoint, ...interior, targetEndpoint])
+      }
+      // Seed the preview so the edge does not flicker to its committed shape on the
+      // first frame (the inserted point starts on the segment).
+      publish(dragInteriorRef.current)
+
+      const handlePointerMove = (e: PointerEvent) => {
+        if (e.pointerId !== pointerId) return
+        const flowPoint = screenToFlowPosition({ x: e.clientX, y: e.clientY })
+        dragInteriorRef.current = moveWaypoint(
+          dragInteriorRef.current,
+          index,
+          flowPoint
+        )
+        dragMovedRef.current = true
+        publish(dragInteriorRef.current)
+      }
+
+      const teardown = () => {
+        ownerDocument.removeEventListener("pointermove", handlePointerMove)
+        ownerDocument.removeEventListener("pointerup", handlePointerUp)
+        ownerDocument.removeEventListener("pointercancel", handlePointerCancel)
+        if (pointerTarget.hasPointerCapture(pointerId))
+          pointerTarget.releasePointerCapture(pointerId)
+        if (activePointerTeardownRef.current === teardown) {
+          activePointerTeardownRef.current = null
+          activePointerCancelRef.current = null
+        }
+      }
+
+      const handlePointerCancel = (e?: PointerEvent) => {
+        if (e && e.pointerId !== pointerId) return
+        setDragPreviewPoints(null)
+        teardown()
+      }
+
+      const handlePointerUp = (e: PointerEvent) => {
+        if (e.pointerId !== pointerId) return
+        setDragPreviewPoints(null)
+        // Drag-to-collinear removes redundant bends (incl. the dragged one).
+        const pruned = pruneCollinearWaypoints([
+          sourceEndpoint,
+          ...dragInteriorRef.current,
+          targetEndpoint,
+        ])
+        // Only persist when the geometry actually changed (a click that never
+        // moved must not freeze a fresh point into the model).
+        if (dragMovedRef.current || pruned.length !== interiorPoints.length) {
+          persistInterior(pruned)
+        }
+        setSelectedWaypointIndex(null)
+        teardown()
+      }
+
+      activePointerCancelRef.current = handlePointerCancel
+      activePointerTeardownRef.current = teardown
+      ownerDocument.addEventListener("pointermove", handlePointerMove)
+      ownerDocument.addEventListener("pointerup", handlePointerUp)
+      ownerDocument.addEventListener("pointercancel", handlePointerCancel)
+    },
+    [
+      interiorPoints.length,
+      persistInterior,
+      screenToFlowPosition,
+      sourceEndpoint,
+      targetEndpoint,
+    ]
+  )
+
+  const handleWaypointPointerDown = useCallback(
+    (event: ReactPointerEvent<SVGRectElement>, index: number) => {
+      if (!event.isPrimary || event.button !== 0) return
+      event.preventDefault()
+      event.stopPropagation()
+      activePointerCancelRef.current?.()
+      setSelectedWaypointIndex(index)
+      beginWaypointDrag(
+        event.pointerId,
+        event.currentTarget,
+        index,
+        interiorPoints
+      )
+    },
+    [beginWaypointDrag, interiorPoints]
+  )
+
+  // A ghost midpoint materialises a new waypoint only once the pointer has moved
+  // past the threshold (so a stray tap never litters the edge with points); the
+  // gesture then continues as an ordinary waypoint drag on the new point.
+  const handleGhostPointerDown = useCallback(
+    (event: ReactPointerEvent<SVGRectElement>, segmentIndex: number) => {
+      if (!event.isPrimary || event.button !== 0) return
+      event.preventDefault()
+      event.stopPropagation()
+      activePointerCancelRef.current?.()
+      const pointerId = event.pointerId
+      const pointerTarget = event.currentTarget
+      pointerTarget.setPointerCapture(pointerId)
+      const ownerDocument = pointerTarget.ownerDocument
+      const origin = screenToFlowPosition({
+        x: event.clientX,
+        y: event.clientY,
+      })
+
+      const cleanup = () => {
+        ownerDocument.removeEventListener("pointermove", handleFirstMove)
+        ownerDocument.removeEventListener("pointerup", handleEnd)
+        ownerDocument.removeEventListener("pointercancel", handleEnd)
+        if (pointerTarget.hasPointerCapture(pointerId))
+          pointerTarget.releasePointerCapture(pointerId)
+        if (activePointerTeardownRef.current === cleanup) {
+          activePointerTeardownRef.current = null
+          activePointerCancelRef.current = null
+        }
+      }
+
+      const handleFirstMove = (e: PointerEvent) => {
+        if (e.pointerId !== pointerId) return
+        const flowPoint = screenToFlowPosition({ x: e.clientX, y: e.clientY })
+        if (!exceedsDragThreshold(origin, flowPoint)) return
+        cleanup()
+        const seeded = insertWaypoint(
+          interiorPoints,
+          segmentIndex,
+          snapPoint(flowPoint)
+        )
+        setSelectedWaypointIndex(segmentIndex)
+        // Hand off to the shared drag routine on the same pointer/element.
+        beginWaypointDrag(pointerId, pointerTarget, segmentIndex, seeded)
+      }
+
+      const handleEnd = (e: PointerEvent) => {
+        if (e.pointerId !== pointerId) return
+        cleanup()
+      }
+
+      activePointerCancelRef.current = cleanup
+      activePointerTeardownRef.current = cleanup
+      ownerDocument.addEventListener("pointermove", handleFirstMove)
+      ownerDocument.addEventListener("pointerup", handleEnd)
+      ownerDocument.addEventListener("pointercancel", handleEnd)
+    },
+    [beginWaypointDrag, interiorPoints, screenToFlowPosition]
+  )
+
+  const handleWaypointDoubleClick = useCallback(
+    (index: number) => {
+      persistInterior(
+        pruneCollinearWaypoints([
+          sourceEndpoint,
+          ...removeWaypoint(interiorPoints, index),
+          targetEndpoint,
+        ])
+      )
+      setSelectedWaypointIndex(null)
+    },
+    [interiorPoints, persistInterior, sourceEndpoint, targetEndpoint]
+  )
+
   return {
     pathRef,
     edgeData,
@@ -664,9 +902,17 @@ export const useStraightPathEdge = ({
     strokeDashArray,
     sourcePoint,
     targetPoint,
+    sourceNeighbor,
+    targetNeighbor,
+    route: renderPoints,
+    interior: interiorPoints,
+    selectedWaypointIndex,
     isDiagramModifiable,
     canEditEndpoint,
     handleEndpointPointerDown,
+    handleWaypointPointerDown,
+    handleGhostPointerDown,
+    handleWaypointDoubleClick,
     sourcePosition: renderSourcePosition,
     targetPosition: renderTargetPosition,
   }

--- a/library/lib/i18n/labels.ts
+++ b/library/lib/i18n/labels.ts
@@ -21,6 +21,10 @@ export interface ApollonLabels {
   redoHint: string
   multiSelection: string
   multiSelectionHint: string
+  /** Syntax-tree tidy-layout button (accessible name). */
+  tidyLayout: string
+  /** Syntax-tree tidy-layout tooltip. */
+  tidyLayoutHint: string
 
   // Minimap
   miniMap: string
@@ -307,6 +311,8 @@ export const DEFAULT_LABELS: ApollonLabels = Object.freeze<ApollonLabels>({
   redoHint: "Redo (Ctrl+Y or Ctrl+Shift+Z)",
   multiSelection: "Select multiple elements",
   multiSelectionHint: "Select multiple: click elements to add or remove",
+  tidyLayout: "Tidy tree layout",
+  tidyLayoutHint: "Arrange the syntax tree so links no longer overlap nodes",
   miniMap: "Mini map",
   showMinimap: "Show minimap",
   showMinimapHint: "Show minimap (overview)",

--- a/library/lib/store/diagramStore.ts
+++ b/library/lib/store/diagramStore.ts
@@ -19,6 +19,7 @@ import {
   STORE_ORIGIN,
 } from "@/sync/ydoc"
 import { recordStoreNodeWrite } from "@/sync/perfCounters"
+import { computeTidyLayout } from "@/utils/tidyTree"
 import { deepEqual } from "@/utils/storeUtils"
 import { Assessment, DraggingNode, InteractiveElements } from "@/typings"
 import {
@@ -153,6 +154,9 @@ export type DiagramStore = {
    */
   endTransientNodeBroadcast: () => void
   setNodes: (payload: Node[] | ((nodes: Node[]) => Node[])) => void
+  /** Reposition syntax-tree nodes into a tidy hierarchical layout (issue #282).
+   * A single undo step; a no-op on non-syntax-tree or already-tidy diagrams. */
+  layoutSyntaxTree: () => void
   setEdges: (payload: Edge[] | ((edges: Edge[]) => Edge[])) => void
   setNodesAndEdges: (nodes: Node[], edges: Edge[]) => void
   addEdge: (edge: Edge) => void
@@ -501,6 +505,13 @@ export const createDiagramStore = (
               undefined,
               "setNodes"
             )
+          },
+
+          layoutSyntaxTree: () => {
+            // Tidy the syntax tree by repositioning nodes (issue #282). Routed
+            // through `setNodes`, so it is a single Yjs transaction / one undo step
+            // and the deep-equal guard makes an already-tidy layout a no-op.
+            get().setNodes(computeTidyLayout(get().nodes, get().edges))
           },
 
           setEdges: (payload) => {

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -988,61 +988,13 @@
   fill: color-mix(in srgb, var(--apollon-primary, #3e8acc) 70%, #000);
 }
 
-/* Straight-edge waypoint editing. A materialised waypoint reads as a hollow pill
-   (like an endpoint grip); a ghost midpoint is a faint solid dot that materialises
-   a bend on drag. Both stay hidden until the edge is hovered/selected, matching the
-   bend-handle affordance, so an idle diagram is not littered with dots. */
-.edge-waypoint-handle {
-  opacity: 0;
-  fill: var(--apollon-background, #fff);
-  stroke: var(--apollon-primary, #3e8acc);
-  paint-order: stroke;
-  transition:
-    fill 120ms ease,
-    opacity 120ms ease,
-    stroke 120ms ease;
-}
-
-.edge-waypoint-ghost {
-  opacity: 0;
-  stroke: none;
-  fill: color-mix(
-    in srgb,
-    var(--apollon-primary, #3e8acc) 34%,
-    var(--apollon-background, #fff)
-  );
-  transition:
-    fill 120ms ease,
-    opacity 120ms ease;
-}
-
-.react-flow__edge:hover .edge-waypoint-handle,
-.react-flow__edge.selected .edge-waypoint-handle,
-.edge-waypoint-handle--selected {
+/* Straight-edge bend handles reuse `.edge-bend-handle` above, so they are the same
+   affordance as a step edge's: invisible until the edge is hovered or selected, then
+   a primary-coloured pill that darkens under the pointer. Only the active (selected)
+   waypoint gets an extra emphasis. */
+.edge-bend-handle--active {
   opacity: 1;
-}
-
-.react-flow__edge:hover .edge-waypoint-handle--selected {
-  fill: color-mix(
-    in srgb,
-    var(--apollon-primary, #3e8acc) 18%,
-    var(--apollon-background, #fff)
-  );
-}
-
-.react-flow__edge:hover .edge-waypoint-ghost,
-.react-flow__edge.selected .edge-waypoint-ghost {
-  opacity: 0.4;
-}
-
-.edge-waypoint-ghost-group:hover .edge-waypoint-ghost {
-  opacity: 1;
-  fill: var(--apollon-primary, #3e8acc);
-}
-
-.edge-waypoint-group:hover .edge-waypoint-handle {
   fill: color-mix(in srgb, var(--apollon-primary, #3e8acc) 70%, #000);
-  stroke: color-mix(in srgb, var(--apollon-primary, #3e8acc) 70%, #000);
 }
 
 .react-flow__edge:hover .edge-overlay {

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -988,11 +988,33 @@
   fill: color-mix(in srgb, var(--apollon-primary, #3e8acc) 70%, #000);
 }
 
-/* Straight-edge bend handles reuse `.edge-bend-handle` above, so they are the same
-   affordance as a step edge's: invisible until the edge is hovered or selected, then
-   a primary-coloured pill that darkens under the pointer. Only the active (selected)
-   waypoint gets an extra emphasis. */
-.edge-bend-handle--active {
+/* Straight-edge WAYPOINT handles: a round grip on the point itself, since a straight
+   edge is edited by moving points rather than by sliding segments. Hidden until the
+   edge is hovered or selected, like every other edge handle. A "proposed" handle sits
+   at a segment midpoint and is drawn faint — it is not a waypoint until dragged. */
+.edge-waypoint-handle {
+  opacity: 0;
+  fill: var(--apollon-background, #fff);
+  stroke: var(--apollon-primary, #3e8acc);
+  paint-order: stroke;
+  transition:
+    fill 120ms ease,
+    opacity 120ms ease,
+    stroke 120ms ease;
+}
+
+.react-flow__edge:hover .edge-waypoint-handle,
+.react-flow__edge.selected .edge-waypoint-handle {
+  opacity: 1;
+}
+
+.react-flow__edge:hover .edge-waypoint-handle--proposed,
+.react-flow__edge.selected .edge-waypoint-handle--proposed {
+  opacity: 0.45;
+}
+
+.edge-waypoint-handle--active,
+.react-flow__edge .edge-waypoint-handle:hover {
   opacity: 1;
   fill: color-mix(in srgb, var(--apollon-primary, #3e8acc) 70%, #000);
 }

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -988,6 +988,63 @@
   fill: color-mix(in srgb, var(--apollon-primary, #3e8acc) 70%, #000);
 }
 
+/* Straight-edge waypoint editing. A materialised waypoint reads as a hollow pill
+   (like an endpoint grip); a ghost midpoint is a faint solid dot that materialises
+   a bend on drag. Both stay hidden until the edge is hovered/selected, matching the
+   bend-handle affordance, so an idle diagram is not littered with dots. */
+.edge-waypoint-handle {
+  opacity: 0;
+  fill: var(--apollon-background, #fff);
+  stroke: var(--apollon-primary, #3e8acc);
+  paint-order: stroke;
+  transition:
+    fill 120ms ease,
+    opacity 120ms ease,
+    stroke 120ms ease;
+}
+
+.edge-waypoint-ghost {
+  opacity: 0;
+  stroke: none;
+  fill: color-mix(
+    in srgb,
+    var(--apollon-primary, #3e8acc) 34%,
+    var(--apollon-background, #fff)
+  );
+  transition:
+    fill 120ms ease,
+    opacity 120ms ease;
+}
+
+.react-flow__edge:hover .edge-waypoint-handle,
+.react-flow__edge.selected .edge-waypoint-handle,
+.edge-waypoint-handle--selected {
+  opacity: 1;
+}
+
+.react-flow__edge:hover .edge-waypoint-handle--selected {
+  fill: color-mix(
+    in srgb,
+    var(--apollon-primary, #3e8acc) 18%,
+    var(--apollon-background, #fff)
+  );
+}
+
+.react-flow__edge:hover .edge-waypoint-ghost,
+.react-flow__edge.selected .edge-waypoint-ghost {
+  opacity: 0.4;
+}
+
+.edge-waypoint-ghost-group:hover .edge-waypoint-ghost {
+  opacity: 1;
+  fill: var(--apollon-primary, #3e8acc);
+}
+
+.edge-waypoint-group:hover .edge-waypoint-handle {
+  fill: color-mix(in srgb, var(--apollon-primary, #3e8acc) 70%, #000);
+  stroke: color-mix(in srgb, var(--apollon-primary, #3e8acc) 70%, #000);
+}
+
 .react-flow__edge:hover .edge-overlay {
   opacity: 0;
 }

--- a/library/lib/typings.ts
+++ b/library/lib/typings.ts
@@ -105,7 +105,12 @@ export type ApollonNode = {
 
 export interface OrthogonalEdgeData {
   [key: string]: unknown
-  // Manual waypoint array used by the step-path edges.
+  // Manual waypoint array. Its semantics differ by edge regime:
+  //  • step (orthogonal) edges store the FULL committed route (endpoints included),
+  //    re-projected by the solver;
+  //  • straight-hook edges (use-case, syntax-tree, petri-net) store INTERIOR
+  //    waypoints ONLY (JointJS "vertices" model) — the route is
+  //    [source, ...points, target] connected by plain diagonal segments.
   points: IPoint[]
 }
 

--- a/library/lib/utils/geometry/edgeGeometrySolver.ts
+++ b/library/lib/utils/geometry/edgeGeometrySolver.ts
@@ -1366,6 +1366,11 @@ function computeAllEdgeGeometryPass(
     // neighbour map so step edges route around it.
     if (straightHookTypes.has(edge.type ?? "")) {
       const interior = getStraightHookInterior(edge)
+      // Syntax trees are drawn as straight parent→child lines; node overlaps are
+      // resolved by the tidy-tree layout, NOT by per-edge obstacle routing (which
+      // produces backtracking spaghetti on a dense tree). Use-case / petri edges
+      // form general graphs and keep automatic obstacle avoidance.
+      const avoidsObstacles = edge.type !== "SyntaxTreeLink"
       const straightObstacles = getEdgeObstacles(
         nodes,
         edge.source,
@@ -1416,6 +1421,10 @@ function computeAllEdgeGeometryPass(
               true,
               nodeIndex
             ),
+          // Side selection stays obstacle-aware for EVERY straight edge, so a
+          // stacked node makes the edge pick a side that clears it (a straight line
+          // that avoids the overlap) rather than one that runs through it. Only the
+          // bend-generating router below is gated per type.
           obstacles: straightObstacles,
           thirdPartyObstacles: straightObstacles.filter(
             (o) => !o.soft && o.id !== edge.source && o.id !== edge.target
@@ -1428,14 +1437,20 @@ function computeAllEdgeGeometryPass(
           straightTarget = selected.endpoints.adjustedTarget
         }
       }
-      const line = routeStraightPolyline({
-        source: straightSource,
-        target: straightTarget,
-        checkpoints: interior,
-        obstacles: straightObstacles,
-        neighborRoutes: [],
-        clearancePx: EDGES.NODE_CLEARANCE_PX,
-      })
+      const line = avoidsObstacles
+        ? routeStraightPolyline({
+            source: straightSource,
+            target: straightTarget,
+            checkpoints: interior,
+            // Never treat the edge's OWN endpoint nodes as obstacles — they are
+            // where it attaches, and routing around them produces a backwards jog.
+            obstacles: straightObstacles.filter(
+              (o) => o.id !== edge.source && o.id !== edge.target
+            ),
+            neighborRoutes: [],
+            clearancePx: EDGES.NODE_CLEARANCE_PX,
+          })
+        : [straightSource, ...interior, straightTarget]
       routeById[edge.id] = line
       indexRoutePolyline(neighborGrid, edge.id, line)
       continue

--- a/library/lib/utils/geometry/edgeGeometrySolver.ts
+++ b/library/lib/utils/geometry/edgeGeometrySolver.ts
@@ -34,6 +34,7 @@ import {
   type ObstacleRect,
 } from "@/utils/geometry/obstacles"
 import { routeStepEdge } from "@/utils/geometry/edgeRoute"
+import { routeStraightPolyline } from "@/utils/geometry/straightPolylineRouter"
 import {
   routeChosenAnchors,
   selectEdgeAnchors,
@@ -293,6 +294,20 @@ const NEIGHBOR_CELL_PX = 256
 const cellKey = (cx: number, cy: number): string => `${cx},${cy}`
 
 /** Bucket `edgeId` under every cell its polyline's segments pass through. */
+/**
+ * Interior waypoints authored on a straight-hook edge. Following the JointJS
+ * "vertices" model, a straight-hook edge's `data.points` holds ONLY the interior
+ * bends; its route is `[adjustedSource, ...interior, adjustedTarget]` connected by
+ * plain diagonal segments — never re-projected onto an orthogonal staircase (that
+ * would silently diverge preview from commit). Returns `[]` for an unbent edge.
+ */
+function getStraightHookInterior(edge: {
+  data?: { points?: unknown }
+}): IPoint[] {
+  const points = edge.data?.points
+  return Array.isArray(points) ? (points as IPoint[]) : []
+}
+
 function indexRoutePolyline(
   grid: NeighborGrid,
   edgeId: string,
@@ -1218,6 +1233,28 @@ function computeAllEdgeGeometryPass(
       reservedRouteById.set(edge.id, liveOverride.points)
       continue
     }
+    // Straight-hook edges are checked FIRST so their interior waypoints reserve a
+    // diagonal passthrough and never fall into the orthogonal reprojection below
+    // (their `data.points` are interior-only, not a step edge's full route).
+    if (straightHookTypes.has(edge.type ?? "")) {
+      const endpoints = resolveEdgeEndpoints(
+        edge,
+        nodes,
+        nodeById,
+        nodeLookup,
+        connectionMode,
+        undefined,
+        undefined,
+        nodeIndex
+      )
+      if (endpoints)
+        reservedRouteById.set(edge.id, [
+          endpoints.adjustedSource,
+          ...getStraightHookInterior(edge),
+          endpoints.adjustedTarget,
+        ])
+      continue
+    }
     const manual = edge.data?.points
     if (Array.isArray(manual) && manual.length >= 2) {
       const endpoints = resolveEdgeEndpoints(
@@ -1243,23 +1280,6 @@ function computeAllEdgeGeometryPass(
           : (manual as IPoint[])
       )
       continue
-    }
-    if (straightHookTypes.has(edge.type ?? "")) {
-      const endpoints = resolveEdgeEndpoints(
-        edge,
-        nodes,
-        nodeById,
-        nodeLookup,
-        connectionMode,
-        undefined,
-        undefined,
-        nodeIndex
-      )
-      if (endpoints)
-        reservedRouteById.set(edge.id, [
-          endpoints.adjustedSource,
-          endpoints.adjustedTarget,
-        ])
     }
   }
   const bandPorts = assignPorts(
@@ -1299,16 +1319,6 @@ function computeAllEdgeGeometryPass(
       continue
     }
 
-    // Straight-hook edges (use-case, syntax-tree, petri-net) are a plain line
-    // between the adjusted endpoints — no obstacle or neighbour routing — but
-    // their polyline still enters the map so step edges route around them.
-    if (straightHookTypes.has(edge.type ?? "")) {
-      const line = [endpoints.adjustedSource, endpoints.adjustedTarget]
-      routeById[edge.id] = line
-      indexRoutePolyline(neighborGrid, edge.id, line)
-      continue
-    }
-
     const candidateBounds: Rect = {
       x: Math.min(
         endpoints.sourceAbsolutePosition.x,
@@ -1336,6 +1346,33 @@ function computeAllEdgeGeometryPass(
           endpoints.sourceAbsolutePosition.y,
           endpoints.targetAbsolutePosition.y
         ),
+    }
+
+    // Straight-hook edges (use-case, syntax-tree, petri-net) stay diagonal lines
+    // through their authored interior waypoints. They auto-bend ONLY to clear an
+    // intervening node body (Track D); an unobstructed chord stays straight. The
+    // waypoints are honoured as mandatory checkpoints. The resulting polyline enters
+    // the neighbour map so step edges route around it.
+    if (straightHookTypes.has(edge.type ?? "")) {
+      const line = routeStraightPolyline({
+        source: endpoints.adjustedSource,
+        target: endpoints.adjustedTarget,
+        checkpoints: getStraightHookInterior(edge),
+        obstacles: getEdgeObstacles(
+          nodes,
+          edge.source,
+          edge.target,
+          endpoints.adjustedSource,
+          endpoints.adjustedTarget,
+          nodeIndex,
+          candidateBounds
+        ),
+        neighborRoutes: [],
+        clearancePx: EDGES.NODE_CLEARANCE_PX,
+      })
+      routeById[edge.id] = line
+      indexRoutePolyline(neighborGrid, edge.id, line)
+      continue
     }
     const obstacles: ObstacleRect[] = getEdgeObstacles(
       nodes,

--- a/library/lib/utils/geometry/edgeGeometrySolver.ts
+++ b/library/lib/utils/geometry/edgeGeometrySolver.ts
@@ -50,6 +50,7 @@ import {
 import {
   canRunStraight,
   centerOf,
+  normalAlignedSide,
   sideAxisLength,
 } from "@/utils/geometry/rectSides"
 import {
@@ -1307,6 +1308,35 @@ function computeAllEdgeGeometryPass(
       continue
     }
   }
+  // `assignSides` chooses the side pair that minimises ORTHOGONAL corners — the
+  // right objective for a step edge, and the wrong one for a straight line, which
+  // pays no corner to reach any side. What a straight edge pays for is the angle it
+  // leaves at, so its side is decided by the direction of its partner: the
+  // "partner direction decides side" rule this pipeline already follows for
+  // ordering (Hegemann & Wolff, GD 2023 — see geometry/README.md). Because the rule
+  // is a pure function of the two rectangles, a mirror-symmetric diagram yields
+  // mirror-symmetric sides, which corner-minimisation does not guarantee.
+  const straightSideByEnd = new Map<string, Position>(sideOverrideByEnd ?? [])
+  for (const edge of coordinationEdges) {
+    if (!straightHookTypes.has(edge.type ?? "")) continue
+    if (edge.source === edge.target) continue
+    if (getStraightHookInterior(edge).length > 0) continue
+    const sourceRect = nodeRect(edge.source, nodes, nodeById)
+    const targetRect = nodeRect(edge.target, nodes, nodeById)
+    if (!sourceRect || !targetRect) continue
+    const sourceKey = endKey(edge.id, "source")
+    const targetKey = endKey(edge.id, "target")
+    if (!fixedPorts.has(sourceKey) && !sideOverrideByEnd?.has(sourceKey))
+      straightSideByEnd.set(
+        sourceKey,
+        normalAlignedSide(sourceRect, centerOf(targetRect))
+      )
+    if (!fixedPorts.has(targetKey) && !sideOverrideByEnd?.has(targetKey))
+      straightSideByEnd.set(
+        targetKey,
+        normalAlignedSide(targetRect, centerOf(sourceRect))
+      )
+  }
   const bandPorts = assignPorts(
     collectPortEnds(
       coordinationEdges,
@@ -1314,9 +1344,28 @@ function computeAllEdgeGeometryPass(
       nodeById,
       fixedPorts,
       [...reservedRouteById.values()],
-      sideOverrideByEnd
+      straightSideByEnd
     )
   )
+
+  /**
+   * Where a straight edge attaches. On a shared node side the coordinated band seat
+   * applies; a LONE end has no seat, so it takes the CENTRE of its normal-aligned
+   * side — the same "centre it when nothing competes" rule `endpointPlacementCost`
+   * rewards for step edges. Leaving a lone end free instead lets the anchor search
+   * wrap it onto a side the edge does not approach from, and breaks the mirror
+   * symmetry of an otherwise symmetric diagram.
+   */
+  const coordinatedStraightPort = (
+    edgeId: string,
+    end: "source" | "target"
+  ): FreeformEdgeAnchor | undefined => {
+    const key = endKey(edgeId, end)
+    const banded = bandPorts.get(key)
+    if (banded) return banded
+    const side = straightSideByEnd.get(key)
+    return side ? { side, ratio: 0.5 } : undefined
+  }
 
   for (const edge of ordered) {
     if (liveOverride && liveOverride.edgeId === edge.id) {
@@ -1400,6 +1449,7 @@ function computeAllEdgeGeometryPass(
       let straightSourceSide = endpoints.sourcePosition
       let straightTargetSide = endpoints.targetPosition
       let straightNeighbors: IPoint[][] = []
+      let straightSiblings: IPoint[][] = []
       if (interior.length === 0) {
         const sourceType = nodeById.get(edge.source)?.type
         const targetType = nodeById.get(edge.target)?.type
@@ -1424,10 +1474,19 @@ function computeAllEdgeGeometryPass(
           ),
           sourceType,
           targetType,
-          sourceCustom: asFreeformAnchor(edge.data?.sourceAnchor),
-          targetCustom: asFreeformAnchor(edge.data?.targetAnchor),
-          sourcePreferred: bandPorts.get(endKey(edge.id, "source")),
-          targetPreferred: bandPorts.get(endKey(edge.id, "target")),
+          // On a node side shared with other connectors the coordinated seat is
+          // AUTHORITATIVE, not a suggestion. A straight edge can always shorten
+          // itself by aiming its port straight at the partner, so a soft
+          // preference loses every time — and the whole fan collapses onto one or
+          // two points, which is how two edges end up leaving from the SAME pixel.
+          // Pinning the seat is what keeps the fan evenly spread and symmetric.
+          // Lone ends are absent from the band and stay free to optimise.
+          sourceCustom:
+            asFreeformAnchor(edge.data?.sourceAnchor) ??
+            coordinatedStraightPort(edge.id, "source"),
+          targetCustom:
+            asFreeformAnchor(edge.data?.targetAnchor) ??
+            coordinatedStraightPort(edge.id, "target"),
           resolve: (overrides) =>
             resolveEdgeEndpoints(
               edge,
@@ -1461,11 +1520,12 @@ function computeAllEdgeGeometryPass(
           other.target === edge.source ||
           other.target === edge.target
         straightNeighbors = []
+        straightSiblings = []
         for (const [otherId, route] of Object.entries(routeById)) {
           if (otherId === edge.id || route.length < 2) continue
           const other = edgeById.get(otherId)
-          if (other && shares(other)) continue
-          straightNeighbors.push(route)
+          if (other && shares(other)) straightSiblings.push(route)
+          else straightNeighbors.push(route)
         }
         if (selected) {
           straightSource = selected.endpoints.adjustedSource
@@ -1485,6 +1545,7 @@ function computeAllEdgeGeometryPass(
               (o) => o.id !== edge.source && o.id !== edge.target
             ),
             neighborRoutes: straightNeighbors,
+            siblingRoutes: straightSiblings,
             clearancePx: EDGES.NODE_CLEARANCE_PX,
             sourceNormal: outwardNormal(straightSourceSide),
             targetNormal: outwardNormal(straightTargetSide),

--- a/library/lib/utils/geometry/edgeGeometrySolver.ts
+++ b/library/lib/utils/geometry/edgeGeometrySolver.ts
@@ -50,7 +50,7 @@ import {
 import {
   canRunStraight,
   centerOf,
-  normalAlignedSide,
+  facingSide,
   sideAxisLength,
 } from "@/utils/geometry/rectSides"
 import {
@@ -1308,14 +1308,17 @@ function computeAllEdgeGeometryPass(
       continue
     }
   }
-  // `assignSides` chooses the side pair that minimises ORTHOGONAL corners — the
+  // `assignSides` chooses the side PAIR that minimises ORTHOGONAL corners — the
   // right objective for a step edge, and the wrong one for a straight line, which
-  // pays no corner to reach any side. What a straight edge pays for is the angle it
-  // leaves at, so its side is decided by the direction of its partner: the
-  // "partner direction decides side" rule this pipeline already follows for
-  // ordering (Hegemann & Wolff, GD 2023 — see geometry/README.md). Because the rule
-  // is a pure function of the two rectangles, a mirror-symmetric diagram yields
-  // mirror-symmetric sides, which corner-minimisation does not guarantee.
+  // pays no corner to reach any side. A straight edge's side is instead decided by
+  // where its partner lies: the "partner direction decides side" rule this pipeline
+  // already follows for ordering (Hegemann & Wolff, GD 2023 — see
+  // geometry/README.md). `facingSide` weighs that direction against the node's own
+  // half-extents, so a row of children below a parent all attach on their TOP edge
+  // rather than some of them catching a corner and coming in sideways — which is
+  // what makes a fan of siblings read as parallel. Being a pure function of the two
+  // rectangles, it also yields mirror-symmetric sides for a mirror-symmetric
+  // diagram, which corner-minimisation does not guarantee.
   const straightSideByEnd = new Map<string, Position>(sideOverrideByEnd ?? [])
   for (const edge of coordinationEdges) {
     if (!straightHookTypes.has(edge.type ?? "")) continue
@@ -1329,12 +1332,12 @@ function computeAllEdgeGeometryPass(
     if (!fixedPorts.has(sourceKey) && !sideOverrideByEnd?.has(sourceKey))
       straightSideByEnd.set(
         sourceKey,
-        normalAlignedSide(sourceRect, centerOf(targetRect))
+        facingSide(sourceRect, centerOf(targetRect))
       )
     if (!fixedPorts.has(targetKey) && !sideOverrideByEnd?.has(targetKey))
       straightSideByEnd.set(
         targetKey,
-        normalAlignedSide(targetRect, centerOf(sourceRect))
+        facingSide(targetRect, centerOf(sourceRect))
       )
   }
   const bandPorts = assignPorts(
@@ -1347,6 +1350,50 @@ function computeAllEdgeGeometryPass(
       straightSideByEnd
     )
   )
+
+  // How far off its side's centre each seat sits, and the largest such offset on
+  // every occupied (node, side). Used to nest a fan — see `straightCornerRing`.
+  const seatOffset = (anchor: FreeformEdgeAnchor): number =>
+    Math.abs(anchor.ratio - 0.5)
+  const outermostSeatOffset = new Map<string, number>()
+  for (const edge of coordinationEdges) {
+    for (const [end, nodeId] of [
+      ["source", edge.source],
+      ["target", edge.target],
+    ] as const) {
+      const seat = bandPorts.get(endKey(edge.id, end))
+      if (!seat) continue
+      const key = `${nodeId}|${seat.side}`
+      outermostSeatOffset.set(
+        key,
+        Math.max(outermostSeatOffset.get(key) ?? 0, seatOffset(seat))
+      )
+    }
+  }
+
+  /**
+   * Which corner ring this edge should turn on. The OUTERMOST members of a fan —
+   * those seated furthest from their side's centre — stand off obstacles further,
+   * so siblings clearing one obstacle nest instead of meeting at a single elbow.
+   *
+   * Keyed on the seat's distance from the centre rather than its rank along the
+   * side, because reflecting the diagram preserves that distance but reverses the
+   * rank: a rank-keyed rule would nest a symmetric diagram's two halves differently.
+   * Comparing against the side's own maximum keeps it free of a magic threshold,
+   * which the raw ratios (they depend on side length and seat count) would trip over.
+   */
+  const straightCornerRing = (edge: Edge): number => {
+    for (const [end, nodeId] of [
+      ["source", edge.source],
+      ["target", edge.target],
+    ] as const) {
+      const seat = bandPorts.get(endKey(edge.id, end))
+      if (!seat) continue
+      const outermost = outermostSeatOffset.get(`${nodeId}|${seat.side}`) ?? 0
+      if (outermost > 0 && seatOffset(seat) >= outermost) return 1
+    }
+    return 0
+  }
 
   /**
    * Where a straight edge attaches. On a shared node side the coordinated band seat
@@ -1546,6 +1593,11 @@ function computeAllEdgeGeometryPass(
             ),
             neighborRoutes: straightNeighbors,
             siblingRoutes: straightSiblings,
+            // Outer members of a fan turn on the outer corner ring, so siblings
+            // clearing one obstacle nest instead of stacking on a single elbow.
+            // `|ratio - 1/2|` is mirror-invariant, so the two halves of a
+            // symmetric diagram still make the same choice.
+            preferredCornerRing: straightCornerRing(edge),
             clearancePx: EDGES.NODE_CLEARANCE_PX,
             sourceNormal: outwardNormal(straightSourceSide),
             targetNormal: outwardNormal(straightTargetSide),

--- a/library/lib/utils/geometry/edgeGeometrySolver.ts
+++ b/library/lib/utils/geometry/edgeGeometrySolver.ts
@@ -838,7 +838,6 @@ function collectFixedPorts(
   nodeById: Map<string, Node>,
   nodeLookup: Map<string, InternalNode>,
   connectionMode: ConnectionMode,
-  straightHookTypes: ReadonlySet<string>,
   liveOverride: LiveEdgeOverride | null | undefined,
   fixedRoutes: Readonly<Record<string, IPoint[]>>,
   nodeIndex: NodeIndex
@@ -850,9 +849,13 @@ function collectFixedPorts(
     if (sourcePinned) result.set(endKey(edge.id, "source"), sourcePinned)
     if (targetPinned) result.set(endKey(edge.id, "target"), targetPinned)
 
+    // A straight-hook edge is NO LONGER pinned to its drawn handle. Unbent,
+    // unpinned ones become free ends so they get the same facing-side selection
+    // and balanced port band as step edges (their route is drawn straight, not
+    // orthogonal). Only an authored bend (points) or an explicit pin fixes a
+    // straight-hook endpoint — handled by the clauses below.
     const topologyFixed =
       edge.id === liveOverride?.edgeId ||
-      straightHookTypes.has(edge.type ?? "") ||
       edge.source === edge.target ||
       (Array.isArray(edge.data?.points) && edge.data.points.length > 0) ||
       fixedRoutes[edge.id] !== undefined
@@ -1220,7 +1223,6 @@ function computeAllEdgeGeometryPass(
     nodeById,
     nodeLookup,
     connectionMode,
-    straightHookTypes,
     liveOverride,
     fixedRoutes,
     nodeIndex
@@ -1233,26 +1235,32 @@ function computeAllEdgeGeometryPass(
       reservedRouteById.set(edge.id, liveOverride.points)
       continue
     }
-    // Straight-hook edges are checked FIRST so their interior waypoints reserve a
-    // diagonal passthrough and never fall into the orthogonal reprojection below
-    // (their `data.points` are interior-only, not a step edge's full route).
+    // Straight-hook edges are checked FIRST. A BENT one (authored interior
+    // waypoints) reserves a diagonal passthrough and must never fall into the
+    // orthogonal reprojection below (its `data.points` are interior-only). An
+    // UNBENT one is a free end — its facing side and balanced port are assigned
+    // like a step edge and its straight route is computed in the main pass, so it
+    // reserves nothing here.
     if (straightHookTypes.has(edge.type ?? "")) {
-      const endpoints = resolveEdgeEndpoints(
-        edge,
-        nodes,
-        nodeById,
-        nodeLookup,
-        connectionMode,
-        undefined,
-        undefined,
-        nodeIndex
-      )
-      if (endpoints)
-        reservedRouteById.set(edge.id, [
-          endpoints.adjustedSource,
-          ...getStraightHookInterior(edge),
-          endpoints.adjustedTarget,
-        ])
+      const interior = getStraightHookInterior(edge)
+      if (interior.length > 0) {
+        const endpoints = resolveEdgeEndpoints(
+          edge,
+          nodes,
+          nodeById,
+          nodeLookup,
+          connectionMode,
+          undefined,
+          undefined,
+          nodeIndex
+        )
+        if (endpoints)
+          reservedRouteById.set(edge.id, [
+            endpoints.adjustedSource,
+            ...interior,
+            endpoints.adjustedTarget,
+          ])
+      }
       continue
     }
     const manual = edge.data?.points
@@ -1348,25 +1356,83 @@ function computeAllEdgeGeometryPass(
         ),
     }
 
-    // Straight-hook edges (use-case, syntax-tree, petri-net) stay diagonal lines
-    // through their authored interior waypoints. They auto-bend ONLY to clear an
-    // intervening node body (Track D); an unobstructed chord stays straight. The
-    // waypoints are honoured as mandatory checkpoints. The resulting polyline enters
-    // the neighbour map so step edges route around it.
+    // Straight-hook edges (use-case, syntax-tree, petri-net) render as diagonal
+    // lines, but they get the SAME sophistication as step edges up to the routing
+    // primitive: an unbent, unpinned edge picks its facing sides and a balanced
+    // centred port (via `selectEdgeAnchors` + the shared `assignPorts` band), while
+    // a bent edge keeps its authored waypoints. The chosen endpoints are then joined
+    // by a straight, obstacle-avoiding polyline (Track D) instead of an orthogonal
+    // route — waypoints ride along as mandatory checkpoints. The result enters the
+    // neighbour map so step edges route around it.
     if (straightHookTypes.has(edge.type ?? "")) {
-      const line = routeStraightPolyline({
-        source: endpoints.adjustedSource,
-        target: endpoints.adjustedTarget,
-        checkpoints: getStraightHookInterior(edge),
-        obstacles: getEdgeObstacles(
+      const interior = getStraightHookInterior(edge)
+      const straightObstacles = getEdgeObstacles(
+        nodes,
+        edge.source,
+        edge.target,
+        endpoints.adjustedSource,
+        endpoints.adjustedTarget,
+        nodeIndex,
+        candidateBounds
+      )
+      let straightSource = endpoints.adjustedSource
+      let straightTarget = endpoints.adjustedTarget
+      if (interior.length === 0) {
+        const sourceType = nodeById.get(edge.source)?.type
+        const targetType = nodeById.get(edge.target)?.type
+        const { edgeRoutes: neighborEdges } = collectNeighbors(
+          edge,
+          endpoints,
           nodes,
-          edge.source,
-          edge.target,
-          endpoints.adjustedSource,
-          endpoints.adjustedTarget,
           nodeIndex,
-          candidateBounds
-        ),
+          straightObstacles,
+          routeById,
+          neighborGrid,
+          edgeById
+        )
+        const selected = selectEdgeAnchors({
+          sourceRect: rectFromEndpoint(
+            endpoints.sourceAbsolutePosition,
+            endpoints.sourceSize
+          ),
+          targetRect: rectFromEndpoint(
+            endpoints.targetAbsolutePosition,
+            endpoints.targetSize
+          ),
+          sourceType,
+          targetType,
+          sourceCustom: asFreeformAnchor(edge.data?.sourceAnchor),
+          targetCustom: asFreeformAnchor(edge.data?.targetAnchor),
+          sourcePreferred: bandPorts.get(endKey(edge.id, "source")),
+          targetPreferred: bandPorts.get(endKey(edge.id, "target")),
+          resolve: (overrides) =>
+            resolveEdgeEndpoints(
+              edge,
+              nodes,
+              nodeById,
+              nodeLookup,
+              connectionMode,
+              overrides,
+              true,
+              nodeIndex
+            ),
+          obstacles: straightObstacles,
+          thirdPartyObstacles: straightObstacles.filter(
+            (o) => !o.soft && o.id !== edge.source && o.id !== edge.target
+          ),
+          neighborEdges,
+          enableStraightPath: true,
+        })
+        if (selected) {
+          straightSource = selected.endpoints.adjustedSource
+          straightTarget = selected.endpoints.adjustedTarget
+        }
+      }
+      const line = routeStraightPolyline({
+        source: straightSource,
+        target: straightTarget,
+        checkpoints: interior,
+        obstacles: straightObstacles,
         neighborRoutes: [],
         clearancePx: EDGES.NODE_CLEARANCE_PX,
       })

--- a/library/lib/utils/geometry/edgeGeometrySolver.ts
+++ b/library/lib/utils/geometry/edgeGeometrySolver.ts
@@ -928,6 +928,7 @@ function collectFixedPorts(
  * capacity model as immutable reservations. Ends of single-edge nodes are omitted:
  * there is no sibling capacity to coordinate there. */
 function collectPortEnds(
+  straightHookTypes: ReadonlySet<string>,
   ordered: readonly Edge[],
   nodes: readonly Node[],
   nodeById: Map<string, Node>,
@@ -1057,6 +1058,7 @@ function collectPortEnds(
         nodeId: edge.source,
         rect: sourceRect,
         side: sourceSide,
+        straight: straightHookTypes.has(edge.type ?? ""),
         partnerCenter: centerOf(targetRect),
         partnerNodeId: edge.target,
         partnerRect: targetRect,
@@ -1071,6 +1073,7 @@ function collectPortEnds(
         nodeId: edge.target,
         rect: targetRect,
         side: targetSide,
+        straight: straightHookTypes.has(edge.type ?? ""),
         partnerCenter: centerOf(sourceRect),
         partnerNodeId: edge.source,
         partnerRect: sourceRect,
@@ -1342,6 +1345,7 @@ function computeAllEdgeGeometryPass(
   }
   const bandPorts = assignPorts(
     collectPortEnds(
+      straightHookTypes,
       coordinationEdges,
       nodes,
       nodeById,

--- a/library/lib/utils/geometry/edgeGeometrySolver.ts
+++ b/library/lib/utils/geometry/edgeGeometrySolver.ts
@@ -1353,8 +1353,15 @@ function computeAllEdgeGeometryPass(
 
   // How far off its side's centre each seat sits, and the largest such offset on
   // every occupied (node, side). Used to nest a fan — see `straightCornerRing`.
+  // QUANTISED, and that is the whole point. A seat and its mirror image are the same
+  // distance from their side's centre in exact arithmetic, but not in binary
+  // floating point: for a seven-way band, 0.5 - 1/7 and 6/7 - 0.5 differ in the last
+  // bit. Comparing raw distances therefore made one flank of a symmetric diagram
+  // take the roomy corner ring and the other the tight one — a visible asymmetry
+  // from a rounding artefact. Rounding to whole permille is far finer than any seat
+  // spacing yet coarse enough that reflection is exact.
   const seatOffset = (anchor: FreeformEdgeAnchor): number =>
-    Math.abs(anchor.ratio - 0.5)
+    Math.round(Math.abs(anchor.ratio - 0.5) * 1000)
   const outermostSeatOffset = new Map<string, number>()
   for (const edge of coordinationEdges) {
     for (const [end, nodeId] of [

--- a/library/lib/utils/geometry/edgeGeometrySolver.ts
+++ b/library/lib/utils/geometry/edgeGeometrySolver.ts
@@ -308,6 +308,23 @@ function getStraightHookInterior(edge: {
   return Array.isArray(points) ? (points as IPoint[]) : []
 }
 
+/** Outward unit normal of a node side, so the straight router can price a route
+ * that leaves (or meets) a node at a grazing angle instead of squarely. */
+function outwardNormal(side: Position | undefined): IPoint | undefined {
+  switch (side) {
+    case Position.Top:
+      return { x: 0, y: -1 }
+    case Position.Right:
+      return { x: 1, y: 0 }
+    case Position.Bottom:
+      return { x: 0, y: 1 }
+    case Position.Left:
+      return { x: -1, y: 0 }
+    default:
+      return undefined
+  }
+}
+
 function indexRoutePolyline(
   grid: NeighborGrid,
   edgeId: string,
@@ -1366,11 +1383,9 @@ function computeAllEdgeGeometryPass(
     // neighbour map so step edges route around it.
     if (straightHookTypes.has(edge.type ?? "")) {
       const interior = getStraightHookInterior(edge)
-      // Syntax trees are drawn as straight parent→child lines; node overlaps are
-      // resolved by the tidy-tree layout, NOT by per-edge obstacle routing (which
-      // produces backtracking spaghetti on a dense tree). Use-case / petri edges
-      // form general graphs and keep automatic obstacle avoidance.
-      const avoidsObstacles = edge.type !== "SyntaxTreeLink"
+      // Every straight edge avoids intervening node bodies; the routing cost keeps
+      // the detour readable (see `straightPolylineRouter`).
+      const avoidsObstacles = true
       const straightObstacles = getEdgeObstacles(
         nodes,
         edge.source,
@@ -1382,6 +1397,9 @@ function computeAllEdgeGeometryPass(
       )
       let straightSource = endpoints.adjustedSource
       let straightTarget = endpoints.adjustedTarget
+      let straightSourceSide = endpoints.sourcePosition
+      let straightTargetSide = endpoints.targetPosition
+      let straightNeighbors: IPoint[][] = []
       if (interior.length === 0) {
         const sourceType = nodeById.get(edge.source)?.type
         const targetType = nodeById.get(edge.target)?.type
@@ -1432,9 +1450,28 @@ function computeAllEdgeGeometryPass(
           neighborEdges,
           enableStraightPath: true,
         })
+        // Sibling carve-out (the same one the orthogonal neighbour scan makes):
+        // connectors that share a node with this edge are MEANT to fan out from it
+        // side by side. Pricing that as crowding makes the search shove the
+        // departure sideways into exactly the grazing exit we are trying to remove.
+        // Unrelated edges still contribute crossing/overlap/crowding cost.
+        const shares = (other: Edge): boolean =>
+          other.source === edge.source ||
+          other.source === edge.target ||
+          other.target === edge.source ||
+          other.target === edge.target
+        straightNeighbors = []
+        for (const [otherId, route] of Object.entries(routeById)) {
+          if (otherId === edge.id || route.length < 2) continue
+          const other = edgeById.get(otherId)
+          if (other && shares(other)) continue
+          straightNeighbors.push(route)
+        }
         if (selected) {
           straightSource = selected.endpoints.adjustedSource
           straightTarget = selected.endpoints.adjustedTarget
+          straightSourceSide = selected.endpoints.sourcePosition
+          straightTargetSide = selected.endpoints.targetPosition
         }
       }
       const line = avoidsObstacles
@@ -1447,8 +1484,10 @@ function computeAllEdgeGeometryPass(
             obstacles: straightObstacles.filter(
               (o) => o.id !== edge.source && o.id !== edge.target
             ),
-            neighborRoutes: [],
+            neighborRoutes: straightNeighbors,
             clearancePx: EDGES.NODE_CLEARANCE_PX,
+            sourceNormal: outwardNormal(straightSourceSide),
+            targetNormal: outwardNormal(straightTargetSide),
           })
         : [straightSource, ...interior, straightTarget]
       routeById[edge.id] = line

--- a/library/lib/utils/geometry/freeWaypoints.ts
+++ b/library/lib/utils/geometry/freeWaypoints.ts
@@ -1,0 +1,151 @@
+/**
+ * Free-2D waypoint geometry for straight (diagonal) edges.
+ *
+ * Unlike the orthogonal `bendHandles.ts` (H/V staircase jogs), a straight-hook
+ * edge bends at arbitrary 2D points. Following the JointJS "vertices" model, the
+ * persisted `data.points` for these edges holds INTERIOR waypoints ONLY; the
+ * rendered route is `[source, ...interior, target]`. This module owns the pure,
+ * deterministic math for editing that interior list.
+ *
+ * These are document data (authored, persisted), not memoryless auto-geometry, so
+ * they need not be byte-identical across engines — but we still keep the math
+ * integer/grid-snapped and use integer cross-products (never `atan2`) to match the
+ * rest of the geometry kernel and to snap cleanly onto the canvas grid.
+ */
+import { IPoint } from "@/edges/Connection"
+import { EDGES } from "@/utils/geometry/routingConstants"
+
+export interface SegmentGhostHandle {
+  /** Index of the route segment this ghost sits on: route[i] → route[i+1]. */
+  segmentIndex: number
+  /** Integer midpoint of the segment. */
+  position: IPoint
+  /** Squared length of the segment, so the renderer can hide a ghost on a stub. */
+  segmentLengthSq: number
+}
+
+const snap = (value: number, grid: number): number =>
+  grid > 0 ? Math.round(value / grid) * grid : Math.round(value)
+
+/** Snap a free 2D point to the bend grid. */
+export const snapPoint = (
+  point: IPoint,
+  grid: number = EDGES.BEND_SNAP_GRID_PX
+): IPoint => ({ x: snap(point.x, grid), y: snap(point.y, grid) })
+
+/**
+ * A faint ghost handle at the midpoint of every route segment. Dragging one past
+ * `exceedsDragThreshold` materialises a new interior waypoint (see `insertWaypoint`).
+ * Segments shorter than `WAYPOINT_GHOST_MIN_SEGMENT_PX` are skipped so a ghost never
+ * fuses with an endpoint or an adjacent waypoint handle.
+ */
+export const getSegmentGhostHandles = (
+  route: readonly IPoint[]
+): SegmentGhostHandle[] => {
+  const handles: SegmentGhostHandle[] = []
+  const minLenSq =
+    EDGES.WAYPOINT_GHOST_MIN_SEGMENT_PX * EDGES.WAYPOINT_GHOST_MIN_SEGMENT_PX
+  for (let i = 0; i < route.length - 1; i++) {
+    const a = route[i]
+    const b = route[i + 1]
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const lengthSq = dx * dx + dy * dy
+    if (lengthSq < minLenSq) continue
+    handles.push({
+      segmentIndex: i,
+      position: {
+        x: Math.round((a.x + b.x) / 2),
+        y: Math.round((a.y + b.y) / 2),
+      },
+      segmentLengthSq: lengthSq,
+    })
+  }
+  return handles
+}
+
+/**
+ * Materialise a new interior waypoint on route segment `segmentIndex`. Because the
+ * route is `[source, ...interior, target]`, segment `i` lies between `route[i]` and
+ * `route[i+1]`, so the new interior index is exactly `segmentIndex` (segment 0 →
+ * before the current first interior point; the last segment → appended).
+ */
+export const insertWaypoint = (
+  interior: readonly IPoint[],
+  segmentIndex: number,
+  point: IPoint,
+  grid: number = EDGES.BEND_SNAP_GRID_PX
+): IPoint[] => {
+  const index = Math.max(0, Math.min(segmentIndex, interior.length))
+  const next = interior.slice()
+  next.splice(index, 0, snapPoint(point, grid))
+  return next
+}
+
+/** Move interior waypoint `index` to a new (snapped) 2D point. */
+export const moveWaypoint = (
+  interior: readonly IPoint[],
+  index: number,
+  point: IPoint,
+  grid: number = EDGES.BEND_SNAP_GRID_PX
+): IPoint[] => {
+  if (index < 0 || index >= interior.length) return interior.slice()
+  const next = interior.slice()
+  next[index] = snapPoint(point, grid)
+  return next
+}
+
+/** Remove interior waypoint `index`. */
+export const removeWaypoint = (
+  interior: readonly IPoint[],
+  index: number
+): IPoint[] => {
+  if (index < 0 || index >= interior.length) return interior.slice()
+  const next = interior.slice()
+  next.splice(index, 1)
+  return next
+}
+
+/**
+ * Continuous redundancy removal: drop any interior waypoint whose perpendicular
+ * distance from the line through its two route-neighbours is within tolerance
+ * (near-collinear). Uses an integer cross-product — no `atan2`/`hypot`: a point `c`
+ * is collinear with `a`,`b` when `cross(a,b,c)² <= tol² · |b-a|²`.
+ *
+ * Takes the full route `[source, ...interior, target]` so terminal waypoints are
+ * measured against the fixed endpoints; returns the pruned interior list.
+ */
+export const pruneCollinearWaypoints = (
+  route: readonly IPoint[],
+  tolerancePx: number = EDGES.WAYPOINT_COLLINEAR_TOLERANCE_PX
+): IPoint[] => {
+  if (route.length <= 2) return []
+  const tolSq = tolerancePx * tolerancePx
+  const kept: IPoint[] = [route[0]]
+  for (let i = 1; i < route.length - 1; i++) {
+    const a = kept[kept.length - 1]
+    const b = route[i]
+    const c = route[i + 1]
+    const abx = c.x - a.x
+    const aby = c.y - a.y
+    const spanSq = abx * abx + aby * aby
+    const cross = (b.x - a.x) * aby - (b.y - a.y) * abx
+    // Collinear (or a as good as on the a→c line): drop b. spanSq === 0 means the
+    // two neighbours coincide, so b is redundant regardless.
+    if (spanSq === 0 || cross * cross <= tolSq * spanSq) continue
+    kept.push(b)
+  }
+  // `kept` currently begins with the source; interior is everything after it.
+  return kept.slice(1)
+}
+
+/** Did the pointer travel far enough from a grabbed ghost to materialise a bend? */
+export const exceedsDragThreshold = (
+  from: IPoint,
+  to: IPoint,
+  thresholdPx: number = EDGES.WAYPOINT_DRAG_THRESHOLD_PX
+): boolean => {
+  const dx = to.x - from.x
+  const dy = to.y - from.y
+  return dx * dx + dy * dy > thresholdPx * thresholdPx
+}

--- a/library/lib/utils/geometry/integerGeometry.ts
+++ b/library/lib/utils/geometry/integerGeometry.ts
@@ -1,0 +1,95 @@
+/**
+ * Determinism leaf for straight-polyline routing.
+ *
+ * Every function here is a pure integer computation. No `Math.sqrt`, `Math.hypot`
+ * or `Math.atan2` appears on any decision path — those are permitted engine-defined
+ * rounding, and the auto-router's output must be reproduced byte-identically by Yjs
+ * peers and after a reload on a different JS engine (V8/JSC). The only square root is
+ * an exact integer floor (`isqrt`); angle classification uses `BigInt` dot/cross
+ * comparisons so it stays exact for any coordinate magnitude.
+ */
+import type { IPoint } from "@/edges/Connection"
+
+/**
+ * Exact integer floor square root for a non-negative integer up to 2^53.
+ *
+ * Computed by the bit-by-bit method rather than `Math.floor(Math.sqrt(n))`: the
+ * float path can be off by one near perfect squares once `n` approaches 2^53, and a
+ * single off-by-one in a segment length would desynchronise peers. Every
+ * intermediate value here stays `<= n` (so `<= 2^53`, exactly representable) or is a
+ * power of two, so the arithmetic is exact.
+ */
+export function isqrt(n: number): number {
+  if (!Number.isInteger(n) || n < 0)
+    throw new RangeError("isqrt requires a non-negative integer")
+  if (n < 2) return n
+
+  // Highest power of four not exceeding n. `bit * 4` is a power of two and thus
+  // exactly representable even when it briefly exceeds 2^53.
+  let bit = 1
+  while (bit * 4 <= n) bit *= 4
+
+  let result = 0
+  let remaining = n
+  while (bit !== 0) {
+    if (remaining >= result + bit) {
+      remaining -= result + bit
+      // result stays below 2^27 for n <= 2^53, so the halving is exact.
+      result = Math.floor(result / 2) + bit
+    } else {
+      result = Math.floor(result / 2)
+    }
+    bit = Math.floor(bit / 4)
+  }
+  return result
+}
+
+/** Squared distance between two integer points. Exact for realistic coordinates
+ * (each squared delta is well under 2^53). */
+export function distSqInt(a: IPoint, b: IPoint): number {
+  const dx = a.x - b.x
+  const dy = a.y - b.y
+  return dx * dx + dy * dy
+}
+
+/** Integer (floored) Euclidean length of the segment a→b. */
+export function segLenInt(a: IPoint, b: IPoint): number {
+  return isqrt(distSqInt(a, b))
+}
+
+/**
+ * Classify the turn between an incoming travel vector `(ux,uy)` and an outgoing
+ * travel vector `(vx,vy)` into a coarse integer bucket, using ONLY integer dot and
+ * cross products — never `atan2`.
+ *
+ * Buckets (θ is the turn angle between the two travel directions; 0 = dead straight):
+ *   0 — near-straight, θ ≤ 45°  (interior corner angle ≥ 135°)
+ *   1 — moderate,      45° < θ ≤ 90°
+ *   2 — acute/hairpin, θ > 90°
+ *
+ * The thresholds come from comparing cos²θ against sin²θ without a square root:
+ * with `dot = |u||v|cosθ` and `cross = |u||v|sinθ`, `dot² ≥ cross²` iff θ ≤ 45°, and
+ * `sign(dot)` alone splits θ ≤ 90° from θ > 90°. `BigInt` keeps `dot²`/`cross²`
+ * exact for any coordinate magnitude (plain numbers would overflow 2^53 when
+ * squaring large products).
+ */
+export function turnBucket(
+  ux: number,
+  uy: number,
+  vx: number,
+  vy: number
+): number {
+  // A degenerate (zero-length) incoming or outgoing vector implies no genuine
+  // corner; treat it as straight so it never adds a spurious penalty.
+  if ((ux === 0 && uy === 0) || (vx === 0 && vy === 0)) return 0
+
+  const bux = BigInt(ux)
+  const buy = BigInt(uy)
+  const bvx = BigInt(vx)
+  const bvy = BigInt(vy)
+  const dot = bux * bvx + buy * bvy
+  const cross = bux * bvy - buy * bvx
+  if (dot > 0n && dot * dot >= cross * cross) return 0
+  if (dot >= 0n) return 1
+  return 2
+}

--- a/library/lib/utils/geometry/portAssignment.ts
+++ b/library/lib/utils/geometry/portAssignment.ts
@@ -748,6 +748,9 @@ export type EndRef = {
   nodeId: string
   rect: Rect
   side: Position
+  /** This end belongs to a STRAIGHT edge, which reaches its partner directly rather
+   * than along axes — see `rotOf` for why that changes the non-crossing order. */
+  straight?: boolean
   partnerCenter: IPoint
   /** The partner node's id and rect — used to detect and align PARALLEL SIBLINGS
    * (several edges between the same node pair), which must share one straight lane
@@ -1009,12 +1012,19 @@ export const assignPorts = (
     const tangentialHalfExtent = sideAxisLength(side, rect) / 2
     const rotOf = (e: EndRef): number => {
       const c = centerOf(e.rect)
-      return crossingOrderKey(
-        side,
-        e.partnerCenter.x - c.x,
-        e.partnerCenter.y - c.y,
-        tangentialHalfExtent
-      )
+      const dx = e.partnerCenter.x - c.x
+      const dy = e.partnerCenter.y - c.y
+      // A STRAIGHT edge runs directly at its partner, so the order that avoids a
+      // fan crossing itself is simply the angular one. `crossingOrderKey` exists
+      // for orthogonal routes, which leave along an axis and turn far away: for a
+      // partner beyond the node's own band it deliberately INVERTS the angular
+      // order so the farther-reaching route nests outside the nearer one. Applied
+      // to a straight line that inversion manufactures exactly the crossing it is
+      // meant to prevent — a near partner gets seated past a far one, and the two
+      // rays must cross.
+      return e.straight
+        ? alongSideKey(side, dx, dy)
+        : crossingOrderKey(side, dx, dy, tangentialHalfExtent)
     }
     const byPartner = new Map<string, EndRef[]>()
     for (const e of group) {

--- a/library/lib/utils/geometry/rectSides.ts
+++ b/library/lib/utils/geometry/rectSides.ts
@@ -81,35 +81,6 @@ export const facingSide = (rect: Rect, toward: IPoint): Position => {
       : Position.Top
 }
 
-/**
- * The side of `rect` whose outward normal points most directly at `toward` — the
- * side a STRAIGHT run should leave from.
- *
- * This differs from `facingSide` on purpose. `facingSide` scales the displacement by
- * the node's half-extents, because an orthogonal route leaves along an axis and the
- * node's shape decides which axis it can escape on. A straight run pays no corner to
- * reach any side; what it pays for is the angle it departs at, and that is governed
- * by the raw direction alone. On a wide node the two rules genuinely disagree, and
- * using the orthogonal one makes a straight edge slide out along the node's edge.
- *
- * Comparing |dx| against |dy| keeps the rule exact and mirror-symmetric: reflecting
- * the diagram flips the sign of `dx` without touching the comparison, so a symmetric
- * diagram gets symmetric sides. Ties resolve to the vertical axis, which is likewise
- * preserved by reflection.
- */
-export const normalAlignedSide = (rect: Rect, toward: IPoint): Position => {
-  const c = centerOf(rect)
-  const dx = toward.x - c.x
-  const dy = toward.y - c.y
-  return Math.abs(dx) > Math.abs(dy)
-    ? dx >= 0
-      ? Position.Right
-      : Position.Left
-    : dy >= 0
-      ? Position.Bottom
-      : Position.Top
-}
-
 /** How much two intervals overlap (0 when they do not). */
 export const rangeOverlapLen = (
   aLo: number,

--- a/library/lib/utils/geometry/rectSides.ts
+++ b/library/lib/utils/geometry/rectSides.ts
@@ -81,6 +81,35 @@ export const facingSide = (rect: Rect, toward: IPoint): Position => {
       : Position.Top
 }
 
+/**
+ * The side of `rect` whose outward normal points most directly at `toward` — the
+ * side a STRAIGHT run should leave from.
+ *
+ * This differs from `facingSide` on purpose. `facingSide` scales the displacement by
+ * the node's half-extents, because an orthogonal route leaves along an axis and the
+ * node's shape decides which axis it can escape on. A straight run pays no corner to
+ * reach any side; what it pays for is the angle it departs at, and that is governed
+ * by the raw direction alone. On a wide node the two rules genuinely disagree, and
+ * using the orthogonal one makes a straight edge slide out along the node's edge.
+ *
+ * Comparing |dx| against |dy| keeps the rule exact and mirror-symmetric: reflecting
+ * the diagram flips the sign of `dx` without touching the comparison, so a symmetric
+ * diagram gets symmetric sides. Ties resolve to the vertical axis, which is likewise
+ * preserved by reflection.
+ */
+export const normalAlignedSide = (rect: Rect, toward: IPoint): Position => {
+  const c = centerOf(rect)
+  const dx = toward.x - c.x
+  const dy = toward.y - c.y
+  return Math.abs(dx) > Math.abs(dy)
+    ? dx >= 0
+      ? Position.Right
+      : Position.Left
+    : dy >= 0
+      ? Position.Bottom
+      : Position.Top
+}
+
 /** How much two intervals overlap (0 when they do not). */
 export const rangeOverlapLen = (
   aLo: number,

--- a/library/lib/utils/geometry/routingConstants.ts
+++ b/library/lib/utils/geometry/routingConstants.ts
@@ -76,4 +76,19 @@ export const EDGES = Object.freeze({
   LABEL_LINE_HEIGHT: 14,
   /** Nominal label half-width used by placement scoring. */
   LABEL_NOMINAL_HALF_EXTENT: 40,
+  /** Flow-space distance a straight-edge ghost midpoint must travel before it
+   * materialises a real waypoint (Excalidraw DRAGGING_THRESHOLD analogue). */
+  WAYPOINT_DRAG_THRESHOLD_PX: 6,
+  /** A straight-edge interior waypoint within this perpendicular distance of the
+   * line through its neighbours is treated as collinear and pruned. */
+  WAYPOINT_COLLINEAR_TOLERANCE_PX: 4,
+  /** Preferred on-screen radius of a materialised straight-edge waypoint handle. */
+  WAYPOINT_HANDLE_RADIUS_PX: 6,
+  /** On-screen radius of a faint ghost midpoint handle. */
+  WAYPOINT_GHOST_RADIUS_PX: 5,
+  /** Invisible hit target around a waypoint/ghost handle (touch-friendly). */
+  WAYPOINT_HIT_TARGET_PX: 24,
+  /** Shortest segment (flow px) that still shows a ghost midpoint handle, so two
+   * handles never fuse on a tiny segment. */
+  WAYPOINT_GHOST_MIN_SEGMENT_PX: 24,
 } as const)

--- a/library/lib/utils/geometry/routingConstants.ts
+++ b/library/lib/utils/geometry/routingConstants.ts
@@ -82,7 +82,9 @@ export const EDGES = Object.freeze({
   /** A straight-edge interior waypoint within this perpendicular distance of the
    * line through its neighbours is treated as collinear and pruned. */
   WAYPOINT_COLLINEAR_TOLERANCE_PX: 4,
-  /** Invisible hit target around a waypoint/ghost handle (touch-friendly). */
+  /** Radius of the round handle drawn on a route waypoint. */
+  WAYPOINT_HANDLE_RADIUS_PX: 5,
+  /** Invisible hit target around a waypoint handle (touch-friendly). */
   WAYPOINT_HIT_TARGET_PX: 24,
   /** Shortest segment (flow px) that still shows a ghost midpoint handle, so two
    * handles never fuse on a tiny segment. */

--- a/library/lib/utils/geometry/routingConstants.ts
+++ b/library/lib/utils/geometry/routingConstants.ts
@@ -82,10 +82,6 @@ export const EDGES = Object.freeze({
   /** A straight-edge interior waypoint within this perpendicular distance of the
    * line through its neighbours is treated as collinear and pruned. */
   WAYPOINT_COLLINEAR_TOLERANCE_PX: 4,
-  /** Preferred on-screen radius of a materialised straight-edge waypoint handle. */
-  WAYPOINT_HANDLE_RADIUS_PX: 6,
-  /** On-screen radius of a faint ghost midpoint handle. */
-  WAYPOINT_GHOST_RADIUS_PX: 5,
   /** Invisible hit target around a waypoint/ghost handle (touch-friendly). */
   WAYPOINT_HIT_TARGET_PX: 24,
   /** Shortest segment (flow px) that still shows a ghost midpoint handle, so two

--- a/library/lib/utils/geometry/straightPolylineRouter.ts
+++ b/library/lib/utils/geometry/straightPolylineRouter.ts
@@ -66,6 +66,11 @@ export interface StraightRouteRequest {
    * roomier of the two corner rings; the guaranteed margin is MIN_NODE_CLEARANCE_PX.
    * Edge-to-edge crowding is measured separately (EDGE_CROWDING_CLEARANCE_PX). */
   clearancePx: number
+  /** Routes of edges that SHARE a node with this one. They are meant to fan out
+   * side by side, so they are exempt from the crowding term — but never from
+   * crossing or from lying exactly on top of one another, which is always a defect.
+   * Pricing them at zero crowding clearance expresses precisely that. */
+  siblingRoutes?: IPoint[][]
   /** Outward unit normal of the node side the route leaves from, when known. The
    * search then prices a grazing departure (see `ENDPOINT_ANGLE_PENALTY_PX`). */
   sourceNormal?: IPoint
@@ -490,6 +495,7 @@ const routeSubPath = (
   blockRects: readonly IntRect[],
   neighborRoutes: readonly (readonly IPoint[])[],
   crowdingClearancePx: number,
+  siblingRoutes: readonly (readonly IPoint[])[],
   sourceNormal: IPoint | undefined,
   targetNormal: IPoint | undefined
 ): IPoint[] => {
@@ -534,7 +540,9 @@ const routeSubPath = (
       vertices[j],
       neighborRoutes,
       crowdingClearancePx
-    )
+    ) +
+    // Zero clearance: a sibling only costs when it is crossed or lain upon.
+    neighborCostPx(vertices[i], vertices[j], siblingRoutes, 0)
 
   for (const v of adjacency[startIndex]) {
     const dir = {
@@ -655,6 +663,7 @@ const totalRouteCostPx = (
   route: readonly IPoint[],
   neighborRoutes: readonly (readonly IPoint[])[],
   crowdingClearancePx: number,
+  siblingRoutes: readonly (readonly IPoint[])[],
   sourceNormal: IPoint | undefined,
   targetNormal: IPoint | undefined
 ): number => {
@@ -667,6 +676,7 @@ const totalRouteCostPx = (
       neighborRoutes,
       crowdingClearancePx
     )
+    cost += neighborCostPx(route[i - 1], route[i], siblingRoutes, 0)
     if (i >= 2) cost += turnCostPx(route[i - 2], route[i - 1], route[i])
   }
   if (sourceNormal && route.length >= 2)
@@ -702,6 +712,7 @@ const simplifyRoute = (
   blockRects: readonly IntRect[],
   neighborRoutes: readonly (readonly IPoint[])[],
   crowdingClearancePx: number,
+  siblingRoutes: readonly (readonly IPoint[])[],
   sourceNormal: IPoint | undefined,
   targetNormal: IPoint | undefined
 ): IPoint[] => {
@@ -710,6 +721,7 @@ const simplifyRoute = (
     best,
     neighborRoutes,
     crowdingClearancePx,
+    siblingRoutes,
     sourceNormal,
     targetNormal
   )
@@ -731,6 +743,7 @@ const simplifyRoute = (
         candidate,
         neighborRoutes,
         crowdingClearancePx,
+        siblingRoutes,
         sourceNormal,
         targetNormal
       )
@@ -771,6 +784,7 @@ export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
     obstacles,
     neighborRoutes,
     clearancePx,
+    siblingRoutes,
     sourceNormal,
     targetNormal,
   } = req
@@ -823,6 +837,7 @@ export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
             blockRects,
             neighborRoutes,
             EDGE_CROWDING_CLEARANCE_PX,
+            siblingRoutes ?? [],
             k === 1 ? sourceNormal : undefined,
             k === anchors.length - 1 ? targetNormal : undefined
           )
@@ -838,6 +853,7 @@ export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
       blockRects,
       neighborRoutes,
       EDGE_CROWDING_CLEARANCE_PX,
+      siblingRoutes ?? [],
       sourceNormal,
       targetNormal
     ),

--- a/library/lib/utils/geometry/straightPolylineRouter.ts
+++ b/library/lib/utils/geometry/straightPolylineRouter.ts
@@ -1,0 +1,571 @@
+/**
+ * Deterministic obstacle-avoiding STRAIGHT polyline router.
+ *
+ * Given resolved integer endpoints, ordered mandatory checkpoints, and hard/soft
+ * obstacle rectangles, this produces the shortest straight-segment polyline that
+ * keeps clearance from the hard obstacles. It feeds memoryless auto-routing, so the
+ * output MUST be reproduced byte-identically by Yjs peers and after a reload:
+ *
+ *  - Every decision is integer. The only square root is `isqrt` (exact floor); no
+ *    `hypot`/`atan2`/float comparison ever chooses a vertex or breaks a tie.
+ *  - Vertices carry a canonical key `(x, y, kind, ownerId, cornerIndex)` and the
+ *    graph, adjacency lists and A* frontier are all built in that fixed order.
+ *  - The A* frontier is a 4-ary min-heap keyed on `(gPlusH, vertexIndex, seq)`,
+ *    whose final tie-break — the monotonic insertion counter `seq` — is a unique
+ *    discriminator, so the search result cannot depend on engine scheduling or on
+ *    the input order of obstacles/neighbours.
+ *
+ * Design (per the approved plan):
+ *  1. Gate: if every checkpoint sub-chord already clears all hard obstacles by
+ *     ≥ MIN clearance, return the straight polyline unchanged (the common case).
+ *  2. Otherwise build a reduced/tangent visibility graph over the endpoints, the
+ *     checkpoints, and the clearance-inflated corners of each HARD obstacle. Soft
+ *     obstacles never block visibility (they are priced, not avoided).
+ *  3. Route each checkpoint sub-chord independently with A* on that graph and
+ *     concatenate — making checkpoints mandatory via-points (the libavoid model).
+ *  4. Collapse collinear points exactly (integer cross product).
+ *
+ * This module is deliberately self-contained: `segmentsCrossOpen` and the 4-ary heap
+ * live privately in `routingCost.ts` / `orthogonalRouter.ts` and are not exported, so
+ * the equivalent logic is re-implemented here rather than editing those files.
+ */
+import type { IPoint } from "@/edges/Connection"
+import { EDGES } from "@/utils/geometry/routingConstants"
+import { polylineConflictCost } from "@/utils/geometry/routingCost"
+import {
+  distSqInt,
+  isqrt,
+  segLenInt,
+  turnBucket,
+} from "@/utils/geometry/integerGeometry"
+
+export interface StraightRouteObstacle {
+  id: string
+  x: number
+  y: number
+  width: number
+  height: number
+  soft: boolean
+}
+
+export interface StraightRouteRequest {
+  /** Resolved, integer, adjusted source endpoint. */
+  source: IPoint
+  /** Resolved, integer, adjusted target endpoint. */
+  target: IPoint
+  /** Ordered mandatory via-points (user waypoints); may be empty. */
+  checkpoints: IPoint[]
+  /** Corridor obstacle rects (bboxes). */
+  obstacles: StraightRouteObstacle[]
+  /** Other edges' polylines, for crossing/overlap/crowding pricing. */
+  neighborRoutes: IPoint[][]
+  /** Node buffer (EDGES.NODE_CLEARANCE_PX); also the crowding clearance. */
+  clearancePx: number
+}
+
+/** The MINIMUM clearance the returned route guarantees from every hard obstacle.
+ * It is also the gate threshold: a straight chord clearing every hard obstacle by
+ * this much is returned as-is. */
+const MIN_CLEARANCE_PX = EDGES.MIN_NODE_CLEARANCE_PX
+
+/** Small angle penalty per turn bucket. It is a pure tie-break: at a scale far
+ * below `ROUTING_COST.edgeCrossing` (400) and small against real segment lengths,
+ * it prefers straighter equal-length routes without ever buying a detour. */
+const ANGLE_PENALTY_PER_BUCKET = 4
+
+type Kind = 0 | 1 | 2 | 3
+const KIND_SOURCE: Kind = 0
+const KIND_TARGET: Kind = 1
+const KIND_CHECKPOINT: Kind = 2
+const KIND_CORNER: Kind = 3
+
+type Vertex = {
+  x: number
+  y: number
+  kind: Kind
+  ownerId: string
+  cornerIndex: number
+}
+
+type IntRect = { x: number; y: number; w: number; h: number }
+
+const rectOf = (o: StraightRouteObstacle): IntRect => ({
+  x: o.x,
+  y: o.y,
+  w: o.width,
+  h: o.height,
+})
+
+const inflate = (r: IntRect, d: number): IntRect => ({
+  x: r.x - d,
+  y: r.y - d,
+  w: r.w + 2 * d,
+  h: r.h + 2 * d,
+})
+
+const strictlyInside = (r: IntRect, p: IPoint): boolean =>
+  p.x > r.x && p.x < r.x + r.w && p.y > r.y && p.y < r.y + r.h
+
+const inclusiveContains = (r: IntRect, p: IPoint): boolean =>
+  p.x >= r.x && p.x <= r.x + r.w && p.y >= r.y && p.y <= r.y + r.h
+
+/** Orientation sign of point c relative to the directed line a→b (integer). */
+const orient = (a: IPoint, b: IPoint, c: IPoint): number =>
+  (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+
+/**
+ * Strict interior crossing of two segments. Endpoint touches are attachment
+ * geometry, not crossings — this mirrors the private `segmentsCrossOpen` in
+ * `routingCost.ts`, re-implemented here so the module stays self-contained.
+ */
+const segmentsCrossOpen = (
+  a1: IPoint,
+  a2: IPoint,
+  b1: IPoint,
+  b2: IPoint
+): boolean => {
+  const l1 = orient(a1, a2, b1)
+  const l2 = orient(a1, a2, b2)
+  const r1 = orient(b1, b2, a1)
+  const r2 = orient(b1, b2, a2)
+  return l1 * l2 < 0 && r1 * r2 < 0
+}
+
+/**
+ * Does the open segment a→b pass through the OPEN interior of the axis-aligned
+ * rectangle? Three exact integer tests: either endpoint strictly inside, the
+ * midpoint strictly inside (doubled coordinates keep it integer — this catches a
+ * corner-to-corner diagonal that grazes only the rectangle's own corners), or a
+ * strict crossing of any of the four sides. Corner touches are allowed.
+ */
+const segmentIntersectsRectInterior = (
+  a: IPoint,
+  b: IPoint,
+  r: IntRect
+): boolean => {
+  if (strictlyInside(r, a) || strictlyInside(r, b)) return true
+
+  const sx = a.x + b.x
+  const sy = a.y + b.y
+  if (
+    sx > 2 * r.x &&
+    sx < 2 * (r.x + r.w) &&
+    sy > 2 * r.y &&
+    sy < 2 * (r.y + r.h)
+  )
+    return true
+
+  const c0 = { x: r.x, y: r.y }
+  const c1 = { x: r.x + r.w, y: r.y }
+  const c2 = { x: r.x + r.w, y: r.y + r.h }
+  const c3 = { x: r.x, y: r.y + r.h }
+  return (
+    segmentsCrossOpen(a, b, c0, c1) ||
+    segmentsCrossOpen(a, b, c1, c2) ||
+    segmentsCrossOpen(a, b, c2, c3) ||
+    segmentsCrossOpen(a, b, c3, c0)
+  )
+}
+
+/**
+ * Does the straight chord a→b clear every HARD obstacle by at least
+ * `minClearancePx`? An obstacle whose `minClearancePx`-inflated body already
+ * contains an endpoint is that endpoint's OWN node and is exempt (you cannot clear
+ * the node your endpoint sits on). Soft obstacles are ignored.
+ */
+export function chordClearsObstacles(
+  a: IPoint,
+  b: IPoint,
+  hardObstacles: StraightRouteObstacle[],
+  minClearancePx: number
+): boolean {
+  for (const o of hardObstacles) {
+    if (o.soft) continue
+    const inflated = inflate(rectOf(o), minClearancePx)
+    if (inclusiveContains(inflated, a) || inclusiveContains(inflated, b))
+      continue
+    if (segmentIntersectsRectInterior(a, b, inflated)) return false
+  }
+  return true
+}
+
+const samePoint = (a: IPoint, b: IPoint): boolean => a.x === b.x && a.y === b.y
+
+const compareStrings = (a: string, b: string): number =>
+  a < b ? -1 : a > b ? 1 : 0
+
+/** Canonical total order on vertices. Deterministic across engines: numeric fields
+ * compare exactly and string ids compare by UTF-16 code unit. */
+const compareVertices = (a: Vertex, b: Vertex): number =>
+  a.x - b.x ||
+  a.y - b.y ||
+  a.kind - b.kind ||
+  compareStrings(a.ownerId, b.ownerId) ||
+  a.cornerIndex - b.cornerIndex
+
+/**
+ * A minimal deterministic 4-ary min-heap keyed on `(priority, vertexIndex, seq)`.
+ * Adapted from the private heap in `orthogonalRouter.ts`; `vertexIndex` is both the
+ * stored payload and the secondary key, and the monotonic `seq` is a unique final
+ * discriminator, so pops are engine-independent.
+ */
+class MinHeap {
+  private readonly pr: number[] = []
+  private readonly idx: number[] = []
+  private readonly sq: number[] = []
+
+  get size(): number {
+    return this.pr.length
+  }
+
+  private less(i: number, j: number): boolean {
+    if (this.pr[i] !== this.pr[j]) return this.pr[i] < this.pr[j]
+    if (this.idx[i] !== this.idx[j]) return this.idx[i] < this.idx[j]
+    return this.sq[i] < this.sq[j]
+  }
+
+  private swap(i: number, j: number): void {
+    ;[this.pr[i], this.pr[j]] = [this.pr[j], this.pr[i]]
+    ;[this.idx[i], this.idx[j]] = [this.idx[j], this.idx[i]]
+    ;[this.sq[i], this.sq[j]] = [this.sq[j], this.sq[i]]
+  }
+
+  push(priority: number, vertexIndex: number, seq: number): void {
+    this.pr.push(priority)
+    this.idx.push(vertexIndex)
+    this.sq.push(seq)
+    let i = this.pr.length - 1
+    while (i > 0) {
+      const parent = (i - 1) >> 2
+      if (!this.less(i, parent)) break
+      this.swap(i, parent)
+      i = parent
+    }
+  }
+
+  /** The lowest-priority payload, or -1 when empty. */
+  pop(): number {
+    if (this.pr.length === 0) return -1
+    const top = this.idx[0]
+    const lastPr = this.pr.pop() as number
+    const lastIdx = this.idx.pop() as number
+    const lastSq = this.sq.pop() as number
+    if (this.pr.length === 0) return top
+    this.pr[0] = lastPr
+    this.idx[0] = lastIdx
+    this.sq[0] = lastSq
+    let i = 0
+    const n = this.pr.length
+    for (;;) {
+      const first = 4 * i + 1
+      if (first >= n) break
+      let best = first
+      const end = Math.min(first + 4, n)
+      for (let c = first + 1; c < end; c++) if (this.less(c, best)) best = c
+      if (!this.less(best, i)) break
+      this.swap(i, best)
+      i = best
+    }
+    return top
+  }
+}
+
+/** Build the canonical, deduplicated vertex list and a coordinate → index lookup.
+ * On a shared coordinate the canonically-smallest vertex wins, so an endpoint (low
+ * kind) is never shadowed by a coincident obstacle corner. */
+const buildVertices = (
+  source: IPoint,
+  target: IPoint,
+  checkpoints: readonly IPoint[],
+  hardObstacles: readonly StraightRouteObstacle[],
+  clearancePx: number
+): { vertices: Vertex[]; indexAt: (p: IPoint) => number } => {
+  const raw: Vertex[] = [
+    {
+      x: source.x,
+      y: source.y,
+      kind: KIND_SOURCE,
+      ownerId: "",
+      cornerIndex: 0,
+    },
+    {
+      x: target.x,
+      y: target.y,
+      kind: KIND_TARGET,
+      ownerId: "",
+      cornerIndex: 0,
+    },
+  ]
+  checkpoints.forEach((c, i) =>
+    raw.push({
+      x: c.x,
+      y: c.y,
+      kind: KIND_CHECKPOINT,
+      ownerId: "",
+      cornerIndex: i,
+    })
+  )
+  for (const o of hardObstacles) {
+    if (o.soft) continue
+    const r = inflate(rectOf(o), clearancePx)
+    const corners: IPoint[] = [
+      { x: r.x, y: r.y },
+      { x: r.x + r.w, y: r.y },
+      { x: r.x + r.w, y: r.y + r.h },
+      { x: r.x, y: r.y + r.h },
+    ]
+    corners.forEach((p, ci) =>
+      raw.push({
+        x: p.x,
+        y: p.y,
+        kind: KIND_CORNER,
+        ownerId: o.id,
+        cornerIndex: ci,
+      })
+    )
+  }
+
+  raw.sort(compareVertices)
+
+  const vertices: Vertex[] = []
+  const byCoord = new Map<string, number>()
+  for (const v of raw) {
+    const key = `${v.x},${v.y}`
+    if (byCoord.has(key)) continue
+    byCoord.set(key, vertices.length)
+    vertices.push(v)
+  }
+  const indexAt = (p: IPoint): number => byCoord.get(`${p.x},${p.y}`) ?? -1
+  return { vertices, indexAt }
+}
+
+/**
+ * Mutual visibility of two vertices: the segment between them must not enter the
+ * MIN-clearance-inflated interior of any hard obstacle. A segment incident to the
+ * sub-chord's own endpoint is exempt from obstacles whose inflated body contains
+ * that endpoint (the node it departs from / arrives at). Corner touches are allowed.
+ */
+const visible = (
+  vertices: readonly Vertex[],
+  i: number,
+  j: number,
+  endA: number,
+  endB: number,
+  blockRects: readonly IntRect[]
+): boolean => {
+  const p = vertices[i]
+  const q = vertices[j]
+  const exemptI = i === endA || i === endB
+  const exemptJ = j === endA || j === endB
+  for (const r of blockRects) {
+    if (exemptI && inclusiveContains(r, p)) continue
+    if (exemptJ && inclusiveContains(r, q)) continue
+    if (segmentIntersectsRectInterior(p, q, r)) return false
+  }
+  return true
+}
+
+/** Shortest obstacle-avoiding sub-path from vertex `startIndex` to `goalIndex` via
+ * A* on the visibility graph. Returns the ordered point list `[A, …, B]`, or a
+ * straight `[A, B]` fallback when the goal is unreachable (deterministic). */
+const routeSubPath = (
+  vertices: readonly Vertex[],
+  startIndex: number,
+  goalIndex: number,
+  blockRects: readonly IntRect[]
+): IPoint[] => {
+  const a: IPoint = { x: vertices[startIndex].x, y: vertices[startIndex].y }
+  const b: IPoint = { x: vertices[goalIndex].x, y: vertices[goalIndex].y }
+  if (startIndex === goalIndex) return [a]
+
+  const n = vertices.length
+  const goal = vertices[goalIndex]
+
+  // Adjacency built in ascending index order for a deterministic frontier.
+  const adjacency: number[][] = []
+  for (let i = 0; i < n; i++) {
+    const list: number[] = []
+    for (let j = 0; j < n; j++) {
+      if (j === i) continue
+      if (visible(vertices, i, j, startIndex, goalIndex, blockRects))
+        list.push(j)
+    }
+    adjacency.push(list)
+  }
+
+  const gScore = new Array<number>(n).fill(Number.POSITIVE_INFINITY)
+  const cameFrom = new Array<number>(n).fill(-1)
+  const closed = new Array<boolean>(n).fill(false)
+  const heuristic = (i: number): number => isqrt(distSqInt(vertices[i], goal))
+
+  const heap = new MinHeap()
+  let seq = 0
+  gScore[startIndex] = 0
+  heap.push(heuristic(startIndex), startIndex, seq++)
+
+  while (heap.size > 0) {
+    const u = heap.pop()
+    if (closed[u]) continue
+    closed[u] = true
+    if (u === goalIndex) break
+    const pred = cameFrom[u]
+    for (const v of adjacency[u]) {
+      if (closed[v]) continue
+      let turn = 0
+      if (pred >= 0) {
+        turn =
+          turnBucket(
+            vertices[u].x - vertices[pred].x,
+            vertices[u].y - vertices[pred].y,
+            vertices[v].x - vertices[u].x,
+            vertices[v].y - vertices[u].y
+          ) * ANGLE_PENALTY_PER_BUCKET
+      }
+      const tentative = gScore[u] + segLenInt(vertices[u], vertices[v]) + turn
+      if (tentative < gScore[v]) {
+        gScore[v] = tentative
+        cameFrom[v] = u
+        heap.push(tentative + heuristic(v), v, seq++)
+      }
+    }
+  }
+
+  if (!Number.isFinite(gScore[goalIndex])) return [a, b]
+
+  const reversed: IPoint[] = []
+  for (let at = goalIndex; at !== -1; at = cameFrom[at])
+    reversed.push({ x: vertices[at].x, y: vertices[at].y })
+  reversed.reverse()
+  return reversed
+}
+
+/** Drop exact duplicates and interior points that are collinear with their
+ * neighbours (integer cross product). Endpoints are always kept. */
+const collapseCollinear = (points: readonly IPoint[]): IPoint[] => {
+  const dedup: IPoint[] = []
+  for (const p of points) {
+    const last = dedup[dedup.length - 1]
+    if (last && samePoint(last, p)) continue
+    dedup.push(p)
+  }
+  if (dedup.length <= 2) return dedup
+  const out: IPoint[] = [dedup[0]]
+  for (let i = 1; i < dedup.length - 1; i++) {
+    const a = dedup[i - 1]
+    const p = dedup[i]
+    const c = dedup[i + 1]
+    if (orient(a, c, p) === 0) continue
+    out.push(p)
+  }
+  out.push(dedup[dedup.length - 1])
+  return out
+}
+
+/** Full routing objective in integer pixels: floored segment lengths, the small
+ * angle tie-break, and the crossing/overlap/crowding cost against neighbours. Used
+ * to rank candidates; sums over neighbours so it is independent of their order. */
+const routeObjective = (
+  route: readonly IPoint[],
+  neighborRoutes: readonly (readonly IPoint[])[],
+  crowdingClearancePx: number
+): number => {
+  let length = 0
+  let angle = 0
+  for (let i = 1; i < route.length; i++) {
+    length += segLenInt(route[i - 1], route[i])
+    if (i >= 2) {
+      angle +=
+        turnBucket(
+          route[i - 1].x - route[i - 2].x,
+          route[i - 1].y - route[i - 2].y,
+          route[i].x - route[i - 1].x,
+          route[i].y - route[i - 1].y
+        ) * ANGLE_PENALTY_PER_BUCKET
+    }
+  }
+  const conflict = polylineConflictCost(
+    route,
+    neighborRoutes,
+    crowdingClearancePx
+  )
+  return length + angle + conflict.cost
+}
+
+/** Lexicographic order on two polylines; the deterministic final tie-break when
+ * two candidates score identically. */
+const compareRoutes = (a: readonly IPoint[], b: readonly IPoint[]): number => {
+  const len = Math.min(a.length, b.length)
+  for (let i = 0; i < len; i++) {
+    if (a[i].x !== b[i].x) return a[i].x - b[i].x
+    if (a[i].y !== b[i].y) return a[i].y - b[i].y
+  }
+  return a.length - b.length
+}
+
+/**
+ * Route a deterministic straight (obstacle-avoiding) polyline from source to target
+ * through every checkpoint in order. Returns the full route INCLUDING the endpoints:
+ * `[source, …bends, target]`. When the straight polyline already clears all hard
+ * obstacles by ≥ MIN clearance it is returned unchanged.
+ */
+export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
+  const {
+    source,
+    target,
+    checkpoints,
+    obstacles,
+    neighborRoutes,
+    clearancePx,
+  } = req
+  const hardObstacles = obstacles.filter((o) => !o.soft)
+  const anchors: IPoint[] = [source, ...checkpoints, target]
+
+  // 1. Gate: every sub-chord already clears the hard obstacles.
+  const straightClears = anchors.every((a, i) => {
+    if (i === 0) return true
+    return chordClearsObstacles(
+      anchors[i - 1],
+      a,
+      hardObstacles,
+      MIN_CLEARANCE_PX
+    )
+  })
+  if (straightClears) return collapseCollinear(anchors)
+
+  // 2. Visibility graph over endpoints, checkpoints and inflated hard corners.
+  const { vertices, indexAt } = buildVertices(
+    source,
+    target,
+    checkpoints,
+    hardObstacles,
+    clearancePx
+  )
+  const blockRects = hardObstacles.map((o) =>
+    inflate(rectOf(o), MIN_CLEARANCE_PX)
+  )
+
+  // 3. Route each checkpoint sub-chord independently and concatenate.
+  const combined: IPoint[] = []
+  for (let k = 1; k < anchors.length; k++) {
+    const startIndex = indexAt(anchors[k - 1])
+    const goalIndex = indexAt(anchors[k])
+    const sub =
+      startIndex < 0 || goalIndex < 0
+        ? [anchors[k - 1], anchors[k]]
+        : routeSubPath(vertices, startIndex, goalIndex, blockRects)
+    if (combined.length === 0) combined.push(...sub)
+    else combined.push(...sub.slice(1))
+  }
+
+  // 4. Collapse collinear points; verify the single candidate under the full
+  //    objective (a deterministic, neighbour-order-independent scaffold that keeps
+  //    the door open for alternative candidates without changing today's output).
+  const candidate = collapseCollinear(combined)
+  const candidates = [candidate]
+  candidates.sort(
+    (a, b) =>
+      routeObjective(a, neighborRoutes, clearancePx) -
+        routeObjective(b, neighborRoutes, clearancePx) || compareRoutes(a, b)
+  )
+  return candidates[0]
+}

--- a/library/lib/utils/geometry/straightPolylineRouter.ts
+++ b/library/lib/utils/geometry/straightPolylineRouter.ts
@@ -66,6 +66,15 @@ export interface StraightRouteRequest {
    * roomier of the two corner rings; the guaranteed margin is MIN_NODE_CLEARANCE_PX.
    * Edge-to-edge crowding is measured separately (EDGE_CROWDING_CLEARANCE_PX). */
   clearancePx: number
+  /**
+   * Which ring of obstacle corners this route should prefer to turn on: 0 hugs the
+   * guaranteed margin, 1 stands further off. Sibling connectors that must clear the
+   * same obstacle otherwise converge on one shared elbow; giving the outer members
+   * of a fan the outer ring nests them instead, so they stay separated and parallel.
+   * Derived from the edge's own coordinated seat, never from routing order, so a
+   * mirror-symmetric diagram still resolves symmetrically.
+   */
+  preferredCornerRing?: number
   /** Routes of edges that SHARE a node with this one. They are meant to fan out
    * side by side, so they are exempt from the crowding term — but never from
    * crossing or from lying exactly on top of one another, which is always a defect.
@@ -149,12 +158,21 @@ const MIN_CLEARANCE_PX = EDGES.MIN_NODE_CLEARANCE_PX
 const SCALE = 1024
 
 /**
- * Flat cost of HAVING a bend at all, independent of how gentle it is — the same
- * `bendInGridCells` charge the orthogonal engine applies per corner. Without a floor,
- * a graduated angle cost makes a staircase of tiny near-free bends cheaper than one
- * honest corner, and the route acquires a shimmer of pointless kinks.
+ * Flat cost of HAVING a bend at all, independent of how gentle it is — the straight
+ * regime's counterpart to the engine's per-corner `bendInGridCells` charge.
+ *
+ * Two jobs. Without a floor, a graduated angle cost makes a staircase of tiny
+ * near-free bends cheaper than one honest corner and the route acquires a shimmer of
+ * pointless kinks. And the floor has to be GENEROUS — four orthogonal corners' worth
+ * — because a diagonal bend may fall anywhere, so a small floor lets the search buy
+ * an extra corner for a few pixels of length. That is exactly what makes a drawing
+ * unstable: nudge a node and a route that was saving 5px suddenly gains a bend.
+ * Pricing a corner well above such savings measurably steadies the picture (bend
+ * flips under a one-grid-cell node move fell by ~70% in the routing fixtures)
+ * without lengthening a single route in them.
  */
-const BEND_PENALTY_PX = ROUTING_COST.bendInGridCells * CANVAS.SNAP_TO_GRID_PX
+const BEND_PENALTY_PX =
+  4 * ROUTING_COST.bendInGridCells * CANVAS.SNAP_TO_GRID_PX
 
 /** Additional cost scaled by how sharply the route turns. `(1 − cos)` keeps a gentle
  * course correction cheap while a right-angle turn costs ~2 further bends and a
@@ -170,10 +188,36 @@ const TURN_PENALTY_PX = 90
  */
 const ENDPOINT_ANGLE_PENALTY_PX = 150
 
-/** Band within which two parallel edges read as crowded. Uses the engine's own
- * edge-to-edge value, NOT the node clearance: they answer different questions. */
-const EDGE_CROWDING_CLEARANCE_PX =
-  ROUTING_COST.parallelCrowdingClearanceInGridCells * CANVAS.SNAP_TO_GRID_PX
+/**
+ * The separation at which two edges stop reading as one thick line. Below it the
+ * crowding term charges, in proportion to how far short the run falls; at or above
+ * it the charge is exactly zero. That is what makes a pair of neatly parallel
+ * connectors the CHEAPEST arrangement available rather than merely a tolerated one —
+ * expressed as a penalty that vanishes, because a literal bonus would be a negative
+ * edge weight and A* may not have those.
+ *
+ * Deliberately the node clearance rather than the engine's tighter edge-to-edge
+ * band: a straight route is free to sit anywhere, so it can afford real daylight,
+ * and the reported drawings read as cramped at the tighter value.
+ */
+const EDGE_CROWDING_CLEARANCE_PX = EDGES.NODE_CLEARANCE_PX
+
+/**
+ * Charged for turning at a point another route already turns at, so connectors that
+ * must clear the same obstacle do not all pile onto one shared elbow.
+ *
+ * Deliberately SMALL. A larger value unties the knot but is order-dependent — the
+ * first route to claim a corner keeps it and the next is pushed out — which makes a
+ * mirror-symmetric diagram resolve differently on its two halves. Symmetry is worth
+ * more than an untied elbow, so this only breaks ties between otherwise equal
+ * corners; genuinely separating a fan needs deterministic port-rank nudging.
+ */
+const SHARED_BEND_PENALTY_PX = 12
+
+/** Charged for turning on a corner ring other than the edge's preferred one. Enough
+ * to outweigh the extra travel of standing further off an obstacle, far below a
+ * crossing, so it nests a fan without ever buying a conflict. */
+const RING_MISMATCH_PENALTY_PX = 70
 
 /** Beyond this many graph vertices the directed-edge search is skipped in favour of
  * the plain vertex search: the corridor window keeps real diagrams far below it, and
@@ -496,6 +540,8 @@ const routeSubPath = (
   neighborRoutes: readonly (readonly IPoint[])[],
   crowdingClearancePx: number,
   siblingRoutes: readonly (readonly IPoint[])[],
+  occupiedBends: ReadonlySet<string>,
+  preferredCornerRing: number,
   sourceNormal: IPoint | undefined,
   targetNormal: IPoint | undefined
 ): IPoint[] => {
@@ -532,6 +578,19 @@ const routeSubPath = (
   const stateClosed = new Uint8Array(stateCount)
   const heap = new MinHeap()
   let seq = 0
+
+  const bendCostAt = (i: number): number => {
+    if (i === goalIndex) return 0
+    let cost = occupiedBends.has(`${vertices[i].x},${vertices[i].y}`)
+      ? SHARED_BEND_PENALTY_PX
+      : 0
+    if (
+      vertices[i].kind === KIND_CORNER &&
+      Math.floor(vertices[i].cornerIndex / 4) !== preferredCornerRing
+    )
+      cost += RING_MISMATCH_PENALTY_PX
+    return cost
+  }
 
   const segmentCost = (i: number, j: number): number =>
     segLenInt(vertices[i], vertices[j]) +
@@ -583,7 +642,8 @@ const routeSubPath = (
       let cost =
         stateG[state] +
         segmentCost(v, w) +
-        turnCostPx(vertices[u], vertices[v], vertices[w])
+        turnCostPx(vertices[u], vertices[v], vertices[w]) +
+        bendCostAt(v)
       if (w === goalIndex && targetNormal)
         cost += angleCostPx(
           {
@@ -785,6 +845,7 @@ export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
     neighborRoutes,
     clearancePx,
     siblingRoutes,
+    preferredCornerRing,
     sourceNormal,
     targetNormal,
   } = req
@@ -818,6 +879,12 @@ export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
   const blockRects = hardObstacles.map((o) =>
     inflate(rectOf(o), MIN_CLEARANCE_PX)
   )
+  // Elbows other routes already turn at — see SHARED_BEND_PENALTY_PX.
+  const occupiedBends = new Set<string>()
+  for (const route of [...neighborRoutes, ...(siblingRoutes ?? [])])
+    for (const point of route.slice(1, -1))
+      occupiedBends.add(`${point.x},${point.y}`)
+
   // 3. Route each checkpoint sub-chord independently and concatenate. Only the
   //    first sub-chord departs the source node and only the last meets the target,
   //    so the endpoint-angle terms apply to those alone.
@@ -838,6 +905,8 @@ export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
             neighborRoutes,
             EDGE_CROWDING_CLEARANCE_PX,
             siblingRoutes ?? [],
+            occupiedBends,
+            preferredCornerRing ?? 0,
             k === 1 ? sourceNormal : undefined,
             k === anchors.length - 1 ? targetNormal : undefined
           )

--- a/library/lib/utils/geometry/straightPolylineRouter.ts
+++ b/library/lib/utils/geometry/straightPolylineRouter.ts
@@ -127,12 +127,27 @@ const turnCostPx = (from: IPoint, via: IPoint, to: IPoint): number => {
 }
 
 /**
+ * How much dearer a conflict is between STRAIGHT edges than between orthogonal ones.
+ *
+ * The orthogonal engine's weights are calibrated for right-angle meetings, and a
+ * 90-degree crossing is the least harmful there is — the eye follows both lines
+ * straight through it (Huang et al., cited in geometry/README.md). Two straight
+ * edges meet at whatever angle their endpoints dictate, and a shallow crossing or a
+ * near-tangential touch is genuinely hard to trace: the two strokes merge into one
+ * for a stretch and the reader loses which is which. Straight routes are also free
+ * to sit anywhere, so avoiding a conflict rarely costs them much. Both facts point
+ * the same way — price contact far above the orthogonal baseline.
+ */
+const CONFLICT_SEVERITY = 1
+
+/**
  * Cost of one candidate segment against every neighbouring edge, delegated to the
  * SHARED `polylineConflictCost` so a crossing, a collinear overlap and a too-close
- * parallel run are priced on exactly the objective the orthogonal engine uses
- * (`edgeCrossing` 400, `overlapPerPx` 25, `crowdingPerPx` 3). Re-deriving these
- * weights locally is how the two regimes would drift apart. Summed over
- * neighbours, so the result never depends on their order.
+ * parallel run keep the orthogonal engine's RELATIVE ordering (`edgeCrossing` 400,
+ * `overlapPerPx` 25, `crowdingPerPx` 3) — re-deriving those weights locally is how
+ * the two regimes would drift apart — and then scaled as a whole by
+ * `CONFLICT_SEVERITY`. Summed over neighbours, so the result never depends on their
+ * order.
  */
 const neighborCostPx = (
   a: IPoint,
@@ -140,6 +155,7 @@ const neighborCostPx = (
   neighborRoutes: readonly (readonly IPoint[])[],
   crowdingClearancePx: number
 ): number =>
+  CONFLICT_SEVERITY *
   polylineConflictCost([a, b], neighborRoutes, crowdingClearancePx).cost
 
 /** The MINIMUM clearance the returned route guarantees from every hard obstacle.

--- a/library/lib/utils/geometry/straightPolylineRouter.ts
+++ b/library/lib/utils/geometry/straightPolylineRouter.ts
@@ -15,29 +15,32 @@
  *    discriminator, so the search result cannot depend on engine scheduling or on
  *    the input order of obstacles/neighbours.
  *
- * Design (per the approved plan):
+ * Design:
  *  1. Gate: if every checkpoint sub-chord already clears all hard obstacles by
  *     ≥ MIN clearance, return the straight polyline unchanged (the common case).
  *  2. Otherwise build a reduced/tangent visibility graph over the endpoints, the
- *     checkpoints, and the clearance-inflated corners of each HARD obstacle. Soft
+ *     checkpoints, and two rings of inflated corners per HARD obstacle. Soft
  *     obstacles never block visibility (they are priced, not avoided).
- *  3. Route each checkpoint sub-chord independently with A* on that graph and
- *     concatenate — making checkpoints mandatory via-points (the libavoid model).
- *  4. Collapse collinear points exactly (integer cross product).
+ *  3. Route each checkpoint sub-chord with A* over DIRECTED EDGES, so the objective
+ *     can price the things that decide whether a detour looks deliberate or
+ *     accidental: travel, a flat per-bend charge plus a sharpness-graduated turn
+ *     cost, the departure/arrival angle against each node side, and the shared
+ *     crossing / overlap / crowding cost against neighbouring edges. Checkpoints
+ *     are mandatory via-points (the libavoid model).
+ *  4. Collapse collinear points, then string-pull away any bend the route does not
+ *     need — accepted only when it strictly improves that same objective.
  *
  * This module is deliberately self-contained: `segmentsCrossOpen` and the 4-ary heap
  * live privately in `routingCost.ts` / `orthogonalRouter.ts` and are not exported, so
  * the equivalent logic is re-implemented here rather than editing those files.
  */
 import type { IPoint } from "@/edges/Connection"
-import { EDGES } from "@/utils/geometry/routingConstants"
-import { polylineConflictCost } from "@/utils/geometry/routingCost"
+import { CANVAS, EDGES } from "@/utils/geometry/routingConstants"
 import {
-  distSqInt,
-  isqrt,
-  segLenInt,
-  turnBucket,
-} from "@/utils/geometry/integerGeometry"
+  polylineConflictCost,
+  ROUTING_COST,
+} from "@/utils/geometry/routingCost"
+import { distSqInt, isqrt, segLenInt } from "@/utils/geometry/integerGeometry"
 
 export interface StraightRouteObstacle {
   id: string
@@ -59,19 +62,118 @@ export interface StraightRouteRequest {
   obstacles: StraightRouteObstacle[]
   /** Other edges' polylines, for crossing/overlap/crowding pricing. */
   neighborRoutes: IPoint[][]
-  /** Node buffer (EDGES.NODE_CLEARANCE_PX); also the crowding clearance. */
+  /** Preferred breathing room around a node (EDGES.NODE_CLEARANCE_PX). It sets the
+   * roomier of the two corner rings; the guaranteed margin is MIN_NODE_CLEARANCE_PX.
+   * Edge-to-edge crowding is measured separately (EDGE_CROWDING_CLEARANCE_PX). */
   clearancePx: number
+  /** Outward unit normal of the node side the route leaves from, when known. The
+   * search then prices a grazing departure (see `ENDPOINT_ANGLE_PENALTY_PX`). */
+  sourceNormal?: IPoint
+  /** Outward unit normal of the node side the route arrives at, when known. */
+  targetNormal?: IPoint
 }
+
+/** `weight · (1 − cos θ)` between `dir` and a unit `reference`, in integer px. */
+const angleCostPx = (
+  dir: IPoint,
+  reference: IPoint,
+  weightPx: number
+): number => {
+  const length = isqrt(dir.x * dir.x + dir.y * dir.y)
+  if (length === 0) return 0
+  const dot = dir.x * reference.x + dir.y * reference.y
+  const cosScaled = Math.trunc((dot * SCALE) / length)
+  return Math.trunc((weightPx * (SCALE - cosScaled)) / SCALE)
+}
+
+/** Cost of the bend at `via` between the incoming and outgoing segments. */
+const turnCostPx = (from: IPoint, via: IPoint, to: IPoint): number => {
+  const incoming = { x: via.x - from.x, y: via.y - from.y }
+  const outgoing = { x: to.x - via.x, y: to.y - via.y }
+  const incomingLength = isqrt(
+    incoming.x * incoming.x + incoming.y * incoming.y
+  )
+  if (incomingLength === 0) return 0
+  // Normalising the incoming direction to the fixed-point scale keeps the whole
+  // computation integer while measuring the true deviation from "straight on".
+  const reference = {
+    x: Math.trunc((incoming.x * SCALE) / incomingLength),
+    y: Math.trunc((incoming.y * SCALE) / incomingLength),
+  }
+  const outgoingLength = isqrt(
+    outgoing.x * outgoing.x + outgoing.y * outgoing.y
+  )
+  if (outgoingLength === 0) return 0
+  const dot = outgoing.x * reference.x + outgoing.y * reference.y
+  const cosScaled = Math.trunc(dot / outgoingLength)
+  return (
+    BEND_PENALTY_PX +
+    Math.trunc((TURN_PENALTY_PX * (SCALE - cosScaled)) / SCALE)
+  )
+}
+
+/**
+ * Cost of one candidate segment against every neighbouring edge, delegated to the
+ * SHARED `polylineConflictCost` so a crossing, a collinear overlap and a too-close
+ * parallel run are priced on exactly the objective the orthogonal engine uses
+ * (`edgeCrossing` 400, `overlapPerPx` 25, `crowdingPerPx` 3). Re-deriving these
+ * weights locally is how the two regimes would drift apart. Summed over
+ * neighbours, so the result never depends on their order.
+ */
+const neighborCostPx = (
+  a: IPoint,
+  b: IPoint,
+  neighborRoutes: readonly (readonly IPoint[])[],
+  crowdingClearancePx: number
+): number =>
+  polylineConflictCost([a, b], neighborRoutes, crowdingClearancePx).cost
 
 /** The MINIMUM clearance the returned route guarantees from every hard obstacle.
  * It is also the gate threshold: a straight chord clearing every hard obstacle by
  * this much is returned as-is. */
 const MIN_CLEARANCE_PX = EDGES.MIN_NODE_CLEARANCE_PX
 
-/** Small angle penalty per turn bucket. It is a pure tie-break: at a scale far
- * below `ROUTING_COST.edgeCrossing` (400) and small against real segment lengths,
- * it prefers straighter equal-length routes without ever buying a detour. */
-const ANGLE_PENALTY_PER_BUCKET = 4
+/**
+ * The routing objective, expressed entirely in pixels of travel so it composes with
+ * segment length and with the shared `ROUTING_COST` scale the orthogonal engine uses.
+ *
+ * `SCALE` is the fixed-point denominator for the cosine terms: every angular cost is
+ * `weight · (1 − cos θ) / SCALE`, computed from integer dot products and `isqrt`
+ * lengths, so no float/`atan2` ever reaches a decision.
+ */
+const SCALE = 1024
+
+/**
+ * Flat cost of HAVING a bend at all, independent of how gentle it is — the same
+ * `bendInGridCells` charge the orthogonal engine applies per corner. Without a floor,
+ * a graduated angle cost makes a staircase of tiny near-free bends cheaper than one
+ * honest corner, and the route acquires a shimmer of pointless kinks.
+ */
+const BEND_PENALTY_PX = ROUTING_COST.bendInGridCells * CANVAS.SNAP_TO_GRID_PX
+
+/** Additional cost scaled by how sharply the route turns. `(1 − cos)` keeps a gentle
+ * course correction cheap while a right-angle turn costs ~2 further bends and a
+ * hairpin twice that, so an obstacle detour reads as one smooth deviation. */
+const TURN_PENALTY_PX = 90
+
+/**
+ * Cost of leaving (or meeting) a node at anything other than a right angle to its
+ * side. A grazing departure that skims along the node's own edge is the single
+ * ugliest artefact a shortest-path router produces, so it is priced above a bend:
+ * the search would rather spend a corner, or attach on a different side, than slide
+ * out sideways. Running back INTO the node costs twice this.
+ */
+const ENDPOINT_ANGLE_PENALTY_PX = 150
+
+/** Band within which two parallel edges read as crowded. Uses the engine's own
+ * edge-to-edge value, NOT the node clearance: they answer different questions. */
+const EDGE_CROWDING_CLEARANCE_PX =
+  ROUTING_COST.parallelCrowdingClearanceInGridCells * CANVAS.SNAP_TO_GRID_PX
+
+/** Beyond this many graph vertices the directed-edge search is skipped in favour of
+ * the plain vertex search: the corridor window keeps real diagrams far below it, and
+ * the bound stops a pathological scene from spending quadratic state. */
+const MAX_DIRECTED_SEARCH_VERTICES = 176
 
 type Kind = 0 | 1 | 2 | 3
 const KIND_SOURCE: Kind = 0
@@ -278,7 +380,7 @@ const buildVertices = (
   target: IPoint,
   checkpoints: readonly IPoint[],
   hardObstacles: readonly StraightRouteObstacle[],
-  clearancePx: number
+  cornerPads: readonly number[]
 ): { vertices: Vertex[]; indexAt: (p: IPoint) => number } => {
   const raw: Vertex[] = [
     {
@@ -305,24 +407,37 @@ const buildVertices = (
       cornerIndex: i,
     })
   )
+  // Two rings of corner vertices per obstacle. The TIGHT ring (the blocking margin)
+  // keeps a narrow gap between two nodes usable — a single wide ring welds their
+  // padded corners together and closes it. The ROOMY ring gives a second, more
+  // generous turning point where there is space, so two sibling routes bending past
+  // the same node are not forced through one shared pinch point: the crowding term
+  // then separates them instead of stacking them.
+  const blocked = hardObstacles.map((o) => inflate(rectOf(o), MIN_CLEARANCE_PX))
   for (const o of hardObstacles) {
     if (o.soft) continue
-    const r = inflate(rectOf(o), clearancePx)
-    const corners: IPoint[] = [
-      { x: r.x, y: r.y },
-      { x: r.x + r.w, y: r.y },
-      { x: r.x + r.w, y: r.y + r.h },
-      { x: r.x, y: r.y + r.h },
-    ]
-    corners.forEach((p, ci) =>
-      raw.push({
-        x: p.x,
-        y: p.y,
-        kind: KIND_CORNER,
-        ownerId: o.id,
-        cornerIndex: ci,
+    for (const [ring, pad] of cornerPads.entries()) {
+      const r = inflate(rectOf(o), pad)
+      const corners: IPoint[] = [
+        { x: r.x, y: r.y },
+        { x: r.x + r.w, y: r.y },
+        { x: r.x + r.w, y: r.y + r.h },
+        { x: r.x, y: r.y + r.h },
+      ]
+      corners.forEach((p, ci) => {
+        // A roomier corner is only worth having where it is actually reachable.
+        // Keeping one that has drifted inside a NEIGHBOURING node is what welds two
+        // obstacles into one blob and closes the gap between them.
+        if (ring > 0 && blocked.some((b) => strictlyInside(b, p))) return
+        raw.push({
+          x: p.x,
+          y: p.y,
+          kind: KIND_CORNER,
+          ownerId: o.id,
+          cornerIndex: ring * 4 + ci,
+        })
       })
-    )
+    }
   }
 
   raw.sort(compareVertices)
@@ -372,7 +487,11 @@ const routeSubPath = (
   vertices: readonly Vertex[],
   startIndex: number,
   goalIndex: number,
-  blockRects: readonly IntRect[]
+  blockRects: readonly IntRect[],
+  neighborRoutes: readonly (readonly IPoint[])[],
+  crowdingClearancePx: number,
+  sourceNormal: IPoint | undefined,
+  targetNormal: IPoint | undefined
 ): IPoint[] => {
   const a: IPoint = { x: vertices[startIndex].x, y: vertices[startIndex].y }
   const b: IPoint = { x: vertices[goalIndex].x, y: vertices[goalIndex].y }
@@ -393,48 +512,93 @@ const routeSubPath = (
     adjacency.push(list)
   }
 
-  const gScore = new Array<number>(n).fill(Number.POSITIVE_INFINITY)
-  const cameFrom = new Array<number>(n).fill(-1)
-  const closed = new Array<boolean>(n).fill(false)
   const heuristic = (i: number): number => isqrt(distSqInt(vertices[i], goal))
 
+  // The search runs over DIRECTED EDGES, not vertices: the cost of arriving at a
+  // vertex depends on the direction you arrived from (that is what a turn penalty
+  // means), and the departure/arrival angles are properties of the first and last
+  // segment. A state is `from * n + to`, so the bend at `to` is exactly priced when
+  // the state is expanded. Vertex-keyed Dijkstra cannot express this without
+  // under-counting turns.
+  const stateCount = n * n
+  const stateG = new Float64Array(stateCount).fill(Number.POSITIVE_INFINITY)
+  const statePrev = new Int32Array(stateCount).fill(-1)
+  const stateClosed = new Uint8Array(stateCount)
   const heap = new MinHeap()
   let seq = 0
-  gScore[startIndex] = 0
-  heap.push(heuristic(startIndex), startIndex, seq++)
 
+  const segmentCost = (i: number, j: number): number =>
+    segLenInt(vertices[i], vertices[j]) +
+    neighborCostPx(
+      vertices[i],
+      vertices[j],
+      neighborRoutes,
+      crowdingClearancePx
+    )
+
+  for (const v of adjacency[startIndex]) {
+    const dir = {
+      x: vertices[v].x - vertices[startIndex].x,
+      y: vertices[v].y - vertices[startIndex].y,
+    }
+    let cost = segmentCost(startIndex, v)
+    if (sourceNormal)
+      cost += angleCostPx(dir, sourceNormal, ENDPOINT_ANGLE_PENALTY_PX)
+    if (v === goalIndex && targetNormal)
+      cost += angleCostPx(
+        { x: -dir.x, y: -dir.y },
+        targetNormal,
+        ENDPOINT_ANGLE_PENALTY_PX
+      )
+    const state = startIndex * n + v
+    if (cost < stateG[state]) {
+      stateG[state] = cost
+      heap.push(cost + heuristic(v), state, seq++)
+    }
+  }
+
+  let goalState = -1
   while (heap.size > 0) {
-    const u = heap.pop()
-    if (closed[u]) continue
-    closed[u] = true
-    if (u === goalIndex) break
-    const pred = cameFrom[u]
-    for (const v of adjacency[u]) {
-      if (closed[v]) continue
-      let turn = 0
-      if (pred >= 0) {
-        turn =
-          turnBucket(
-            vertices[u].x - vertices[pred].x,
-            vertices[u].y - vertices[pred].y,
-            vertices[v].x - vertices[u].x,
-            vertices[v].y - vertices[u].y
-          ) * ANGLE_PENALTY_PER_BUCKET
-      }
-      const tentative = gScore[u] + segLenInt(vertices[u], vertices[v]) + turn
-      if (tentative < gScore[v]) {
-        gScore[v] = tentative
-        cameFrom[v] = u
-        heap.push(tentative + heuristic(v), v, seq++)
+    const state = heap.pop()
+    if (stateClosed[state]) continue
+    stateClosed[state] = 1
+    const u = (state / n) | 0
+    const v = state % n
+    if (v === goalIndex) {
+      goalState = state
+      break
+    }
+    for (const w of adjacency[v]) {
+      if (w === u) continue
+      const next = v * n + w
+      if (stateClosed[next]) continue
+      let cost =
+        stateG[state] +
+        segmentCost(v, w) +
+        turnCostPx(vertices[u], vertices[v], vertices[w])
+      if (w === goalIndex && targetNormal)
+        cost += angleCostPx(
+          {
+            x: vertices[v].x - vertices[w].x,
+            y: vertices[v].y - vertices[w].y,
+          },
+          targetNormal,
+          ENDPOINT_ANGLE_PENALTY_PX
+        )
+      if (cost < stateG[next]) {
+        stateG[next] = cost
+        statePrev[next] = state
+        heap.push(cost + heuristic(w), next, seq++)
       }
     }
   }
 
-  if (!Number.isFinite(gScore[goalIndex])) return [a, b]
+  if (goalState < 0) return [a, b]
 
   const reversed: IPoint[] = []
-  for (let at = goalIndex; at !== -1; at = cameFrom[at])
-    reversed.push({ x: vertices[at].x, y: vertices[at].y })
+  for (let at = goalState; at !== -1; at = statePrev[at])
+    reversed.push({ x: vertices[at % n].x, y: vertices[at % n].y })
+  reversed.push(a)
   reversed.reverse()
   return reversed
 }
@@ -473,15 +637,7 @@ const routeObjective = (
   let angle = 0
   for (let i = 1; i < route.length; i++) {
     length += segLenInt(route[i - 1], route[i])
-    if (i >= 2) {
-      angle +=
-        turnBucket(
-          route[i - 1].x - route[i - 2].x,
-          route[i - 1].y - route[i - 2].y,
-          route[i].x - route[i - 1].x,
-          route[i].y - route[i - 1].y
-        ) * ANGLE_PENALTY_PER_BUCKET
-    }
+    if (i >= 2) angle += turnCostPx(route[i - 2], route[i - 1], route[i])
   }
   const conflict = polylineConflictCost(
     route,
@@ -489,6 +645,105 @@ const routeObjective = (
     crowdingClearancePx
   )
   return length + angle + conflict.cost
+}
+
+/** The complete objective for a finished route, in integer px: travel, every bend,
+ * both endpoint departure angles, and the shared neighbour-conflict cost. This is
+ * the same sum the search minimises, so simplification can be accepted only when it
+ * genuinely improves the drawing. */
+const totalRouteCostPx = (
+  route: readonly IPoint[],
+  neighborRoutes: readonly (readonly IPoint[])[],
+  crowdingClearancePx: number,
+  sourceNormal: IPoint | undefined,
+  targetNormal: IPoint | undefined
+): number => {
+  let cost = 0
+  for (let i = 1; i < route.length; i++) {
+    cost += segLenInt(route[i - 1], route[i])
+    cost += neighborCostPx(
+      route[i - 1],
+      route[i],
+      neighborRoutes,
+      crowdingClearancePx
+    )
+    if (i >= 2) cost += turnCostPx(route[i - 2], route[i - 1], route[i])
+  }
+  if (sourceNormal && route.length >= 2)
+    cost += angleCostPx(
+      { x: route[1].x - route[0].x, y: route[1].y - route[0].y },
+      sourceNormal,
+      ENDPOINT_ANGLE_PENALTY_PX
+    )
+  if (targetNormal && route.length >= 2) {
+    const last = route.length - 1
+    cost += angleCostPx(
+      {
+        x: route[last - 1].x - route[last].x,
+        y: route[last - 1].y - route[last].y,
+      },
+      targetNormal,
+      ENDPOINT_ANGLE_PENALTY_PX
+    )
+  }
+  return cost
+}
+
+/**
+ * String-pulling: drop any bend the route does not actually need. A visibility graph
+ * can only turn at obstacle corners, so it often rounds a corner it could have cut —
+ * leaving a small kink that reads as a mistake. Each interior point is removed only
+ * when the shortcut still clears every obstacle AND strictly lowers the complete
+ * objective, so this can never trade clearance or a good exit angle for fewer bends.
+ * Deterministic: a single left-to-right sweep, repeated until nothing changes.
+ */
+const simplifyRoute = (
+  route: readonly IPoint[],
+  blockRects: readonly IntRect[],
+  neighborRoutes: readonly (readonly IPoint[])[],
+  crowdingClearancePx: number,
+  sourceNormal: IPoint | undefined,
+  targetNormal: IPoint | undefined
+): IPoint[] => {
+  let best = [...route]
+  let bestCost = totalRouteCostPx(
+    best,
+    neighborRoutes,
+    crowdingClearancePx,
+    sourceNormal,
+    targetNormal
+  )
+  for (let pass = 0; pass < 4; pass++) {
+    let improved = false
+    for (let i = 1; i < best.length - 1; i++) {
+      const candidate = [...best.slice(0, i), ...best.slice(i + 1)]
+      const a = candidate[i - 1]
+      const b = candidate[i]
+      const isEndA = i - 1 === 0
+      const isEndB = i === candidate.length - 1
+      const blocked = blockRects.some((r) => {
+        if (isEndA && inclusiveContains(r, a)) return false
+        if (isEndB && inclusiveContains(r, b)) return false
+        return segmentIntersectsRectInterior(a, b, r)
+      })
+      if (blocked) continue
+      const cost = totalRouteCostPx(
+        candidate,
+        neighborRoutes,
+        crowdingClearancePx,
+        sourceNormal,
+        targetNormal
+      )
+      if (cost < bestCost) {
+        best = candidate
+        bestCost = cost
+        improved = true
+        i--
+      }
+    }
+    if (!improved) break
+  }
+  return best
 }
 
 /** Lexicographic order on two polylines; the deterministic final tie-break when
@@ -516,6 +771,8 @@ export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
     obstacles,
     neighborRoutes,
     clearancePx,
+    sourceNormal,
+    targetNormal,
   } = req
   const hardObstacles = obstacles.filter((o) => !o.soft)
   const anchors: IPoint[] = [source, ...checkpoints, target]
@@ -533,39 +790,63 @@ export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
   if (straightClears) return collapseCollinear(anchors)
 
   // 2. Visibility graph over endpoints, checkpoints and inflated hard corners.
+  //    Corners are inflated by the SAME margin the visibility test blocks at. A
+  //    wider corner pad silently welds neighbouring obstacles together — their
+  //    padded corners land inside each other — which closes legitimate gaps between
+  //    two nodes and forces a long detour around the whole group.
   const { vertices, indexAt } = buildVertices(
     source,
     target,
     checkpoints,
     hardObstacles,
-    clearancePx
+    [MIN_CLEARANCE_PX, clearancePx]
   )
   const blockRects = hardObstacles.map((o) =>
     inflate(rectOf(o), MIN_CLEARANCE_PX)
   )
-
-  // 3. Route each checkpoint sub-chord independently and concatenate.
+  // 3. Route each checkpoint sub-chord independently and concatenate. Only the
+  //    first sub-chord departs the source node and only the last meets the target,
+  //    so the endpoint-angle terms apply to those alone.
   const combined: IPoint[] = []
   for (let k = 1; k < anchors.length; k++) {
     const startIndex = indexAt(anchors[k - 1])
     const goalIndex = indexAt(anchors[k])
     const sub =
-      startIndex < 0 || goalIndex < 0
+      startIndex < 0 ||
+      goalIndex < 0 ||
+      vertices.length > MAX_DIRECTED_SEARCH_VERTICES
         ? [anchors[k - 1], anchors[k]]
-        : routeSubPath(vertices, startIndex, goalIndex, blockRects)
+        : routeSubPath(
+            vertices,
+            startIndex,
+            goalIndex,
+            blockRects,
+            neighborRoutes,
+            EDGE_CROWDING_CLEARANCE_PX,
+            k === 1 ? sourceNormal : undefined,
+            k === anchors.length - 1 ? targetNormal : undefined
+          )
     if (combined.length === 0) combined.push(...sub)
     else combined.push(...sub.slice(1))
   }
 
-  // 4. Collapse collinear points; verify the single candidate under the full
-  //    objective (a deterministic, neighbour-order-independent scaffold that keeps
-  //    the door open for alternative candidates without changing today's output).
-  const candidate = collapseCollinear(combined)
-  const candidates = [candidate]
+  // 4. Collapse collinear points, then string-pull away any bend the route does not
+  //    need. Ranking stays deterministic and neighbour-order independent.
+  const candidates = [
+    simplifyRoute(
+      collapseCollinear(combined),
+      blockRects,
+      neighborRoutes,
+      EDGE_CROWDING_CLEARANCE_PX,
+      sourceNormal,
+      targetNormal
+    ),
+  ]
   candidates.sort(
     (a, b) =>
-      routeObjective(a, neighborRoutes, clearancePx) -
-        routeObjective(b, neighborRoutes, clearancePx) || compareRoutes(a, b)
+      routeObjective(a, neighborRoutes, EDGE_CROWDING_CLEARANCE_PX) -
+        routeObjective(b, neighborRoutes, EDGE_CROWDING_CLEARANCE_PX) ||
+      compareRoutes(a, b)
   )
-  return candidates[0]
+  return collapseCollinear(candidates[0])
 }

--- a/library/lib/utils/tidyTree/applyTidyLayout.ts
+++ b/library/lib/utils/tidyTree/applyTidyLayout.ts
@@ -1,0 +1,123 @@
+import type { Node, Edge, XYPosition } from "@xyflow/react"
+import { getPositionOnCanvas } from "@/utils/nodeUtils"
+import { buildSyntaxTreeForest, type Forest } from "./buildForest"
+import {
+  layoutTidyTree,
+  type TidyNodeInput,
+  type TidyOptions,
+} from "./tidyTree"
+
+export type { TidyOptions } from "./tidyTree"
+export type { Forest } from "./buildForest"
+
+/** Fallback footprint for a syntax-tree node with no measured or declared size. */
+const FALLBACK_WIDTH = 90
+const FALLBACK_HEIGHT = 40
+
+/** Sensible defaults; `gridSnap` mirrors `CANVAS.SNAP_TO_GRID_PX`. */
+export const DEFAULT_TIDY_OPTIONS: TidyOptions = {
+  siblingGap: 30,
+  subtreeGap: 20,
+  levelGap: 60,
+  gridSnap: 5,
+}
+
+const measuredWidth = (node: Node): number =>
+  node.measured?.width ?? node.width ?? FALLBACK_WIDTH
+
+const measuredHeight = (node: Node): number =>
+  node.measured?.height ?? node.height ?? FALLBACK_HEIGHT
+
+/**
+ * Tidy the syntax-tree forest inside `nodes`, leaving every other node untouched.
+ *
+ * Returns a NEW nodes array of the same length and id set. Only nodes the layout
+ * actually moves are replaced with a fresh object (new `position`); every other
+ * node — non-syntax nodes, skipped malformed nodes, and already-tidy nodes — is
+ * returned BY REFERENCE. Each clean component is translated so its root keeps its
+ * current on-canvas position, so a tidy pass never makes the tree jump on screen
+ * and re-running it on an already-tidy tree is idempotent.
+ */
+export function computeTidyLayout(
+  nodes: Node[],
+  edges: Edge[],
+  opts: Partial<TidyOptions> = {}
+): Node[] {
+  const options: TidyOptions = { ...DEFAULT_TIDY_OPTIONS, ...opts }
+  const forest: Forest = buildSyntaxTreeForest(nodes, edges)
+  if (forest.laidOut.size === 0) return nodes
+
+  const nodeById = new Map<string, Node>()
+  for (const node of nodes) nodeById.set(node.id, node)
+
+  // Feed real per-node footprints into the layout so long labels push siblings
+  // apart. Child order comes straight from the forest (already deterministic).
+  const inputById = new Map<string, TidyNodeInput>()
+  for (const id of forest.laidOut) {
+    const node = nodeById.get(id)
+    if (!node) continue
+    inputById.set(id, {
+      id,
+      width: measuredWidth(node),
+      height: measuredHeight(node),
+      childIds: forest.childIds.get(id) ?? [],
+    })
+  }
+
+  const layout = layoutTidyTree(forest.roots, inputById, options)
+
+  // Absolute on-canvas position each laid-out node should end up at: translate
+  // every component so its root stays exactly where it is now.
+  const targetCanvas = new Map<string, XYPosition>()
+  for (const rootId of forest.roots) {
+    const rootNode = nodeById.get(rootId)
+    const rootLayout = layout.get(rootId)
+    if (!rootNode || !rootLayout) continue
+    const rootCanvas = getPositionOnCanvas(rootNode, nodes)
+    const deltaX = rootCanvas.x - rootLayout.x
+    const deltaY = rootCanvas.y - rootLayout.y
+
+    // Walk the component from its root so each node inherits the same delta.
+    const stack = [rootId]
+    const visited = new Set<string>()
+    while (stack.length) {
+      const id = stack.pop()!
+      if (visited.has(id)) continue
+      visited.add(id)
+      const nodeLayout = layout.get(id)
+      if (nodeLayout) {
+        targetCanvas.set(id, {
+          x: nodeLayout.x + deltaX,
+          y: nodeLayout.y + deltaY,
+        })
+      }
+      for (const child of forest.childIds.get(id) ?? []) stack.push(child)
+    }
+  }
+
+  return nodes.map((node) => {
+    const canvasTarget = targetCanvas.get(node.id)
+    if (!canvasTarget) return node
+
+    // Convert the absolute canvas target back into a position relative to the
+    // node's container (parentId), mirroring usePalettePlacement's nesting math.
+    // The container is never a laid-out syntax node, so its canvas position is
+    // read from the untouched input graph.
+    let position: XYPosition = canvasTarget
+    if (node.parentId) {
+      const parent = nodeById.get(node.parentId)
+      if (parent) {
+        const parentCanvas = getPositionOnCanvas(parent, nodes)
+        position = {
+          x: canvasTarget.x - parentCanvas.x,
+          y: canvasTarget.y - parentCanvas.y,
+        }
+      }
+    }
+
+    if (position.x === node.position.x && position.y === node.position.y) {
+      return node
+    }
+    return { ...node, position }
+  })
+}

--- a/library/lib/utils/tidyTree/buildForest.ts
+++ b/library/lib/utils/tidyTree/buildForest.ts
@@ -1,0 +1,244 @@
+import type { Node, Edge } from "@xyflow/react"
+import { getPositionOnCanvas } from "@/utils/nodeUtils"
+
+/**
+ * Reconstruct the clean syntax-tree forest from a freeform React Flow graph.
+ *
+ * The editor lets users draw whatever they like, so the input can be malformed:
+ * a node may have several parents, edges may form cycles, and links may cross
+ * container boundaries. This module contains that mess — it never corrupts the
+ * graph. Anything it cannot lay out as a clean rooted tree is reported in
+ * `skipped` and MUST keep its exact current position; everything else lands in
+ * `laidOut` with an ordered child list ready for `layoutTidyTree`.
+ */
+
+/** Node types that participate in a syntax tree (see `library/lib/constants.ts`). */
+const SYNTAX_TREE_NODE_TYPES: ReadonlySet<string> = new Set([
+  "syntaxTreeNonterminal",
+  "syntaxTreeTerminal",
+])
+
+/** Edge type connecting syntax-tree nodes (see `library/lib/edges/types.tsx`). */
+const SYNTAX_TREE_EDGE_TYPE = "SyntaxTreeLink"
+
+export interface Forest {
+  /** Root ids (indegree-0, clean) of each independently laid-out component. */
+  roots: string[]
+  /** Ordered clean children per laid-out node (parent → child ids). */
+  childIds: Map<string, string[]>
+  /** Nodes the tidy layout will place. */
+  laidOut: Set<string>
+  /** Malformed nodes that must keep their exact current position. */
+  skipped: Set<string>
+}
+
+const isSyntaxTreeNode = (node: Node): boolean =>
+  !!node.type && SYNTAX_TREE_NODE_TYPES.has(node.type)
+
+/** Container-nesting depth: how many `parentId` hops reach a top-level node. */
+const containerDepth = (node: Node, nodeById: Map<string, Node>): number => {
+  let depth = 0
+  let current: Node | undefined = node
+  const guard = new Set<string>()
+  while (current?.parentId && !guard.has(current.id)) {
+    guard.add(current.id)
+    depth++
+    current = nodeById.get(current.parentId)
+  }
+  return depth
+}
+
+export function buildSyntaxTreeForest(nodes: Node[], edges: Edge[]): Forest {
+  const nodeById = new Map<string, Node>()
+  for (const node of nodes) nodeById.set(node.id, node)
+
+  const syntaxNodes = nodes.filter(isSyntaxTreeNode)
+  const syntaxIds = new Set(syntaxNodes.map((node) => node.id))
+
+  // Absolute canvas x per syntax node — the child ordering key, and the
+  // tie-break within cross-container links.
+  const canvasX = new Map<string, number>()
+  for (const node of syntaxNodes) {
+    canvasX.set(node.id, getPositionOnCanvas(node, nodes).x)
+  }
+
+  const skipped = new Set<string>()
+  const childIds = new Map<string, string[]>()
+  const indegree = new Map<string, number>()
+  for (const id of syntaxIds) {
+    childIds.set(id, [])
+    indegree.set(id, 0)
+  }
+
+  // Pass 1: keep only syntax-tree links between two syntax-tree nodes. A link
+  // that crosses a container boundary is dropped and its deeper endpoint marked
+  // skipped, so container scopes never merge into one tree.
+  for (const edge of edges) {
+    if (edge.type !== SYNTAX_TREE_EDGE_TYPE) continue
+    const parentId = edge.source
+    const childId = edge.target
+    if (!syntaxIds.has(parentId) || !syntaxIds.has(childId)) continue
+    if (parentId === childId) {
+      // A self-link is a degenerate cycle — the node cannot be a clean tree.
+      skipped.add(parentId)
+      continue
+    }
+
+    const parentNode = nodeById.get(parentId)!
+    const childNode = nodeById.get(childId)!
+    if (
+      (parentNode.parentId ?? undefined) !== (childNode.parentId ?? undefined)
+    ) {
+      const deeperIsChild =
+        containerDepth(childNode, nodeById) >=
+        containerDepth(parentNode, nodeById)
+      skipped.add(deeperIsChild ? childId : parentId)
+      continue
+    }
+
+    childIds.get(parentId)!.push(childId)
+    indegree.set(childId, (indegree.get(childId) ?? 0) + 1)
+  }
+
+  // Order every parent's children by current absolute x, then id — the fixed,
+  // deterministic order the tidy layout consumes.
+  for (const [parentId, children] of childIds) {
+    children.sort((a, b) => {
+      const dx = (canvasX.get(a) ?? 0) - (canvasX.get(b) ?? 0)
+      return dx !== 0 ? dx : a < b ? -1 : a > b ? 1 : 0
+    })
+    childIds.set(parentId, children)
+  }
+
+  // Pass 2: any node with two or more parents cannot sit in a single tree.
+  // Mark it and its whole descendant subtree skipped.
+  const skipSubtree = (rootId: string): void => {
+    const stack = [rootId]
+    while (stack.length) {
+      const id = stack.pop()!
+      if (skipped.has(id)) continue
+      skipped.add(id)
+      for (const child of childIds.get(id) ?? []) stack.push(child)
+    }
+  }
+  for (const id of syntaxIds) {
+    if ((indegree.get(id) ?? 0) >= 2) skipSubtree(id)
+  }
+
+  // Pass 3: skip every node on a directed cycle (Tarjan strongly-connected
+  // components of size > 1). Self-links were already handled above.
+  for (const id of tarjanCyclicNodes(syntaxIds, childIds)) skipped.add(id)
+
+  // Roots are the clean indegree-0 nodes. Build each component top-down, never
+  // descending into a skipped node and never visiting a node twice.
+  const laidOut = new Set<string>()
+  const roots: string[] = []
+  const cleanChildIds = new Map<string, string[]>()
+
+  const collect = (rootId: string): void => {
+    const stack = [rootId]
+    while (stack.length) {
+      const id = stack.pop()!
+      if (laidOut.has(id) || skipped.has(id)) continue
+      laidOut.add(id)
+      const children = (childIds.get(id) ?? []).filter(
+        (child) => !skipped.has(child)
+      )
+      cleanChildIds.set(id, children)
+      for (const child of children) stack.push(child)
+    }
+  }
+
+  const rootCandidates = [...syntaxIds]
+    .filter((id) => !skipped.has(id) && (indegree.get(id) ?? 0) === 0)
+    .sort((a, b) => {
+      const dx = (canvasX.get(a) ?? 0) - (canvasX.get(b) ?? 0)
+      return dx !== 0 ? dx : a < b ? -1 : a > b ? 1 : 0
+    })
+  for (const id of rootCandidates) {
+    if (laidOut.has(id) || skipped.has(id)) continue
+    roots.push(id)
+    collect(id)
+  }
+
+  // Any clean child list must be pruned to the nodes that survived collection.
+  for (const [id, children] of cleanChildIds) {
+    cleanChildIds.set(
+      id,
+      children.filter((child) => laidOut.has(child))
+    )
+  }
+
+  return { roots, childIds: cleanChildIds, laidOut, skipped }
+}
+
+/**
+ * Ids that belong to a strongly-connected component of size > 1 in the
+ * `parent → child` graph — i.e. every node caught on a directed cycle.
+ * Iterative Tarjan so deep chains cannot overflow the stack.
+ */
+function tarjanCyclicNodes(
+  ids: ReadonlySet<string>,
+  childIds: ReadonlyMap<string, string[]>
+): Set<string> {
+  const index = new Map<string, number>()
+  const lowlink = new Map<string, number>()
+  const onStack = new Set<string>()
+  const stack: string[] = []
+  const cyclic = new Set<string>()
+  let counter = 0
+
+  type Frame = { id: string; childIndex: number }
+
+  for (const start of ids) {
+    if (index.has(start)) continue
+    const frames: Frame[] = [{ id: start, childIndex: 0 }]
+    index.set(start, counter)
+    lowlink.set(start, counter)
+    counter++
+    stack.push(start)
+    onStack.add(start)
+
+    while (frames.length) {
+      const frame = frames[frames.length - 1]
+      const children = childIds.get(frame.id) ?? []
+      if (frame.childIndex < children.length) {
+        const child = children[frame.childIndex]
+        frame.childIndex++
+        if (!index.has(child)) {
+          index.set(child, counter)
+          lowlink.set(child, counter)
+          counter++
+          stack.push(child)
+          onStack.add(child)
+          frames.push({ id: child, childIndex: 0 })
+        } else if (onStack.has(child)) {
+          lowlink.set(
+            frame.id,
+            Math.min(lowlink.get(frame.id)!, index.get(child)!)
+          )
+        }
+      } else {
+        if (lowlink.get(frame.id) === index.get(frame.id)) {
+          const component: string[] = []
+          let popped: string
+          do {
+            popped = stack.pop()!
+            onStack.delete(popped)
+            component.push(popped)
+          } while (popped !== frame.id)
+          if (component.length > 1) for (const id of component) cyclic.add(id)
+        }
+        frames.pop()
+        if (frames.length) {
+          const parent = frames[frames.length - 1]
+          lowlink.set(
+            parent.id,
+            Math.min(lowlink.get(parent.id)!, lowlink.get(frame.id)!)
+          )
+        }
+      }
+    }
+  }
+  return cyclic
+}

--- a/library/lib/utils/tidyTree/index.ts
+++ b/library/lib/utils/tidyTree/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Self-contained syntax-tree tidy-layout module.
+ *
+ * Public entry point is `computeTidyLayout`; the tidy-tree core and the forest
+ * reconstruction are exported for direct testing and advanced callers.
+ */
+export {
+  computeTidyLayout,
+  DEFAULT_TIDY_OPTIONS,
+  type TidyOptions,
+  type Forest,
+} from "./applyTidyLayout"
+export {
+  layoutTidyTree,
+  type TidyNodeInput,
+  type TidyPosition,
+} from "./tidyTree"
+export { buildSyntaxTreeForest } from "./buildForest"

--- a/library/lib/utils/tidyTree/tidyTree.ts
+++ b/library/lib/utils/tidyTree/tidyTree.ts
@@ -1,0 +1,315 @@
+/**
+ * Buchheim–Jünger–Leipert linear-time tidy tree.
+ *
+ * A hand-written implementation of the layout described in:
+ *
+ *   Christoph Buchheim, Michael Jünger, Sebastian Leipert,
+ *   "Improving Walker's Algorithm to Run in Linear Time" (Graph Drawing 2002),
+ *
+ * which itself improves
+ *
+ *   John Q. Walker II, "A Node-Positioning Algorithm for General Trees" (1990),
+ *
+ * the n-ary generalisation of
+ *
+ *   Edward M. Reingold, John S. Tilford,
+ *   "Tidier Drawings of Trees" (IEEE TSE 1981).
+ *
+ * The two-pass structure (`firstWalk` computing preliminary x offsets and per-node
+ * modifiers, `secondWalk` summing modifiers into absolute centres) with contour
+ * threading (`thread`, `leftMost`/`rightMost` via `nextLeft`/`nextRight`), the
+ * `ancestor` shortcut and the `shift`/`change` amortisation is exactly the BJL
+ * scheme; `apportion` runs each contour pair once, giving overall linear time.
+ *
+ * This variant is n-ary and supports **variable node widths**: the minimum
+ * horizontal separation between two adjacent subtrees at the same level is
+ *
+ *     half(width[left]) + siblingGap + half(width[right])   (+ subtreeGap
+ *                                                            for distinct subtrees)
+ *
+ * fed straight into the apportion distance, so a long label pushes its siblings
+ * apart instead of overlapping them. Vertical placement gives each depth a single
+ * y equal to the cumulative maximum row height of the shallower levels plus
+ * `levelGap`. The final absolute top-left coordinates are grid-snapped and the
+ * whole layout is normalised so its minimum x and y are 0. The result is fully
+ * deterministic: child order is fixed by the caller.
+ */
+
+export interface TidyOptions {
+  /** Min horizontal clearance between adjacent sibling subtrees (px). */
+  siblingGap: number
+  /** Extra gap inserted between distinct sibling subtrees (px). */
+  subtreeGap: number
+  /** Vertical gap between depth levels (px). */
+  levelGap: number
+  /** Grid the final absolute coordinates snap to (px). */
+  gridSnap: number
+}
+
+export interface TidyNodeInput {
+  id: string
+  width: number
+  height: number
+  childIds: string[]
+}
+
+export interface TidyPosition {
+  x: number
+  y: number
+}
+
+/**
+ * A mutable working node for the two-pass walk. All coordinate fields live in a
+ * centre-x space until `secondWalk`; `x` then holds the absolute centre.
+ */
+interface WorkNode {
+  id: string
+  width: number
+  height: number
+  depth: number
+  parent: WorkNode | null
+  children: WorkNode[]
+  /** 1-based index among siblings — divisor in the shift smoothing. */
+  number: number
+  ancestor: WorkNode
+  thread: WorkNode | null
+  prelim: number
+  mod: number
+  change: number
+  shift: number
+  /** Absolute centre-x, filled by `secondWalk`. */
+  x: number
+}
+
+const half = (value: number): number => value / 2
+
+const snapToGrid = (value: number, grid: number): number =>
+  grid > 0 ? Math.round(value / grid) * grid : Math.round(value)
+
+/**
+ * Layout a forest of tidy trees. `roots` gives the root id of each independent
+ * component; `nodesById` supplies width/height and the (already ordered) child
+ * ids for every node reachable from those roots. Returns absolute top-left
+ * positions normalised so the whole forest's minimum x and y are 0.
+ *
+ * Anchoring a component to its current on-canvas position is the caller's job —
+ * here every component is laid out in one shared, normalised coordinate space.
+ */
+export function layoutTidyTree(
+  roots: string[],
+  nodesById: Map<string, TidyNodeInput>,
+  opts: TidyOptions
+): Map<string, TidyPosition> {
+  const built: WorkNode[] = []
+  const seen = new Set<string>()
+
+  const build = (
+    id: string,
+    parent: WorkNode | null,
+    depth: number,
+    number: number
+  ): WorkNode | null => {
+    const input = nodesById.get(id)
+    if (!input) return null
+    // A node can be reached only once in a clean forest; the guard keeps a
+    // malformed input from looping and keeps the walk deterministic.
+    if (seen.has(id)) return null
+    seen.add(id)
+
+    const node: WorkNode = {
+      id,
+      width: input.width,
+      height: input.height,
+      depth,
+      parent,
+      children: [],
+      number,
+      ancestor: null as unknown as WorkNode,
+      thread: null,
+      prelim: 0,
+      mod: 0,
+      change: 0,
+      shift: 0,
+      x: 0,
+    }
+    node.ancestor = node
+    built.push(node)
+
+    let childNumber = 1
+    for (const childId of input.childIds) {
+      const child = build(childId, node, depth + 1, childNumber)
+      if (child) {
+        node.children.push(child)
+        childNumber++
+      }
+    }
+    return node
+  }
+
+  const rootNodes: WorkNode[] = []
+  for (const rootId of roots) {
+    const root = build(rootId, null, 0, 1)
+    if (root) rootNodes.push(root)
+  }
+
+  // Vertical: one y per depth, from the cumulative max row height of shallower
+  // levels. Computed across the whole forest so equal depths stay aligned.
+  const rowHeight: number[] = []
+  for (const node of built) {
+    rowHeight[node.depth] = Math.max(rowHeight[node.depth] ?? 0, node.height)
+  }
+  const depthTop: number[] = []
+  let cumulative = 0
+  for (let depth = 0; depth < rowHeight.length; depth++) {
+    depthTop[depth] = cumulative
+    cumulative += (rowHeight[depth] ?? 0) + opts.levelGap
+  }
+
+  const separation = (left: WorkNode, right: WorkNode): number => {
+    const base = half(left.width) + half(right.width) + opts.siblingGap
+    return left.parent === right.parent ? base : base + opts.subtreeGap
+  }
+
+  const nextLeft = (node: WorkNode): WorkNode | null =>
+    node.children.length ? node.children[0] : node.thread
+
+  const nextRight = (node: WorkNode): WorkNode | null =>
+    node.children.length ? node.children[node.children.length - 1] : node.thread
+
+  const nextAncestor = (
+    vim: WorkNode,
+    v: WorkNode,
+    defaultAncestor: WorkNode
+  ): WorkNode =>
+    vim.ancestor.parent === v.parent ? vim.ancestor : defaultAncestor
+
+  const moveSubtree = (wm: WorkNode, wp: WorkNode, shift: number): void => {
+    const subtrees = wp.number - wm.number
+    const change = shift / subtrees
+    wp.change -= change
+    wp.shift += shift
+    wm.change += change
+    wp.prelim += shift
+    wp.mod += shift
+  }
+
+  const executeShifts = (v: WorkNode): void => {
+    let shift = 0
+    let change = 0
+    for (let i = v.children.length - 1; i >= 0; i--) {
+      const w = v.children[i]
+      w.prelim += shift
+      w.mod += shift
+      change += w.change
+      shift += w.shift + change
+    }
+  }
+
+  const previousSibling = (v: WorkNode): WorkNode | null => {
+    if (!v.parent) return null
+    const index = v.number - 2 // number is 1-based; left sibling is number-1
+    return index >= 0 ? v.parent.children[index] : null
+  }
+
+  const apportion = (v: WorkNode, defaultAncestor: WorkNode): WorkNode => {
+    const w = previousSibling(v)
+    if (!w) return defaultAncestor
+
+    let vip: WorkNode | null = v
+    let vop: WorkNode | null = v
+    let vim: WorkNode | null = w
+    let vom: WorkNode | null = v.parent!.children[0]
+    let sip = vip.mod
+    let sop = vop.mod
+    let sim = vim.mod
+    let som = vom.mod
+
+    vim = nextRight(vim)
+    vip = nextLeft(vip)
+    while (vim && vip) {
+      vom = nextLeft(vom!)
+      vop = nextRight(vop!)
+      vop!.ancestor = v
+      const shift = vim.prelim + sim - (vip.prelim + sip) + separation(vim, vip)
+      if (shift > 0) {
+        moveSubtree(nextAncestor(vim, v, defaultAncestor), v, shift)
+        sip += shift
+        sop += shift
+      }
+      sim += vim.mod
+      sip += vip.mod
+      som += vom!.mod
+      sop += vop!.mod
+
+      vim = nextRight(vim)
+      vip = nextLeft(vip)
+    }
+
+    if (vim && !nextRight(vop!)) {
+      vop!.thread = vim
+      vop!.mod += sim - sop
+    }
+    if (vip && !nextLeft(vom!)) {
+      vom!.thread = vip
+      vom!.mod += sip - som
+      defaultAncestor = v
+    }
+    return defaultAncestor
+  }
+
+  const firstWalk = (v: WorkNode): void => {
+    const w = previousSibling(v)
+    if (v.children.length === 0) {
+      v.prelim = w ? w.prelim + separation(v, w) : 0
+      return
+    }
+    let defaultAncestor = v.children[0]
+    for (const child of v.children) {
+      firstWalk(child)
+      defaultAncestor = apportion(child, defaultAncestor)
+    }
+    executeShifts(v)
+    const midpoint = half(
+      v.children[0].prelim + v.children[v.children.length - 1].prelim
+    )
+    if (w) {
+      v.prelim = w.prelim + separation(v, w)
+      v.mod = v.prelim - midpoint
+    } else {
+      v.prelim = midpoint
+    }
+  }
+
+  const secondWalk = (v: WorkNode, modSum: number): void => {
+    v.x = v.prelim + modSum
+    for (const child of v.children) secondWalk(child, modSum + v.mod)
+  }
+
+  for (const root of rootNodes) {
+    firstWalk(root)
+    secondWalk(root, 0)
+  }
+
+  // Convert centre-x + depth into top-left coordinates, then normalise the whole
+  // forest so its minimum x and y are 0 before grid-snapping. Snapping a common
+  // translation of every node preserves the separation invariant exactly when
+  // widths and gaps are grid multiples.
+  let minX = Number.POSITIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  for (const node of built) {
+    const left = node.x - half(node.width)
+    if (left < minX) minX = left
+    if (depthTop[node.depth] < minY) minY = depthTop[node.depth]
+  }
+  if (!Number.isFinite(minX)) minX = 0
+  if (!Number.isFinite(minY)) minY = 0
+
+  const positions = new Map<string, TidyPosition>()
+  for (const node of built) {
+    positions.set(node.id, {
+      x: snapToGrid(node.x - half(node.width) - minX, opts.gridSnap),
+      y: snapToGrid(depthTop[node.depth] - minY, opts.gridSnap),
+    })
+  }
+  return positions
+}

--- a/library/lib/utils/versionConverter.ts
+++ b/library/lib/utils/versionConverter.ts
@@ -5,6 +5,7 @@
  * isn't in scope here. */
 import type { UMLModel, ApollonNode, ApollonEdge, Assessment } from "../typings"
 import { transformEdges } from "../services/migration/EdgeTransformer"
+import { STRAIGHT_HOOK_EDGE_TYPES } from "../edges/edgeRoutingBehavior"
 import { UMLDiagramType } from "../types/DiagramType"
 import { ClassStereotype } from "../types/nodes/enums"
 import type { IPoint } from "../edges/Connection"
@@ -744,6 +745,13 @@ function convertV3RelationshipToV4Edge(
       x: point.x + relationship.bounds.x,
       y: point.y + relationship.bounds.y,
     }))
+  }
+  // Straight-hook edges (use-case, syntax-tree, petri-net) render as diagonal lines
+  // through INTERIOR waypoints only. The legacy v3 `path` is the full rendered
+  // polyline including endpoints and was inert for these types, so importing it as
+  // waypoints would sprout spurious (double-endpoint) bends. Clear it.
+  if (STRAIGHT_HOOK_EDGE_TYPES.has(edgeType as string)) {
+    points = []
   }
 
   const edge: ApollonEdge = {

--- a/library/package.json
+++ b/library/package.json
@@ -80,7 +80,7 @@
     {
       "name": "main entry (published JS, deps externalized)",
       "path": "dist/index.js",
-      "limit": "118 kB",
+      "limit": "126 kB",
       "disablePlugins": [
         "@size-limit/webpack",
         "@size-limit/time"
@@ -89,7 +89,7 @@
     {
       "name": "edge-routing Worker (loaded for large diagrams)",
       "path": "dist/assets/edgeGeometry.worker-*.js",
-      "limit": "40 kB",
+      "limit": "44 kB",
       "disablePlugins": [
         "@size-limit/webpack",
         "@size-limit/time"

--- a/library/tests/unit/freeWaypoints.test.ts
+++ b/library/tests/unit/freeWaypoints.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest"
+import {
+  exceedsDragThreshold,
+  getSegmentGhostHandles,
+  insertWaypoint,
+  moveWaypoint,
+  pruneCollinearWaypoints,
+  removeWaypoint,
+  snapPoint,
+} from "@/utils/geometry/freeWaypoints"
+import { EDGES } from "@/utils/geometry/routingConstants"
+
+const p = (x: number, y: number) => ({ x, y })
+
+describe("freeWaypoints", () => {
+  describe("snapPoint", () => {
+    it("snaps to the bend grid", () => {
+      expect(snapPoint(p(11, 3), 5)).toEqual(p(10, 5))
+      expect(snapPoint(p(13, 7), 5)).toEqual(p(15, 5))
+    })
+    it("defaults to the configured grid and is deterministic", () => {
+      expect(snapPoint(p(2, 2))).toEqual(snapPoint(p(2, 2)))
+    })
+  })
+
+  describe("getSegmentGhostHandles", () => {
+    it("returns one integer midpoint per long-enough segment", () => {
+      const route = [p(0, 0), p(100, 0), p(100, 100)]
+      const ghosts = getSegmentGhostHandles(route)
+      expect(ghosts.map((g) => g.segmentIndex)).toEqual([0, 1])
+      expect(ghosts[0].position).toEqual(p(50, 0))
+      expect(ghosts[1].position).toEqual(p(100, 50))
+    })
+    it("skips segments shorter than the min length so handles never fuse", () => {
+      const short = EDGES.WAYPOINT_GHOST_MIN_SEGMENT_PX - 1
+      const route = [p(0, 0), p(short, 0), p(short + 100, 0)]
+      const ghosts = getSegmentGhostHandles(route)
+      expect(ghosts.map((g) => g.segmentIndex)).toEqual([1])
+    })
+  })
+
+  describe("insert/move/remove", () => {
+    it("inserts on segment i at interior index i", () => {
+      // route = [source, target]; segment 0 → interior index 0
+      expect(insertWaypoint([], 0, p(51, 49))).toEqual([p(50, 50)])
+      // route = [source, w0, target]; last segment index 1 → append
+      expect(insertWaypoint([p(50, 50)], 1, p(80, 20))).toEqual([
+        p(50, 50),
+        p(80, 20),
+      ])
+      // route = [source, w0, target]; segment 0 → before w0
+      expect(insertWaypoint([p(50, 50)], 0, p(20, 20))).toEqual([
+        p(20, 20),
+        p(50, 50),
+      ])
+    })
+    it("moves and snaps a waypoint, no-op out of range", () => {
+      expect(moveWaypoint([p(0, 0), p(50, 50)], 1, p(72, 68))).toEqual([
+        p(0, 0),
+        p(70, 70),
+      ])
+      expect(moveWaypoint([p(0, 0)], 5, p(1, 1))).toEqual([p(0, 0)])
+    })
+    it("removes a waypoint by index", () => {
+      expect(removeWaypoint([p(0, 0), p(1, 1), p(2, 2)], 1)).toEqual([
+        p(0, 0),
+        p(2, 2),
+      ])
+    })
+  })
+
+  describe("pruneCollinearWaypoints", () => {
+    it("drops a near-collinear interior point but keeps a genuine bend", () => {
+      const source = p(0, 0)
+      const target = p(100, 0)
+      // Exactly on the line → pruned.
+      expect(pruneCollinearWaypoints([source, p(50, 0), target])).toEqual([])
+      // Within tolerance → pruned.
+      expect(pruneCollinearWaypoints([source, p(50, 2), target])).toEqual([])
+      // A real bend survives.
+      expect(pruneCollinearWaypoints([source, p(50, 40), target])).toEqual([
+        p(50, 40),
+      ])
+    })
+    it("prunes a collinear point on a straight run but keeps the corner", () => {
+      // (50,0) lies on source→(100,0); (100,0) is a genuine corner into (100,50).
+      const route = [p(0, 0), p(50, 0), p(100, 0), p(100, 50)]
+      expect(pruneCollinearWaypoints(route)).toEqual([p(100, 0)])
+    })
+    it("returns [] for a two-point route", () => {
+      expect(pruneCollinearWaypoints([p(0, 0), p(10, 10)])).toEqual([])
+    })
+  })
+
+  describe("exceedsDragThreshold", () => {
+    it("is false below and true above the threshold", () => {
+      const t = EDGES.WAYPOINT_DRAG_THRESHOLD_PX
+      expect(exceedsDragThreshold(p(0, 0), p(t - 1, 0))).toBe(false)
+      expect(exceedsDragThreshold(p(0, 0), p(t + 1, 0))).toBe(true)
+    })
+  })
+})

--- a/library/tests/unit/integerGeometry.test.ts
+++ b/library/tests/unit/integerGeometry.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest"
+import {
+  distSqInt,
+  isqrt,
+  segLenInt,
+  turnBucket,
+} from "@/utils/geometry/integerGeometry"
+
+describe("isqrt — exact integer floor square root", () => {
+  it("matches a golden table of small values", () => {
+    const golden: Array<[number, number]> = [
+      [0, 0],
+      [1, 1],
+      [2, 1],
+      [3, 1],
+      [4, 2],
+      [5, 2],
+      [8, 2],
+      [9, 3],
+      [15, 3],
+      [16, 4],
+      [24, 4],
+      [25, 5],
+      [26, 5],
+      [99, 9],
+      [100, 10],
+      [101, 10],
+    ]
+    for (const [input, expected] of golden) expect(isqrt(input)).toBe(expected)
+  })
+
+  it("is exact on perfect squares and their boundaries", () => {
+    for (let n = 0; n <= 5000; n++) {
+      const sq = n * n
+      expect(isqrt(sq)).toBe(n)
+      if (n > 0) {
+        // Just below a perfect square floors to n-1; just above still floors to n.
+        expect(isqrt(sq - 1)).toBe(n - 1)
+        expect(isqrt(sq + 1)).toBe(n)
+      }
+    }
+  })
+
+  it("is exact for large values including near 2^53", () => {
+    const cases: Array<[number, number]> = [
+      [1_000_000, 1000],
+      [999_999, 999],
+      [1_000_000_000_000, 1_000_000],
+      [999_999_999_999, 999_999],
+      [Number.MAX_SAFE_INTEGER, 94_906_265], // floor(sqrt(2^53 - 1))
+      [2 ** 52, 67_108_864], // 2^26 exactly
+    ]
+    for (const [input, expected] of cases) {
+      expect(isqrt(input)).toBe(expected)
+      // Defining property: r*r <= n < (r+1)*(r+1).
+      const r = isqrt(input)
+      expect(r * r).toBeLessThanOrEqual(input)
+      expect((r + 1) * (r + 1)).toBeGreaterThan(input)
+    }
+  })
+
+  it("rejects negative and non-integer inputs", () => {
+    expect(() => isqrt(-1)).toThrow(RangeError)
+    expect(() => isqrt(2.5)).toThrow(RangeError)
+  })
+})
+
+describe("segLenInt / distSqInt", () => {
+  it("computes exact squared distance and floored length", () => {
+    expect(distSqInt({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(25)
+    expect(segLenInt({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(5)
+    // 5-12-13 triple
+    expect(segLenInt({ x: 1, y: 1 }, { x: 6, y: 13 })).toBe(13)
+    // Non-integer true length floors down.
+    expect(segLenInt({ x: 0, y: 0 }, { x: 1, y: 1 })).toBe(1) // sqrt(2) -> 1
+    expect(segLenInt({ x: 0, y: 0 }, { x: 2, y: 2 })).toBe(2) // sqrt(8) -> 2
+  })
+})
+
+describe("turnBucket — integer angle classification", () => {
+  const cases: Array<[string, [number, number], [number, number], number]> = [
+    ["dead straight", [1, 0], [1, 0], 0],
+    ["straight (scaled)", [2, 0], [5, 0], 0],
+    ["gentle ~26deg", [1, 0], [2, 1], 0],
+    ["exactly 45deg (inclusive)", [1, 0], [1, 1], 0],
+    ["~63deg", [1, 0], [1, 2], 1],
+    ["right angle", [1, 0], [0, 1], 1],
+    ["right angle other sign", [1, 0], [0, -1], 1],
+    ["~135deg", [1, 0], [-1, 1], 2],
+    ["hairpin reverse", [1, 0], [-1, 0], 2],
+    ["degenerate incoming", [0, 0], [1, 0], 0],
+    ["degenerate outgoing", [1, 0], [0, 0], 0],
+  ]
+  it.each(cases)("%s", (_name, u, v, expected) => {
+    expect(turnBucket(u[0], u[1], v[0], v[1])).toBe(expected)
+  })
+
+  it("is sign-symmetric in the cross product", () => {
+    // Turning left vs right by the same magnitude lands in the same bucket.
+    expect(turnBucket(1, 0, 1, 2)).toBe(turnBucket(1, 0, 1, -2))
+    expect(turnBucket(1, 0, -1, 1)).toBe(turnBucket(1, 0, -1, -1))
+  })
+
+  it("stays exact for large coordinate magnitudes (no overflow)", () => {
+    // dot^2 / cross^2 here far exceed 2^53; BigInt keeps them exact.
+    expect(turnBucket(100_000, 0, 100_000, 0)).toBe(0)
+    expect(turnBucket(100_000, 0, 0, 100_000)).toBe(1)
+    expect(turnBucket(100_000, 1, -100_000, 1)).toBe(2)
+  })
+})

--- a/library/tests/unit/routingCost.test.ts
+++ b/library/tests/unit/routingCost.test.ts
@@ -83,6 +83,32 @@ describe("shared routing cost", () => {
     expect(crossing.crossings).toBe(1)
     expect(crossing.cost).toBe(ROUTING_COST.edgeCrossing)
 
+    // Lying ON another edge is the worst of the three incidences: it is priced
+    // above a crossing per shared pixel, and strictly above merely running close
+    // by. Straight edges rely on this ordering to fan out instead of merging.
+    const shared = [
+      { x: 20, y: 50 },
+      { x: 100, y: 50 },
+    ]
+    const overlapping = polylineConflictCost(route, [shared], 10)
+    const nearby = polylineConflictCost(
+      route,
+      [
+        [
+          { x: 20, y: 56 },
+          { x: 100, y: 56 },
+        ],
+      ],
+      10
+    )
+    expect(overlapping.overlapPx).toBe(80)
+    expect(overlapping.cost).toBe(80 * ROUTING_COST.overlapPerPx)
+    expect(overlapping.cost).toBeGreaterThan(nearby.cost)
+    expect(overlapping.cost).toBeGreaterThan(ROUTING_COST.edgeCrossing)
+    // Crowding is real but an order of magnitude gentler than overlap.
+    expect(nearby.cost).toBeGreaterThan(0)
+    expect(nearby.crowdingPx).toBeGreaterThan(0)
+
     const parallel = polylineConflictCost(
       [
         { x: 0, y: 0 },

--- a/library/tests/unit/straightHookRouting.test.ts
+++ b/library/tests/unit/straightHookRouting.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest"
+import {
+  ConnectionMode,
+  Position,
+  type Edge,
+  type InternalNode,
+  type Node,
+} from "@xyflow/react"
+import {
+  computeAllEdgeGeometry,
+  type SolverInput,
+} from "@/utils/geometry/edgeGeometrySolver"
+import {
+  STRAIGHT_HOOK_EDGE_TYPES,
+  STRAIGHT_PATH_STEP_EDGE_TYPES,
+} from "@/edges/edgeRoutingBehavior"
+import type { IPoint } from "@/edges/Connection"
+
+type TestNode = { node: Node; internal: InternalNode }
+
+const makeNode = (
+  id: string,
+  x: number,
+  y: number,
+  width = 120,
+  height = 80
+): TestNode => {
+  const node = {
+    id,
+    type: "syntaxTreeNonterminal",
+    position: { x, y },
+    width,
+    height,
+    measured: { width, height },
+    data: {},
+  } as Node
+  const internal = {
+    ...node,
+    internals: {
+      positionAbsolute: { x, y },
+      handleBounds: {
+        source: [
+          {
+            id: null,
+            type: "source",
+            position: Position.Right,
+            x: width,
+            y: height / 2,
+            width: 1,
+            height: 1,
+          },
+        ],
+        target: [
+          {
+            id: null,
+            type: "target",
+            position: Position.Left,
+            x: 0,
+            y: height / 2,
+            width: 1,
+            height: 1,
+          },
+        ],
+      },
+    },
+  } as unknown as InternalNode
+  return { node, internal }
+}
+
+const solverInput = (
+  nodes: readonly TestNode[],
+  edges: readonly Edge[]
+): SolverInput => ({
+  nodes: nodes.map(({ node }) => node),
+  nodeLookup: new Map(nodes.map(({ node, internal }) => [node.id, internal])),
+  connectionMode: ConnectionMode.Loose,
+  edges,
+  straightPathTypes: STRAIGHT_PATH_STEP_EDGE_TYPES,
+  straightHookTypes: STRAIGHT_HOOK_EDGE_TYPES,
+})
+
+const straightHookEdge = (points?: IPoint[]): Edge => ({
+  id: "e1",
+  source: "a",
+  target: "b",
+  type: "SyntaxTreeLink",
+  sourceHandle: null,
+  targetHandle: null,
+  data: points ? { points } : {},
+})
+
+const segIntersectsRect = (
+  a: IPoint,
+  b: IPoint,
+  rect: { x: number; y: number; width: number; height: number }
+): boolean => {
+  // Sample the segment densely and check strict-interior containment.
+  const steps = 200
+  for (let i = 1; i < steps; i++) {
+    const t = i / steps
+    const px = a.x + (b.x - a.x) * t
+    const py = a.y + (b.y - a.y) * t
+    if (
+      px > rect.x &&
+      px < rect.x + rect.width &&
+      py > rect.y &&
+      py < rect.y + rect.height
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+describe("straight-hook edge routing", () => {
+  it("passes authored interior waypoints through as diagonal segments (no orthogonalisation)", () => {
+    const nodes = [makeNode("a", 0, 0), makeNode("b", 400, 0)]
+    // An off-axis waypoint that an orthogonal reprojection would rewrite into H/V.
+    const waypoint = { x: 280, y: 200 }
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge([waypoint])])
+    )
+    const route = routeById["e1"]
+    expect(route).toHaveLength(3)
+    // The waypoint is honoured verbatim — proof it was NOT snapped to a staircase.
+    expect(route[1]).toEqual(waypoint)
+    // Endpoints attach to the node sides (right of A, left of B).
+    expect(route[0].x).toBeGreaterThan(100)
+    expect(route[route.length - 1].x).toBeLessThan(420)
+  })
+
+  it("keeps an unobstructed connection straight (a 2-point line)", () => {
+    const nodes = [makeNode("a", 0, 0), makeNode("b", 400, 0)]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge()])
+    )
+    expect(routeById["e1"]).toHaveLength(2)
+  })
+
+  it("auto-bends around a node sitting directly in the path (Track D)", () => {
+    // Blocker C straddles the horizontal chord between A and B.
+    const blocker = makeNode("c", 210, -20, 100, 120)
+    const nodes = [makeNode("a", 0, 0), makeNode("b", 520, 0), blocker]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge()])
+    )
+    const route = routeById["e1"]
+    expect(route.length).toBeGreaterThan(2)
+    const blockerRect = { x: 210, y: -20, width: 100, height: 120 }
+    for (let i = 0; i < route.length - 1; i++) {
+      expect(segIntersectsRect(route[i], route[i + 1], blockerRect)).toBe(false)
+    }
+  })
+
+  it("is deterministic: a cold re-solve yields byte-identical routes", () => {
+    const blocker = makeNode("c", 210, -20, 100, 120)
+    const nodes = [makeNode("a", 0, 0), makeNode("b", 520, 0), blocker]
+    const first = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge([{ x: 150, y: 120 }])])
+    ).routeById["e1"]
+    const second = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge([{ x: 150, y: 120 }])])
+    ).routeById["e1"]
+    expect(second).toEqual(first)
+  })
+})

--- a/library/tests/unit/straightHookRouting.test.ts
+++ b/library/tests/unit/straightHookRouting.test.ts
@@ -169,15 +169,52 @@ describe("straight-hook edge routing", () => {
     }
   })
 
-  it("keeps a syntax-tree link straight through a blocker (tidy layout, not routing)", () => {
-    // A dense hand-drawn tree must not sprout obstacle-avoidance bends; overlaps
-    // are the tidy-tree layout's job.
+  it("bends a syntax-tree link around a blocker without grazing either node", () => {
     const blocker = makeNode("c", 210, -20, 100, 120)
     const nodes = [makeNode("a", 0, 0, 120, 80), makeNode("b", 520, 0), blocker]
     const { routeById } = computeAllEdgeGeometry(
       solverInput(nodes, [straightHookEdge()])
     )
-    expect(routeById["e1"]).toHaveLength(2)
+    const route = routeById["e1"]
+    expect(route.length).toBeGreaterThan(2)
+    const blockerRect = { x: 210, y: -20, width: 100, height: 120 }
+    for (let i = 0; i < route.length - 1; i++) {
+      expect(segIntersectsRect(route[i], route[i + 1], blockerRect)).toBe(false)
+    }
+    // The detour stays economical: one corner, not a staircase of kinks.
+    expect(route.length).toBeLessThanOrEqual(4)
+  })
+
+  it("leaves a node squarely rather than grazing along its side", () => {
+    // A blocker directly under the source used to make the route slide out
+    // sideways along the node's own edge (a 90-degree "exit angle") before
+    // turning. The endpoint-angle term prices that above spending a corner.
+    const blocker = makeNode("c", 150, 140, 120, 80)
+    const nodes = [
+      makeNode("a", 150, 0, 120, 80),
+      makeNode("b", 420, 320, 120, 80),
+      blocker,
+    ]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge()])
+    )
+    const route = routeById["e1"]
+    const source = { ...makeNode("a", 150, 0, 120, 80).node.position }
+    const rect = { x: source.x, y: source.y, width: 120, height: 80 }
+    // Outward normal of whichever side the route departs from.
+    const p = route[0]
+    const distances = [
+      { n: { x: -1, y: 0 }, d: Math.abs(p.x - rect.x) },
+      { n: { x: 1, y: 0 }, d: Math.abs(p.x - (rect.x + rect.width)) },
+      { n: { x: 0, y: -1 }, d: Math.abs(p.y - rect.y) },
+      { n: { x: 0, y: 1 }, d: Math.abs(p.y - (rect.y + rect.height)) },
+    ].sort((a, b) => a.d - b.d)
+    const normal = distances[0].n
+    const dir = { x: route[1].x - p.x, y: route[1].y - p.y }
+    const len = Math.hypot(dir.x, dir.y)
+    const cos = (dir.x * normal.x + dir.y * normal.y) / len
+    const degrees = (Math.acos(Math.max(-1, Math.min(1, cos))) * 180) / Math.PI
+    expect(degrees).toBeLessThan(75)
   })
 
   it("attaches at the facing side with a centred port (not the drawn handle)", () => {

--- a/library/tests/unit/straightHookRouting.test.ts
+++ b/library/tests/unit/straightHookRouting.test.ts
@@ -342,6 +342,53 @@ describe("straight-hook edge routing", () => {
     expect(shared).toEqual([])
   })
 
+  it("nests both flanks of a symmetric fan identically", () => {
+    // Regression: the corner-ring choice compared each seat's distance from its
+    // side's centre against the largest on that side. Mirror-paired seats are the
+    // same distance out in exact arithmetic but NOT in binary floating point — for a
+    // seven-way band, 0.5 - 1/7 and 6/7 - 0.5 differ in the final bit. One flank
+    // therefore took the roomy corner ring and the other the tight one, and the
+    // drawing was visibly lopsided even though every input was symmetric.
+    const AXIS = 190
+    const parent = makeNode("stmt", 155, 215, 70, 50)
+    const columns = [
+      makeNode("colL", 55, 385, 70, 50),
+      makeNode("colR", 255, 385, 70, 50),
+    ]
+    const kids = [
+      makeNode("outerL", -35, 550, 50, 50),
+      makeNode("innerL", 15, 550, 50, 50),
+      makeNode("mid", 155, 310, 70, 50),
+      makeNode("innerR", 315, 550, 50, 50),
+      makeNode("outerR", 365, 550, 50, 50),
+    ]
+    const edges: Edge[] = kids.map((k, i) => ({
+      id: `e${i}`,
+      source: "stmt",
+      target: k.node.id,
+      type: "SyntaxTreeLink",
+      data: {},
+    }))
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput([parent, ...columns, ...kids], edges)
+    )
+    // e0/e4 are the outer pair, e1/e3 the inner pair.
+    for (const [left, right] of [
+      ["e0", "e4"],
+      ["e1", "e3"],
+    ]) {
+      const l = routeById[left]
+      const r = routeById[right]
+      expect(l.length).toBe(r.length)
+      for (let i = 0; i < l.length; i++) {
+        expect(Math.abs(2 * AXIS - l[i].x - r[i].x)).toBeLessThanOrEqual(1)
+        expect(l[i].y).toBe(r[i].y)
+      }
+    }
+    // And the two members of one flank still turn at different points.
+    expect(routeById["e0"][1]).not.toEqual(routeById["e1"][1])
+  })
+
   it("routes a mirror-symmetric diagram symmetrically", () => {
     // Everything below is an exact reflection about x = AXIS, including the
     // obstacles, so every route must be the reflection of its partner. Asymmetry

--- a/library/tests/unit/straightHookRouting.test.ts
+++ b/library/tests/unit/straightHookRouting.test.ts
@@ -139,9 +139,7 @@ describe("straight-hook edge routing", () => {
   })
 
   it("auto-bends a general-graph (use-case) edge around a blocking node", () => {
-    // Obstacle avoidance applies to general-graph straight edges (use-case /
-    // petri), NOT to syntax-tree links (those stay straight — see below). Blocker C
-    // straddles the horizontal chord between A and B.
+    // Blocker C straddles the horizontal chord between A and B.
     const t = "useCaseActor"
     const blocker = makeNode("c", 210, -20, 100, 120, t)
     const nodes = [
@@ -262,6 +260,70 @@ describe("straight-hook edge routing", () => {
     for (const x of sourceXs) {
       expect(x).toBeGreaterThanOrEqual(200)
       expect(x).toBeLessThanOrEqual(320)
+    }
+  })
+
+  it("spreads a fan evenly and symmetrically, never twice on one port", () => {
+    // Five children symmetric about the parent's centre. Their source ports must be
+    // five DISTINCT, evenly spaced seats — two edges leaving from one pixel is the
+    // degenerate overlap the coordinated band exists to prevent.
+    // Placed far enough below that every child is "downward" of the parent, so the
+    // whole fan shares one side and the band has to seat all five on it.
+    const parent = makeNode("p", 200, 0, 120, 60)
+    const kids = [-40, 85, 210, 335, 460].map((x, i) =>
+      makeNode(`c${i}`, x, 400, 100, 60)
+    )
+    const edges: Edge[] = kids.map((_, i) => ({
+      id: `e${i}`,
+      source: "p",
+      target: `c${i}`,
+      type: "SyntaxTreeLink",
+      data: {},
+    }))
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput([parent, ...kids], edges)
+    )
+    const ports = edges
+      .map((e) => routeById[e.id][0])
+      .sort((a, b) => a.x - b.x || a.y - b.y)
+    expect(new Set(ports.map((p) => `${p.x},${p.y}`)).size).toBe(ports.length)
+    // All on the parent's bottom side, and mirror-symmetric about its centre.
+    const centre = 200 + 120 / 2
+    expect(ports.every((p) => p.y === 60)).toBe(true)
+    for (let i = 0; i < ports.length; i++) {
+      const mirrored = ports[ports.length - 1 - i]
+      expect(
+        Math.abs(2 * centre - ports[i].x - mirrored.x)
+      ).toBeLessThanOrEqual(1)
+    }
+    // Evenly spaced: no gap more than one grid cell off any other.
+    const gaps = ports.slice(1).map((p, i) => p.x - ports[i].x)
+    expect(Math.max(...gaps) - Math.min(...gaps)).toBeLessThanOrEqual(5)
+  })
+
+  it("routes a mirror-symmetric diagram symmetrically", () => {
+    // Everything below is an exact reflection about x = AXIS, including the
+    // obstacles, so every route must be the reflection of its partner. Asymmetry
+    // here means some decision is resolving on a non-geometric tie-break.
+    const AXIS = 300
+    const parent = makeNode("p", 260, 0, 80, 60)
+    const leftKid = makeNode("kl", 0, 400, 80, 60)
+    const rightKid = makeNode("kr", 520, 400, 80, 60)
+    const leftBlock = makeNode("bl", 120, 180, 100, 60)
+    const rightBlock = makeNode("br", 380, 180, 100, 60)
+    const edges: Edge[] = [
+      { id: "eL", source: "p", target: "kl", type: "SyntaxTreeLink", data: {} },
+      { id: "eR", source: "p", target: "kr", type: "SyntaxTreeLink", data: {} },
+    ]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput([parent, leftKid, rightKid, leftBlock, rightBlock], edges)
+    )
+    const left = routeById["eL"]
+    const right = routeById["eR"]
+    expect(left.length).toBe(right.length)
+    for (let i = 0; i < left.length; i++) {
+      expect(Math.abs(2 * AXIS - left[i].x - right[i].x)).toBeLessThanOrEqual(1)
+      expect(left[i].y).toBe(right[i].y)
     }
   })
 

--- a/library/tests/unit/straightHookRouting.test.ts
+++ b/library/tests/unit/straightHookRouting.test.ts
@@ -23,11 +23,12 @@ const makeNode = (
   x: number,
   y: number,
   width = 120,
-  height = 80
+  height = 80,
+  type = "syntaxTreeNonterminal"
 ): TestNode => {
   const node = {
     id,
-    type: "syntaxTreeNonterminal",
+    type,
     position: { x, y },
     width,
     height,
@@ -137,12 +138,28 @@ describe("straight-hook edge routing", () => {
     expect(routeById["e1"]).toHaveLength(2)
   })
 
-  it("auto-bends around a node sitting directly in the path (Track D)", () => {
-    // Blocker C straddles the horizontal chord between A and B.
-    const blocker = makeNode("c", 210, -20, 100, 120)
-    const nodes = [makeNode("a", 0, 0), makeNode("b", 520, 0), blocker]
+  it("auto-bends a general-graph (use-case) edge around a blocking node", () => {
+    // Obstacle avoidance applies to general-graph straight edges (use-case /
+    // petri), NOT to syntax-tree links (those stay straight — see below). Blocker C
+    // straddles the horizontal chord between A and B.
+    const t = "useCaseActor"
+    const blocker = makeNode("c", 210, -20, 100, 120, t)
+    const nodes = [
+      makeNode("a", 0, 0, 120, 80, t),
+      makeNode("b", 520, 0, 120, 80, t),
+      blocker,
+    ]
+    const useCaseEdge: Edge = {
+      id: "e1",
+      source: "a",
+      target: "b",
+      type: "UseCaseAssociation",
+      sourceHandle: null,
+      targetHandle: null,
+      data: {},
+    }
     const { routeById } = computeAllEdgeGeometry(
-      solverInput(nodes, [straightHookEdge()])
+      solverInput(nodes, [useCaseEdge])
     )
     const route = routeById["e1"]
     expect(route.length).toBeGreaterThan(2)
@@ -150,6 +167,17 @@ describe("straight-hook edge routing", () => {
     for (let i = 0; i < route.length - 1; i++) {
       expect(segIntersectsRect(route[i], route[i + 1], blockerRect)).toBe(false)
     }
+  })
+
+  it("keeps a syntax-tree link straight through a blocker (tidy layout, not routing)", () => {
+    // A dense hand-drawn tree must not sprout obstacle-avoidance bends; overlaps
+    // are the tidy-tree layout's job.
+    const blocker = makeNode("c", 210, -20, 100, 120)
+    const nodes = [makeNode("a", 0, 0, 120, 80), makeNode("b", 520, 0), blocker]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge()])
+    )
+    expect(routeById["e1"]).toHaveLength(2)
   })
 
   it("attaches at the facing side with a centred port (not the drawn handle)", () => {

--- a/library/tests/unit/straightHookRouting.test.ts
+++ b/library/tests/unit/straightHookRouting.test.ts
@@ -301,6 +301,47 @@ describe("straight-hook edge routing", () => {
     expect(Math.max(...gaps) - Math.min(...gaps)).toBeLessThanOrEqual(5)
   })
 
+  it("nests sibling detours instead of stacking them on one elbow", () => {
+    // Two connectors from the same parent must clear the same obstacle. Shortest
+    // paths send both around its corner, so without a ring preference they bend at
+    // the identical point and the fan reads as a knot.
+    // Real parse-tree geometry: a five-way fan whose two left-hand members must
+    // both clear the same column of nodes. Their coordinated seats sit at different
+    // distances from the side's centre, which picks different corner rings.
+    const parent = makeNode("stmt", 155, 215, 70, 50)
+    const column = [
+      makeNode("colTop", 55, 385, 70, 50),
+      makeNode("colBottom", 55, 460, 70, 50),
+    ]
+    const kids = [
+      makeNode("outer", -35, 550, 50, 50),
+      makeNode("inner", 15, 550, 50, 50),
+      makeNode("mid", 155, 310, 70, 50),
+      makeNode("right1", 315, 550, 50, 50),
+      makeNode("right2", 365, 550, 50, 50),
+    ]
+    const edges: Edge[] = kids.map((k, i) => ({
+      id: `e${i}`,
+      source: "stmt",
+      target: k.node.id,
+      type: "SyntaxTreeLink",
+      data: {},
+    }))
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput([parent, ...column, ...kids], edges)
+    )
+    const outerBends = routeById["e0"].slice(1, -1)
+    const innerBends = routeById["e1"].slice(1, -1)
+    expect(outerBends.length).toBeGreaterThan(0)
+    expect(innerBends.length).toBeGreaterThan(0)
+    // The two never turn at the same point, so the fan reads as nested rather than
+    // knotted at a single shared elbow.
+    const shared = outerBends.filter((a) =>
+      innerBends.some((b) => a.x === b.x && a.y === b.y)
+    )
+    expect(shared).toEqual([])
+  })
+
   it("routes a mirror-symmetric diagram symmetrically", () => {
     // Everything below is an exact reflection about x = AXIS, including the
     // obstacles, so every route must be the reflection of its partner. Asymmetry
@@ -324,6 +365,43 @@ describe("straight-hook edge routing", () => {
     for (let i = 0; i < left.length; i++) {
       expect(Math.abs(2 * AXIS - left[i].x - right[i].x)).toBeLessThanOrEqual(1)
       expect(left[i].y).toBe(right[i].y)
+    }
+  })
+
+  it("does not change topology when a node is nudged one grid cell", () => {
+    // Routing is deterministic but not continuous: a small move can in principle
+    // flip a side or buy a corner. Generous bend pricing keeps the drawing from
+    // reorganising itself under an ordinary drag, which is what a user perceives as
+    // the diagram being stable.
+    const layout = (dx: number, dy: number) => {
+      const nodes = [
+        makeNode("a", 150 + dx, 0 + dy, 120, 80),
+        makeNode("b", 420, 320, 120, 80),
+        makeNode("c", 150, 140, 120, 80),
+      ]
+      const route = computeAllEdgeGeometry(
+        solverInput(nodes, [straightHookEdge()])
+      ).routeById["e1"]
+      const rect = { x: 150 + dx, y: 0 + dy, width: 120, height: 80 }
+      const p = route[0]
+      const side = [
+        ["L", Math.abs(p.x - rect.x)],
+        ["R", Math.abs(p.x - (rect.x + rect.width))],
+        ["T", Math.abs(p.y - rect.y)],
+        ["B", Math.abs(p.y - (rect.y + rect.height))],
+      ].sort((l, r) => (l[1] as number) - (r[1] as number))[0][0]
+      return `${side}:${route.length}`
+    }
+    const base = layout(0, 0)
+    for (const [dx, dy] of [
+      [5, 0],
+      [-5, 0],
+      [0, 5],
+      [0, -5],
+      [5, 5],
+      [-5, -5],
+    ]) {
+      expect(layout(dx, dy)).toBe(base)
     }
   })
 

--- a/library/tests/unit/straightHookRouting.test.ts
+++ b/library/tests/unit/straightHookRouting.test.ts
@@ -152,6 +152,54 @@ describe("straight-hook edge routing", () => {
     }
   })
 
+  it("attaches at the facing side with a centred port (not the drawn handle)", () => {
+    // Parent directly above child. The facing sides are parent-bottom / child-top,
+    // even though the edge was drawn on the right/left handles.
+    const nodes = [makeNode("a", 0, 0, 100, 60), makeNode("b", 0, 300, 100, 60)]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge()])
+    )
+    const route = routeById["e1"]
+    const source = route[0]
+    const target = route[route.length - 1]
+    // Source sits on the parent's BOTTOM edge (y≈60), centred (x≈50) — not on a
+    // left/right handle (x≈0 or 100).
+    expect(Math.abs(source.y - 60)).toBeLessThanOrEqual(6)
+    expect(source.x).toBeGreaterThan(35)
+    expect(source.x).toBeLessThan(65)
+    // Target sits on the child's TOP edge (y≈300), centred.
+    expect(Math.abs(target.y - 300)).toBeLessThanOrEqual(6)
+    expect(target.x).toBeGreaterThan(35)
+    expect(target.x).toBeLessThan(65)
+  })
+
+  it("balances multiple children across a parent's facing side", () => {
+    // A parent with three children below it: their source ports should spread
+    // across the parent's bottom side rather than stacking on one point.
+    const parent = makeNode("p", 200, 0, 120, 60)
+    const c1 = makeNode("c1", 0, 300, 100, 60)
+    const c2 = makeNode("c2", 200, 300, 100, 60)
+    const c3 = makeNode("c3", 400, 300, 100, 60)
+    const edges: Edge[] = [
+      { id: "e1", source: "p", target: "c1", type: "SyntaxTreeLink", data: {} },
+      { id: "e2", source: "p", target: "c2", type: "SyntaxTreeLink", data: {} },
+      { id: "e3", source: "p", target: "c3", type: "SyntaxTreeLink", data: {} },
+    ]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput([parent, c1, c2, c3], edges)
+    )
+    const sourceXs = ["e1", "e2", "e3"]
+      .map((id) => routeById[id][0].x)
+      .sort((a, b) => a - b)
+    // Three distinct ports spread across the parent's bottom side (x in [200,320]).
+    expect(new Set(sourceXs).size).toBe(3)
+    expect(sourceXs[2] - sourceXs[0]).toBeGreaterThan(20)
+    for (const x of sourceXs) {
+      expect(x).toBeGreaterThanOrEqual(200)
+      expect(x).toBeLessThanOrEqual(320)
+    }
+  })
+
   it("is deterministic: a cold re-solve yields byte-identical routes", () => {
     const blocker = makeNode("c", 210, -20, 100, 120)
     const nodes = [makeNode("a", 0, 0), makeNode("b", 520, 0), blocker]

--- a/library/tests/unit/straightPolylineRouter.test.ts
+++ b/library/tests/unit/straightPolylineRouter.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from "vitest"
+import type { IPoint } from "@/edges/Connection"
+import { EDGES } from "@/utils/geometry/routingConstants"
+import {
+  chordClearsObstacles,
+  routeStraightPolyline,
+  type StraightRouteObstacle,
+  type StraightRouteRequest,
+} from "@/utils/geometry/straightPolylineRouter"
+
+const CLEAR = EDGES.NODE_CLEARANCE_PX
+const MIN = EDGES.MIN_NODE_CLEARANCE_PX
+
+type Rect = { x: number; y: number; width: number; height: number }
+
+/** Independent strict interior-crossing tester used to VERIFY router output
+ * (deliberately not sharing code with the module under test). */
+const crossesRectInterior = (a: IPoint, b: IPoint, r: Rect): boolean => {
+  const inside = (p: IPoint) =>
+    p.x > r.x && p.x < r.x + r.width && p.y > r.y && p.y < r.y + r.height
+  if (inside(a) || inside(b)) return true
+  const cross = (p: IPoint, q: IPoint, s: IPoint) =>
+    (q.x - p.x) * (s.y - p.y) - (q.y - p.y) * (s.x - p.x)
+  const open = (a1: IPoint, a2: IPoint, b1: IPoint, b2: IPoint) =>
+    cross(a1, a2, b1) * cross(a1, a2, b2) < 0 &&
+    cross(b1, b2, a1) * cross(b1, b2, a2) < 0
+  const c0 = { x: r.x, y: r.y }
+  const c1 = { x: r.x + r.width, y: r.y }
+  const c2 = { x: r.x + r.width, y: r.y + r.height }
+  const c3 = { x: r.x, y: r.y + r.height }
+  return (
+    open(a, b, c0, c1) ||
+    open(a, b, c1, c2) ||
+    open(a, b, c2, c3) ||
+    open(a, b, c3, c0)
+  )
+}
+
+const inflated = (r: Rect, d: number): Rect => ({
+  x: r.x - d,
+  y: r.y - d,
+  width: r.width + 2 * d,
+  height: r.height + 2 * d,
+})
+
+/** Assert the whole route keeps MIN clearance from a hard obstacle. */
+const expectRouteClears = (
+  route: IPoint[],
+  obstacle: StraightRouteObstacle
+): void => {
+  const guard = inflated(obstacle, MIN)
+  for (let i = 1; i < route.length; i++)
+    expect(crossesRectInterior(route[i - 1], route[i], guard)).toBe(false)
+}
+
+const isInteger = (route: IPoint[]): boolean =>
+  route.every((p) => Number.isInteger(p.x) && Number.isInteger(p.y))
+
+const baseReq = (
+  over: Partial<StraightRouteRequest>
+): StraightRouteRequest => ({
+  source: { x: 0, y: 0 },
+  target: { x: 100, y: 0 },
+  checkpoints: [],
+  obstacles: [],
+  neighborRoutes: [],
+  clearancePx: CLEAR,
+  ...over,
+})
+
+describe("routeStraightPolyline — empty and gated cases", () => {
+  it("returns the straight 2-point chord when there is no obstacle", () => {
+    const route = routeStraightPolyline(baseReq({}))
+    expect(route).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ])
+  })
+
+  it("returns the straight chord when a hard obstacle is well clear of it", () => {
+    const obstacle: StraightRouteObstacle = {
+      id: "n1",
+      x: 40,
+      y: 200,
+      width: 40,
+      height: 40,
+      soft: false,
+    }
+    const route = routeStraightPolyline(baseReq({ obstacles: [obstacle] }))
+    expect(route).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ])
+  })
+
+  it("ignores soft obstacles for visibility (never routes around them)", () => {
+    const soft: StraightRouteObstacle = {
+      id: "pkg",
+      x: 40,
+      y: -50,
+      width: 20,
+      height: 100,
+      soft: true,
+    }
+    const route = routeStraightPolyline(baseReq({ obstacles: [soft] }))
+    expect(route).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ])
+  })
+})
+
+describe("routeStraightPolyline — obstacle avoidance", () => {
+  it("routes around a single blocking obstacle without crossing it", () => {
+    const obstacle: StraightRouteObstacle = {
+      id: "block",
+      x: 80,
+      y: -20,
+      width: 40,
+      height: 40,
+      soft: false,
+    }
+    const route = routeStraightPolyline(
+      baseReq({
+        source: { x: 0, y: 0 },
+        target: { x: 200, y: 0 },
+        obstacles: [obstacle],
+      })
+    )
+    expect(route.length).toBeGreaterThanOrEqual(3)
+    expect(route[0]).toEqual({ x: 0, y: 0 })
+    expect(route[route.length - 1]).toEqual({ x: 200, y: 0 })
+    expect(isInteger(route)).toBe(true)
+    expectRouteClears(route, obstacle)
+  })
+
+  it("threads a two-obstacle corridor, clearing both", () => {
+    const a: StraightRouteObstacle = {
+      id: "A",
+      x: 80,
+      y: -15,
+      width: 40,
+      height: 75,
+      soft: false,
+    }
+    const b: StraightRouteObstacle = {
+      id: "B",
+      x: 180,
+      y: -60,
+      width: 40,
+      height: 75,
+      soft: false,
+    }
+    const route = routeStraightPolyline(
+      baseReq({
+        source: { x: 0, y: 0 },
+        target: { x: 300, y: 0 },
+        obstacles: [a, b],
+      })
+    )
+    expect(route.length).toBeGreaterThanOrEqual(3)
+    expect(route[0]).toEqual({ x: 0, y: 0 })
+    expect(route[route.length - 1]).toEqual({ x: 300, y: 0 })
+    expectRouteClears(route, a)
+    expectRouteClears(route, b)
+  })
+})
+
+describe("routeStraightPolyline — checkpoints", () => {
+  it("passes through a checkpoint in order with no obstacles", () => {
+    const route = routeStraightPolyline(
+      baseReq({
+        source: { x: 0, y: 0 },
+        target: { x: 100, y: 0 },
+        checkpoints: [{ x: 50, y: 50 }],
+      })
+    )
+    expect(route).toEqual([
+      { x: 0, y: 0 },
+      { x: 50, y: 50 },
+      { x: 100, y: 0 },
+    ])
+  })
+
+  it("keeps checkpoints as mandatory via-points around an obstacle", () => {
+    const obstacle: StraightRouteObstacle = {
+      id: "block",
+      x: 120,
+      y: -20,
+      width: 40,
+      height: 40,
+      soft: false,
+    }
+    const cp1 = { x: 60, y: 40 }
+    const cp2 = { x: 260, y: 40 }
+    const route = routeStraightPolyline(
+      baseReq({
+        source: { x: 0, y: 0 },
+        target: { x: 320, y: 0 },
+        checkpoints: [cp1, cp2],
+        obstacles: [obstacle],
+      })
+    )
+    // Both checkpoints appear, and in order.
+    const i1 = route.findIndex((p) => p.x === cp1.x && p.y === cp1.y)
+    const i2 = route.findIndex((p) => p.x === cp2.x && p.y === cp2.y)
+    expect(i1).toBeGreaterThanOrEqual(0)
+    expect(i2).toBeGreaterThan(i1)
+    expectRouteClears(route, obstacle)
+  })
+})
+
+describe("routeStraightPolyline — endpoint own-node exemption", () => {
+  it("leaves a node the source sits on instead of being trapped", () => {
+    // Source (0,0) lies on the right edge of its own node body; the node overlaps
+    // the source, so it must be exempt or the edge could never depart.
+    const ownNode: StraightRouteObstacle = {
+      id: "own",
+      x: -50,
+      y: -25,
+      width: 50,
+      height: 50,
+      soft: false,
+    }
+    const route = routeStraightPolyline(
+      baseReq({
+        source: { x: 0, y: 0 },
+        target: { x: 100, y: 0 },
+        obstacles: [ownNode],
+      })
+    )
+    // The obstacle is behind the source, so the straight chord is valid.
+    expect(route).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ])
+  })
+})
+
+describe("chordClearsObstacles", () => {
+  const obstacle: StraightRouteObstacle = {
+    id: "n",
+    x: 40,
+    y: -20,
+    width: 40,
+    height: 40,
+    soft: false,
+  }
+  it("is false when the chord passes through the obstacle", () => {
+    expect(
+      chordClearsObstacles({ x: 0, y: 0 }, { x: 100, y: 0 }, [obstacle], MIN)
+    ).toBe(false)
+  })
+  it("is true when the chord keeps clearance", () => {
+    expect(
+      chordClearsObstacles(
+        { x: 0, y: 200 },
+        { x: 100, y: 200 },
+        [obstacle],
+        MIN
+      )
+    ).toBe(true)
+  })
+  it("ignores soft obstacles", () => {
+    const soft = { ...obstacle, id: "s", soft: true }
+    expect(
+      chordClearsObstacles({ x: 0, y: 0 }, { x: 100, y: 0 }, [soft], MIN)
+    ).toBe(true)
+  })
+})
+
+describe("routeStraightPolyline — determinism under shuffled input", () => {
+  const shuffle = <T>(items: T[], seed: number): T[] => {
+    // Deterministic Fisher–Yates from a tiny LCG — same seed, same permutation.
+    const out = items.slice()
+    let s = seed >>> 0
+    for (let i = out.length - 1; i > 0; i--) {
+      s = (s * 1_664_525 + 1_013_904_223) >>> 0
+      const j = s % (i + 1)
+      ;[out[i], out[j]] = [out[j], out[i]]
+    }
+    return out
+  }
+
+  const obstacles: StraightRouteObstacle[] = [
+    { id: "b1", x: 80, y: -15, width: 40, height: 75, soft: false },
+    { id: "b2", x: 180, y: -60, width: 40, height: 75, soft: false },
+    { id: "b3", x: 130, y: 120, width: 40, height: 40, soft: false },
+    { id: "far", x: 500, y: 500, width: 30, height: 30, soft: false },
+    { id: "soft", x: 40, y: -200, width: 20, height: 100, soft: true },
+  ]
+  const neighbors: IPoint[][] = [
+    [
+      { x: 0, y: -100 },
+      { x: 300, y: 100 },
+    ],
+    [
+      { x: 150, y: -200 },
+      { x: 150, y: 200 },
+    ],
+  ]
+
+  it("produces byte-identical output regardless of obstacle & neighbour order", () => {
+    const reference = routeStraightPolyline(
+      baseReq({
+        source: { x: 0, y: 0 },
+        target: { x: 300, y: 0 },
+        obstacles,
+        neighborRoutes: neighbors,
+      })
+    )
+    for (let seed = 1; seed <= 8; seed++) {
+      const shuffled = routeStraightPolyline(
+        baseReq({
+          source: { x: 0, y: 0 },
+          target: { x: 300, y: 0 },
+          obstacles: shuffle(obstacles, seed),
+          neighborRoutes: shuffle(neighbors, seed * 7 + 1),
+        })
+      )
+      expect(shuffled).toEqual(reference)
+    }
+    expect(reference[0]).toEqual({ x: 0, y: 0 })
+    expect(reference[reference.length - 1]).toEqual({ x: 300, y: 0 })
+    expect(isInteger(reference)).toBe(true)
+  })
+})

--- a/library/tests/unit/tidyForest.test.ts
+++ b/library/tests/unit/tidyForest.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest"
+import type { Node, Edge } from "@xyflow/react"
+import { buildSyntaxTreeForest } from "@/utils/tidyTree/buildForest"
+import { computeTidyLayout } from "@/utils/tidyTree/applyTidyLayout"
+
+const stNode = (
+  id: string,
+  x: number,
+  y: number,
+  extra: Partial<Node> = {}
+): Node => ({
+  id,
+  type: "syntaxTreeNonterminal",
+  position: { x, y },
+  data: {},
+  measured: { width: 60, height: 40 },
+  ...extra,
+})
+
+const link = (source: string, target: string): Edge => ({
+  id: `${source}->${target}`,
+  source,
+  target,
+  type: "SyntaxTreeLink",
+})
+
+const idSet = (nodes: Node[]): Set<string> => new Set(nodes.map((n) => n.id))
+
+describe("buildSyntaxTreeForest", () => {
+  it("lays out every clean root of a three-tree forest, dropping nothing", () => {
+    const nodes = [
+      stNode("r1", 0, 0),
+      stNode("r1c", 0, 100),
+      stNode("r2", 300, 0),
+      stNode("r2c", 300, 100),
+      stNode("r3", 600, 0),
+      stNode("r3c", 600, 100),
+    ]
+    const edges = [link("r1", "r1c"), link("r2", "r2c"), link("r3", "r3c")]
+    const forest = buildSyntaxTreeForest(nodes, edges)
+
+    expect(forest.roots.sort()).toEqual(["r1", "r2", "r3"])
+    expect(forest.laidOut.size).toBe(6)
+    expect(forest.skipped.size).toBe(0)
+  })
+
+  it("skips a multi-parent node and its whole subtree, leaving them unchanged", () => {
+    const nodes = [
+      stNode("p1", 0, 0),
+      stNode("p2", 200, 0),
+      stNode("c", 100, 100),
+      stNode("gc", 100, 200),
+    ]
+    const edges = [link("p1", "c"), link("p2", "c"), link("c", "gc")]
+    const forest = buildSyntaxTreeForest(nodes, edges)
+
+    expect(forest.skipped.has("c")).toBe(true)
+    expect(forest.skipped.has("gc")).toBe(true)
+    expect(forest.laidOut.has("c")).toBe(false)
+    expect(forest.laidOut.has("gc")).toBe(false)
+
+    const out = computeTidyLayout(nodes, edges)
+    const byId = new Map(out.map((n) => [n.id, n]))
+    // Skipped nodes keep their exact object (position untouched).
+    expect(byId.get("c")).toBe(nodes[2])
+    expect(byId.get("gc")).toBe(nodes[3])
+  })
+
+  it("skips a directed cycle and returns its nodes by reference", () => {
+    const nodes = [stNode("a", 0, 0), stNode("b", 100, 0), stNode("c", 200, 0)]
+    const edges = [link("a", "b"), link("b", "c"), link("c", "a")]
+    const forest = buildSyntaxTreeForest(nodes, edges)
+
+    expect(forest.roots).toEqual([])
+    expect(forest.laidOut.size).toBe(0)
+    expect(forest.skipped).toEqual(new Set(["a", "b", "c"]))
+
+    const out = computeTidyLayout(nodes, edges)
+    out.forEach((n, i) => expect(n).toBe(nodes[i]))
+  })
+
+  it("ignores non-syntax nodes and non-syntax edges entirely", () => {
+    const nodes = [
+      stNode("r", 0, 0),
+      stNode("rc", 0, 100),
+      { ...stNode("box", 500, 500), type: "package" } as Node,
+      { ...stNode("cls", 700, 700), type: "class" } as Node,
+    ]
+    const edges = [
+      link("r", "rc"),
+      { id: "assoc", source: "box", target: "cls", type: "ClassLink" } as Edge,
+    ]
+    const forest = buildSyntaxTreeForest(nodes, edges)
+
+    expect(forest.laidOut).toEqual(new Set(["r", "rc"]))
+    expect(forest.skipped.size).toBe(0)
+
+    const out = computeTidyLayout(nodes, edges)
+    const byId = new Map(out.map((n) => [n.id, n]))
+    // The non-syntax nodes are returned untouched, by reference.
+    expect(byId.get("box")).toBe(nodes[2])
+    expect(byId.get("cls")).toBe(nodes[3])
+  })
+})
+
+describe("computeTidyLayout", () => {
+  it("preserves the node count and id set", () => {
+    const nodes = [
+      stNode("r", 0, 0),
+      stNode("a", -50, 100),
+      stNode("b", 50, 100),
+      { ...stNode("other", 900, 900), type: "package" } as Node,
+    ]
+    const edges = [link("r", "a"), link("r", "b")]
+    const out = computeTidyLayout(nodes, edges)
+
+    expect(out.length).toBe(nodes.length)
+    expect(idSet(out)).toEqual(idSet(nodes))
+  })
+
+  it("keeps the root pinned and writes container-relative child positions", () => {
+    const container = {
+      id: "container",
+      type: "package",
+      position: { x: 500, y: 400 },
+      data: {},
+      measured: { width: 400, height: 400 },
+    } as Node
+    const nodes = [
+      container,
+      stNode("root", 10, 10, { parentId: "container" }),
+      stNode("child", 200, 10, { parentId: "container" }),
+    ]
+    const edges = [link("root", "child")]
+    const out = computeTidyLayout(nodes, edges)
+    const byId = new Map(out.map((n) => [n.id, n]))
+
+    // Root does not move (returned by reference).
+    expect(byId.get("root")).toBe(nodes[1])
+    // Child sits one level below the root: canvas y = rootCanvasY + h + levelGap
+    // = 410 + 40 + 60 = 510, minus the container origin (400) => 110 relative.
+    // Centred under the equal-width root: canvas x = 510, minus 500 => 10.
+    expect(byId.get("child")!.position).toEqual({ x: 10, y: 110 })
+  })
+
+  it("marks a cross-container link's deeper node as skipped", () => {
+    const container = {
+      id: "container",
+      type: "package",
+      position: { x: 500, y: 500 },
+      data: {},
+      measured: { width: 300, height: 300 },
+    } as Node
+    const nodes = [
+      container,
+      stNode("outer", 0, 0),
+      stNode("inner", 10, 10, { parentId: "container" }),
+    ]
+    const edges = [link("outer", "inner")]
+    const forest = buildSyntaxTreeForest(nodes, edges)
+
+    expect(forest.skipped.has("inner")).toBe(true)
+    expect(forest.laidOut.has("inner")).toBe(false)
+  })
+
+  it("is idempotent: re-laying-out a tidy tree returns nodes by reference", () => {
+    const nodes = [
+      stNode("r", 0, 0),
+      stNode("a", -80, 100),
+      stNode("b", 80, 100),
+      stNode("a1", -120, 200),
+      stNode("a2", -40, 200),
+    ]
+    const edges = [
+      link("r", "a"),
+      link("r", "b"),
+      link("a", "a1"),
+      link("a", "a2"),
+    ]
+    const first = computeTidyLayout(nodes, edges)
+    const second = computeTidyLayout(first, edges)
+
+    // A second pass over an already-tidy tree moves nothing.
+    second.forEach((n, i) => expect(n).toBe(first[i]))
+    for (let i = 0; i < first.length; i++) {
+      expect(second[i].position).toEqual(first[i].position)
+    }
+  })
+})

--- a/library/tests/unit/tidyTree.test.ts
+++ b/library/tests/unit/tidyTree.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest"
+import {
+  layoutTidyTree,
+  type TidyNodeInput,
+  type TidyOptions,
+  type TidyPosition,
+} from "@/utils/tidyTree/tidyTree"
+
+const OPTS: TidyOptions = {
+  siblingGap: 30,
+  subtreeGap: 20,
+  levelGap: 60,
+  gridSnap: 5,
+}
+
+/** Build a `nodesById` map from a flat list of node specs. */
+const toMap = (
+  specs: ReadonlyArray<TidyNodeInput>
+): Map<string, TidyNodeInput> => {
+  const map = new Map<string, TidyNodeInput>()
+  for (const spec of specs) map.set(spec.id, spec)
+  return map
+}
+
+const node = (
+  id: string,
+  width: number,
+  height: number,
+  childIds: string[] = []
+): TidyNodeInput => ({ id, width, height, childIds })
+
+const centerX = (pos: TidyPosition, spec: TidyNodeInput): number =>
+  pos.x + spec.width / 2
+
+const requiredSeparation = (
+  left: TidyNodeInput,
+  right: TidyNodeInput
+): number => left.width / 2 + OPTS.siblingGap + right.width / 2
+
+describe("layoutTidyTree", () => {
+  it("places a single node at the normalised origin", () => {
+    const specs = [node("a", 160, 100)]
+    const layout = layoutTidyTree(["a"], toMap(specs), OPTS)
+    expect(layout.get("a")).toEqual({ x: 0, y: 0 })
+  })
+
+  it("lays out a balanced binary tree symmetrically with no sibling overlap", () => {
+    const specs = [
+      node("r", 60, 40, ["l", "rr"]),
+      node("l", 60, 40, ["ll", "lr"]),
+      node("rr", 60, 40, ["rl", "rrr"]),
+      node("ll", 60, 40),
+      node("lr", 60, 40),
+      node("rl", 60, 40),
+      node("rrr", 60, 40),
+    ]
+    const map = toMap(specs)
+    const layout = layoutTidyTree(["r"], map, OPTS)
+
+    const c = (id: string) => centerX(layout.get(id)!, map.get(id)!)
+
+    // Depth 1 siblings clear the required separation.
+    expect(c("rr") - c("l")).toBeGreaterThanOrEqual(
+      requiredSeparation(map.get("l")!, map.get("rr")!)
+    )
+    // Depth 2 sibling pairs likewise.
+    expect(c("lr") - c("ll")).toBeGreaterThanOrEqual(
+      requiredSeparation(map.get("ll")!, map.get("lr")!)
+    )
+    expect(c("rrr") - c("rl")).toBeGreaterThanOrEqual(
+      requiredSeparation(map.get("rl")!, map.get("rrr")!)
+    )
+
+    // Symmetry: the tree is a mirror image about the root's centre.
+    const root = c("r")
+    expect(c("rr") - root).toBeCloseTo(root - c("l"), 6)
+    expect(c("rl") - root).toBeCloseTo(root - c("lr"), 6)
+    expect(c("rrr") - root).toBeCloseTo(root - c("ll"), 6)
+  })
+
+  it("centres an n-ary parent over its children", () => {
+    const specs = [
+      node("p", 60, 40, ["a", "b", "c", "d"]),
+      node("a", 60, 40),
+      node("b", 60, 40),
+      node("c", 60, 40),
+      node("d", 60, 40),
+    ]
+    const map = toMap(specs)
+    const layout = layoutTidyTree(["p"], map, OPTS)
+    const c = (id: string) => centerX(layout.get(id)!, map.get(id)!)
+
+    const childrenMidpoint = (c("a") + c("d")) / 2
+    expect(Math.abs(c("p") - childrenMidpoint)).toBeLessThanOrEqual(
+      OPTS.gridSnap
+    )
+
+    // Children are evenly spaced and non-overlapping.
+    for (const [left, right] of [
+      ["a", "b"],
+      ["b", "c"],
+      ["c", "d"],
+    ] as const) {
+      expect(c(right) - c(left)).toBeGreaterThanOrEqual(
+        requiredSeparation(map.get(left)!, map.get(right)!)
+      )
+    }
+  })
+
+  it("pushes siblings apart around a wide-label child (#282 guard)", () => {
+    const specs = [
+      node("p", 60, 40, ["a", "wide", "c"]),
+      node("a", 60, 40),
+      node("wide", 400, 40),
+      node("c", 60, 40),
+    ]
+    const map = toMap(specs)
+    const layout = layoutTidyTree(["p"], map, OPTS)
+    const c = (id: string) => centerX(layout.get(id)!, map.get(id)!)
+
+    // No bounding-box overlap on either side of the wide child.
+    expect(c("wide") - c("a")).toBeGreaterThanOrEqual(
+      map.get("a")!.width / 2 + map.get("wide")!.width / 2
+    )
+    expect(c("c") - c("wide")).toBeGreaterThanOrEqual(
+      map.get("wide")!.width / 2 + map.get("c")!.width / 2
+    )
+    // And the full separation clearance is honoured.
+    expect(c("wide") - c("a")).toBeGreaterThanOrEqual(
+      requiredSeparation(map.get("a")!, map.get("wide")!)
+    )
+    expect(c("c") - c("wide")).toBeGreaterThanOrEqual(
+      requiredSeparation(map.get("wide")!, map.get("c")!)
+    )
+  })
+
+  it("stacks a deep skewed chain with no cross-level overlap", () => {
+    const specs = [
+      node("n0", 60, 40, ["n1"]),
+      node("n1", 60, 40, ["n2"]),
+      node("n2", 60, 40, ["n3"]),
+      node("n3", 60, 40, ["n4"]),
+      node("n4", 60, 40),
+    ]
+    const map = toMap(specs)
+    const layout = layoutTidyTree(["n0"], map, OPTS)
+
+    for (let d = 1; d <= 4; d++) {
+      const parent = layout.get(`n${d - 1}`)!
+      const child = layout.get(`n${d}`)!
+      expect(child.y - parent.y).toBeGreaterThanOrEqual(
+        map.get(`n${d - 1}`)!.height + OPTS.levelGap
+      )
+    }
+  })
+
+  it("is deterministic and produces integer, grid-snapped coordinates", () => {
+    const specs = [
+      node("r", 90, 50, ["a", "b"]),
+      node("a", 70, 40, ["a1", "a2", "a3"]),
+      node("b", 120, 40, ["b1"]),
+      node("a1", 60, 40),
+      node("a2", 60, 40),
+      node("a3", 60, 40),
+      node("b1", 200, 40),
+    ]
+    const map = toMap(specs)
+    const first = layoutTidyTree(["r"], map, OPTS)
+    const second = layoutTidyTree(["r"], map, OPTS)
+
+    expect([...second.entries()].sort()).toEqual([...first.entries()].sort())
+
+    for (const pos of first.values()) {
+      expect(Number.isInteger(pos.x)).toBe(true)
+      expect(Number.isInteger(pos.y)).toBe(true)
+      expect(pos.x % OPTS.gridSnap).toBe(0)
+      expect(pos.y % OPTS.gridSnap).toBe(0)
+    }
+  })
+
+  it("normalises a forest so the minimum x and y are 0", () => {
+    const specs = [
+      node("r1", 60, 40, ["r1a"]),
+      node("r1a", 60, 40),
+      node("r2", 60, 40),
+    ]
+    const layout = layoutTidyTree(["r1", "r2"], toMap(specs), OPTS)
+    const minX = Math.min(...[...layout.values()].map((p) => p.x))
+    const minY = Math.min(...[...layout.values()].map((p) => p.y))
+    expect(minX).toBe(0)
+    expect(minY).toBe(0)
+  })
+})

--- a/library/tests/unit/tidyTree.test.ts
+++ b/library/tests/unit/tidyTree.test.ts
@@ -78,6 +78,59 @@ describe("layoutTidyTree", () => {
     expect(c("rrr") - root).toBeCloseTo(root - c("ll"), 6)
   })
 
+  it("draws a mirror-symmetric tree symmetrically", () => {
+    // The classic parse-tree shape: a root over a deep middle spine with matching
+    // subtrees either side. Reflecting the input must reflect the output — the
+    // "identical subtrees are drawn identically" aesthetic Reingold–Tilford
+    // guarantees, and the property a reader perceives as the drawing being tidy.
+    const specs = [
+      node("root", 70, 50, ["l", "m", "r"]),
+      node("l", 70, 50, ["lc"]),
+      node("lc", 70, 50, []),
+      node("m", 70, 50, ["mc"]),
+      node("mc", 70, 50, []),
+      node("r", 70, 50, ["rc"]),
+      node("rc", 70, 50, []),
+    ]
+    const map = toMap(specs)
+    const layout = layoutTidyTree(["root"], map, OPTS)
+    const cx = (id: string) => centerX(layout.get(id)!, map.get(id)!)
+
+    // The root and the middle spine share one axis.
+    const axis = cx("root")
+    expect(cx("m")).toBe(axis)
+    expect(cx("mc")).toBe(axis)
+    // Each flanking subtree is the reflection of its partner about that axis.
+    expect(axis - cx("l")).toBe(cx("r") - axis)
+    expect(axis - cx("lc")).toBe(cx("rc") - axis)
+    // Matching depths share a row.
+    expect(layout.get("l")!.y).toBe(layout.get("r")!.y)
+    expect(layout.get("lc")!.y).toBe(layout.get("rc")!.y)
+  })
+
+  it("keeps an odd fan symmetric about its parent", () => {
+    const specs = [
+      node("p", 70, 50, ["a", "b", "c", "d", "e"]),
+      node("a", 50, 50),
+      node("b", 50, 50),
+      node("c", 50, 50),
+      node("d", 50, 50),
+      node("e", 50, 50),
+    ]
+    const map = toMap(specs)
+    const layout = layoutTidyTree(["p"], map, OPTS)
+    const axis = centerX(layout.get("p")!, map.get("p")!)
+    const centres = ["a", "b", "c", "d", "e"].map((id) =>
+      centerX(layout.get(id)!, map.get(id)!)
+    )
+    // Middle child under the parent; outer pairs equidistant; even spacing.
+    expect(centres[2]).toBe(axis)
+    expect(axis - centres[0]).toBe(centres[4] - axis)
+    expect(axis - centres[1]).toBe(centres[3] - axis)
+    const gaps = centres.slice(1).map((c, i) => c - centres[i])
+    expect(new Set(gaps).size).toBe(1)
+  })
+
   it("centres an n-ary parent over its children", () => {
     const specs = [
       node("p", 60, 40, ["a", "b", "c", "d"]),

--- a/library/tests/unit/versionConverter.test.ts
+++ b/library/tests/unit/versionConverter.test.ts
@@ -649,6 +649,27 @@ describe("convertV3ToV4", () => {
     expect((edge.data.points as unknown[])[1]).toEqual({ x: 15, y: 25 })
   })
 
+  it("clears legacy path points on straight-hook edges", () => {
+    // v3 stored the full rendered polyline (endpoints included) in `path`. Under
+    // the interior-waypoint model these were inert, so importing them as waypoints
+    // would sprout spurious bends — the converter must drop them.
+    const rel = makeV3Relationship({
+      id: "r2",
+      type: "SyntaxTreeLink",
+      source: { element: "n1", direction: "Down" },
+      target: { element: "n2", direction: "Up" },
+      path: [
+        { x: 0, y: 0 },
+        { x: 10, y: 20 },
+        { x: 30, y: 40 },
+      ],
+      bounds: { x: 5, y: 5, width: 0, height: 0 },
+    })
+    const result = convertV3ToV4(makeV3Wrapped({ relationships: { r2: rel } }))
+    expect(result.edges[0].type).toBe("SyntaxTreeLink")
+    expect(result.edges[0].data.points).toEqual([])
+  })
+
   it("defaults missing relationship fields gracefully", () => {
     const rel = makeV3Relationship({
       name: "",


### PR DESCRIPTION
### Summary

Brings the **straight-hook** edge regime (UML use-case associations/include/extend/generalization, syntax-tree links, petri-net arcs) to parity with the orthogonal step-edge engine from #826. These edges were dumb 2-point diagonal lines with no bend handles, no auto-layout, and no obstacle avoidance. They now support hand-editing, automatic node avoidance, and — for syntax trees — a one-click tidy layout.

Closes #392. Addresses #282 (both the literal "add a joint" ask and its root cause) and lands a first concrete slice of #128.

Straight-hook edges are diagonal **by UML convention** — this is deliberately *not* "make them orthogonal". It is a parallel straight-polyline regime that shares the engine's contracts (memoryless, deterministic, preview==commit) and cost vocabulary, but not the orthogonal grid-A\* search or the H/V jog machinery.

### Track A — manual waypoints ("bend handles to pin it")

- Draggable free-2D waypoints on every straight-hook edge. A faint **ghost** handle at each segment midpoint materialises a bend once dragged past a threshold; a bend drags in 2D; remove it by double-click or by dragging it back onto the line (continuous near-collinear pruning).
- **Model:** `data.points` holds **interior waypoints only** (JointJS "vertices" model); the route is `[source, ...points, target]` connected by plain diagonal segments. Documented divergence from step edges (which store the full route).
- **Solver (S1):** both manual-points call sites (the port-coordination reservation *and* the main loop) now use a regime-aware diagonal passthrough — no orthogonal reprojection, which would silently break preview==commit.
- **Rendering (S2):** grip/marker orientation follows the terminal segment, not the endpoint chord, so a bent edge's arrowhead and reconnect grips point the right way. Touch-friendly (no hover-only affordance; generous hit targets).
- **Migration:** the v3 `path` (full polyline incl. endpoints, previously inert for these types) is cleared on import so old diagrams don't sprout spurious/double bends.

### Track B — syntax-tree tidy layout (#282)

- A user-triggered **"Tidy tree layout"** reconstructs the hierarchy from `SyntaxTreeLink` edges and repositions nodes so parent→child links no longer overlap siblings — the root-cause fix for #282 (a node-separation problem, not routing).
- Hand-written integer **Buchheim/Walker/Reingold–Tilford** tidy-tree with **variable-width** sibling separation (long labels push siblings apart). Malformed input (forests, cycles, multi-parent) degrades gracefully — never corrupts the diagram.
- One Yjs transaction / one undo step; a no-op on already-tidy or non-syntax-tree diagrams. Exposed as `ApollonEditor.layoutSyntaxTree()` and a SyntaxTree-only builtin control.

### Track D — automatic obstacle-avoiding straight router

- Straight edges now **auto-bend around any node** sitting directly in their path; an unobstructed chord stays straight. User waypoints are honoured as mandatory **checkpoints** (libavoid model).
- Deterministic reduced/tangent **visibility graph + integer A\***. Every decision is integer — `isqrt` (exact floor) for length, integer dot/cross **turn buckets** for the angle penalty; **no `hypot`/`atan2`/float on any decision path**. Canonical vertex/heap keys keep the search **byte-identical across Yjs peers and reloads**. Reuses `polylineConflictCost` and the obstacle corridor.

### Design & bundle

Budgets were **raised deliberately** (they are a guardrail, not a physical ceiling) with headroom, rather than distorting the architecture to fit an arbitrary number: main entry 118→126 kB (measured 122.06), routing worker 40→44 kB (measured 39.95). `/model` and `/export` unchanged.

### Implementation notes

New modules: `utils/geometry/freeWaypoints.ts`, `utils/geometry/integerGeometry.ts`, `utils/geometry/straightPolylineRouter.ts`, `utils/tidyTree/{tidyTree,buildForest,applyTidyLayout}.ts`. The design was pressure-tested from four independent angles (codebase map, OSS/industry survey, principal-engineer review, product devil's-advocate) before implementation; a cost-model attachment-selection track was deliberately cut as subsumed by Track D and determinism-unsafe on the use-case ellipse.

### Steps for testing

1. In a use-case/petri-net/syntax-tree diagram, hover an edge, drag a ghost midpoint → a bend appears and persists; drag it; double-click or drag-to-collinear to remove; reload → identical.
2. Place a node between two connected use cases → the straight edge auto-bends around it; move the node → it re-routes; a clear path stays straight.
3. Pin a waypoint, then let the router run → the pin is respected as a checkpoint.
4. Build a syntax tree with overlapping siblings → **Tidy tree layout** → no link overlaps a node; one undo reverts.
5. Import a v3 use-case/syntax-tree diagram → no spurious bends.

### Tests

Unit: `freeWaypoints`, `integerGeometry`, `straightPolylineRouter` (incl. shuffled-input determinism), `tidyTree`, `tidyForest`, `straightHookRouting` (solver S1 passthrough + Track D obstacle bend + cold-solve determinism), and a v3-migration case. Full suite: **1783 passed / 1 skipped**. `lint`, `format:check`, `build` (all packages), `size`, `knip` all green.

### Checklist

- [x] Added a user-voice changeset for the library
- [x] `feat` type matches the primary user-visible change
- [x] Tests added
- [x] `pnpm lint && pnpm format:check && pnpm build && pnpm test` — green
- [ ] Interactive-gesture E2E coverage (recommended follow-up; the gestures are thin glue over unit-tested pure functions + the solver integration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)