### PR TITLE
fix(release): decouple releases from staging availability

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -97,13 +97,3 @@ jobs:
             exit 1
           fi
           echo "Docker build passed or was skipped"
-
-  deploy-staging:
-    name: Deploy to Staging
-    needs: [docker-build-gate, build-and-push-workflow]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.docker-build-gate.result == 'success' && needs.build-and-push-workflow.result == 'success'
-    uses: ./.github/workflows/deploy-staging.yml
-    with:
-      image-tag: sha-${{ github.sha }}
-      deploy-app: true
-    secrets: inherit

--- a/.github/workflows/deploy-staging-after-build.yml
+++ b/.github/workflows/deploy-staging-after-build.yml
@@ -1,0 +1,28 @@
+name: Deploy to Staging after Docker Build
+
+on:
+  workflow_run:
+    workflows: [Build and Push Docker Image]
+    types: [completed]
+    branches: [main]
+
+concurrency:
+  group: deploy-staging-after-build
+  cancel-in-progress: false
+
+# Keep staging availability independent from image publication and releases.
+# A failed deployment remains visible here without changing the conclusion of
+# the Docker build that produced the deployable images.
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  deploy:
+    name: Deploy to Staging
+    if: github.event.workflow_run.conclusion == 'success'
+    uses: ./.github/workflows/deploy-staging.yml
+    with:
+      image-tag: sha-${{ github.event.workflow_run.head_sha }}
+      deploy-app: true
+    secrets: inherit

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -25,7 +25,9 @@ jobs:
           - apollon/server
     steps:
       - name: Delete stale sha-tagged versions
-        uses: snok/container-retention-policy@4f22ef80902ad409ed55a99dc5133cc1250a0d03 # v3.0.0
+        # v3.1.0 accepts GitHub's current installation-token format and
+        # automatically protects the child manifests of retained multi-arch images.
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
         with:
           account: ls1intum
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-standalone.yml
+++ b/.github/workflows/release-standalone.yml
@@ -1,6 +1,12 @@
 name: Release Standalone
 
 on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        type: string
+        required: true
+        description: "Commit SHA whose successfully built images should be released"
   workflow_run:
     workflows: [Build and Push Docker Image]
     types: [completed]
@@ -15,7 +21,7 @@ permissions: {}
 jobs:
   check:
     name: Check for new version
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -23,11 +29,15 @@ jobs:
     outputs:
       version: ${{ steps.v.outputs.version }}
       release: ${{ steps.v.outputs.release }}
-      sha: ${{ github.event.workflow_run.head_sha }}
+      sha: ${{ steps.source.outputs.sha }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.sha || github.event.workflow_run.head_sha }}
+
+      - id: source
+        name: Resolve source commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - id: v
         env:
@@ -51,7 +61,7 @@ jobs:
           echo "version=$WEBAPP" >> "$GITHUB_OUTPUT"
 
   release:
-    name: Retag, sign, release, deploy
+    name: Retag, sign, and release
     needs: [check]
     if: needs.check.outputs.release == 'true'
     runs-on: ubuntu-latest

--- a/docs/contributor/deployment/github-actions.md
+++ b/docs/contributor/deployment/github-actions.md
@@ -12,13 +12,20 @@ Deployments are fully automatic on merge to `main`; production promotion is one 
 
 | Stage          | Trigger                                     | Workflow                                                                        | Result                                                                                      |
 | -------------- | ------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Staging (auto) | push to `main`                              | `build-and-push.yml` → `deploy-staging.yml`                                     | Docker images built + tagged `sha-<commit>`, staging deploy fires                           |
+| Staging (auto) | successful Docker build on `main`           | `deploy-staging-after-build.yml` → `deploy-staging.yml`                         | The matching `sha-<commit>` images deploy to staging                                        |
 | Docs (auto)    | push to `main`                              | `docs.yml`                                                                      | Docusaurus site rebuilt and published to GitHub Pages                                       |
 | Release        | version change merged to `main`             | `release-library.yml`, `release-standalone.yml`, `release-vscode-extension.yml` | npm / VS Code Marketplace publish + Docker retag to `vX.Y.Z` + cosign sign + GitHub Release |
 | Production     | Actions → **Deploy to Production** (manual) | `deploy-prod.yml`                                                               | prod runs the selected `image-tag`                                                          |
 
 `version-monotonicity.yml` guards every PR by failing if a workspace
 `package.json` version moves backwards.
+
+Docker image publication, staging deployment, and standalone release are separate
+downstream workflows. A staging infrastructure outage therefore remains visible as
+a failed deployment without turning a successful image build red or suppressing a
+release. If a standalone release is interrupted after its images were built, run
+**Release Standalone** manually with that build's commit SHA; its retag, signing,
+tagging, and GitHub Release steps are safe to resume.
 
 `pr-health-checks.yml` runs the full per-PR matrix, including the visual-regression
 guard (pinned Playwright container) feeding the required **PR Health Gate** check.


### PR DESCRIPTION
## Summary

- run staging deployment as an independent workflow after a successful Docker build
- let standalone releases be resumed manually from an already-built commit SHA
- update GHCR cleanup to the token-format-compatible, multi-arch-safe v3.1.0 action
- document the independent failure and recovery paths

## Root cause

The standalone release listened to the overall Build and Push Docker Image conclusion, but that workflow also contained staging deployment. A gateway outage therefore changed a successful image build into a failed workflow and suppressed the release. The cleanup workflow separately pinned an action version that predates the current GitHub installation-token format.

## Validation

- actionlint on all modified workflows
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm test: 1,751 passed, 1 skipped
- docs markdown lint

No changeset: this changes CI and release orchestration only.