### PR TITLE
fix(release): automate TestFlight after standalone releases

### DIFF
--- a/.github/workflows/ios-live-update.yml
+++ b/.github/workflows/ios-live-update.yml
@@ -18,13 +18,14 @@ on:
       source-ref:
         description: >
           Commit to package, as the deployed image tag (`sha-<commit>`) or a raw
-          commit SHA. Empty uses the dispatched ref.
+          commit SHA. Semantic image tags such as `5.2.0` resolve to the matching
+          `v5.2.0` Git tag. Empty uses the dispatched ref.
         required: false
         type: string
   workflow_call:
     inputs:
       source-ref:
-        description: "Deployed image tag (`sha-<commit>`) or commit SHA to package."
+        description: "Deployed image tag (`sha-<commit>` or `X.Y.Z`) or commit SHA to package."
         required: false
         type: string
 
@@ -40,13 +41,26 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     steps:
-      # `sha-<commit>` is the tag convention build-and-push publishes images under,
-      # so stripping the prefix yields the commit the deployed image was built from.
+      # SHA image tags map directly to commits. Standalone release image tags omit
+      # the Git tag's leading `v`, so add it back before checkout.
       - name: Resolve the commit to package
         id: source
         run: |
+          set -euo pipefail
+
           REF="${{ inputs.source-ref }}"
-          echo "ref=${REF#sha-}" >> "$GITHUB_OUTPUT"
+          if [ -z "$REF" ]; then
+            RESOLVED_REF="$GITHUB_SHA"
+          elif [[ "$REF" == sha-* ]]; then
+            RESOLVED_REF="${REF#sha-}"
+          elif [[ "$REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            RESOLVED_REF="v$REF"
+          else
+            RESOLVED_REF="$REF"
+          fi
+
+          echo "Packaging deployed image tag $REF from $RESOLVED_REF."
+          echo "ref=$RESOLVED_REF" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/ios-testflight-release.yml
+++ b/.github/workflows/ios-testflight-release.yml
@@ -25,24 +25,102 @@ on:
         options:
           - raw
           - framed
+  workflow_run:
+    workflows: [Release Standalone]
+    types: [completed]
+    branches: [main]
 
 concurrency:
-  group: ios-release-${{ github.ref }}
+  group: ios-release-${{ github.event.workflow_run.head_sha || github.ref }}
   cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
+  check:
+    name: Check whether an iOS build should publish
+    runs-on: ubuntu-latest
+    outputs:
+      destination: ${{ steps.release.outputs.destination }}
+      publish: ${{ steps.release.outputs.publish }}
+      source-ref: ${{ steps.release.outputs.source-ref }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Resolve release intent
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_DESTINATION: ${{ inputs.destination }}
+          UPSTREAM_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          UPSTREAM_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          VERSION=$(node -p "require('./standalone/webapp/package.json').version")
+          SOURCE_REF=$(git rev-parse HEAD)
+          {
+            echo "version=$VERSION"
+            echo "source-ref=$SOURCE_REF"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            {
+              echo "destination=$INPUT_DESTINATION"
+              echo "publish=true"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "destination=testflight" >> "$GITHUB_OUTPUT"
+          if [ "$UPSTREAM_CONCLUSION" != "success" ]; then
+            echo "::notice::Standalone release did not succeed; skipping TestFlight."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          RELEASE_SHA=$(
+            gh release view "v$VERSION" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json targetCommitish \
+              --jq .targetCommitish 2>/dev/null || true
+          )
+          if [ "$RELEASE_SHA" != "$UPSTREAM_SHA" ]; then
+            echo "::notice::v$VERSION was not released from $UPSTREAM_SHA; skipping TestFlight."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/tags/ios-testflight@$VERSION" \
+            >/dev/null 2>&1; then
+            echo "::notice::iOS $VERSION is already marked as uploaded to TestFlight."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+
   release:
+    needs: check
+    if: needs.check.outputs.publish == 'true'
     runs-on: [self-hosted, macOS]
     timeout-minutes: 60
+    permissions:
+      contents: write
     defaults:
       run:
         shell: bash
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.check.outputs.source-ref }}
 
       - name: Set up Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -56,7 +134,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Validate App Store metadata and public links
-        if: inputs.destination != 'testflight'
+        if: needs.check.outputs.destination != 'testflight'
         working-directory: standalone/webapp
         run: pnpm appstore:metadata:validate
 
@@ -92,26 +170,26 @@ jobs:
         run: pnpm exec cap sync ios
 
       - name: Resolve marketing version and build number
-        if: inputs.destination != 'app-store-assets'
+        if: needs.check.outputs.destination != 'app-store-assets'
         run: |
           MARKETING_VERSION=$(node -p "require('./standalone/webapp/package.json').version")
           echo "MARKETING_VERSION=$MARKETING_VERSION" >> "$GITHUB_ENV"
           echo "BUILD_NUMBER=$(date +'%Y%m%d%H%M')" >> "$GITHUB_ENV"
 
       - name: Prepare licensed Apple product bezels
-        if: inputs.destination != 'testflight' && inputs.screenshot_style == 'framed'
+        if: needs.check.outputs.destination != 'testflight' && inputs.screenshot_style == 'framed'
         working-directory: standalone/webapp
         run: pnpm run appstore:screenshots:prepare-frames
 
       - name: Capture iPhone and iPad App Store screenshots
-        if: inputs.destination != 'testflight'
+        if: needs.check.outputs.destination != 'testflight'
         working-directory: standalone/webapp
         env:
           APP_STORE_SCREENSHOT_STYLE: ${{ inputs.screenshot_style }}
         run: bundle exec fastlane screenshots
 
       - name: Upload App Store screenshot review
-        if: inputs.destination != 'testflight'
+        if: needs.check.outputs.destination != 'testflight'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ios-app-store-screenshot-review
@@ -123,7 +201,7 @@ jobs:
           retention-days: 14
 
       - name: Build iOS app (Fastlane)
-        if: inputs.destination != 'app-store-assets'
+        if: needs.check.outputs.destination != 'app-store-assets'
         working-directory: standalone/webapp
         env:
           BUILD_NUMBER: ${{ env.BUILD_NUMBER }}
@@ -142,7 +220,7 @@ jobs:
         run: bundle exec fastlane build
 
       - name: Upload to TestFlight (Fastlane)
-        if: inputs.destination == 'testflight'
+        if: needs.check.outputs.destination == 'testflight'
         working-directory: standalone/webapp
         env:
           API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_KEY_ID }}
@@ -151,7 +229,7 @@ jobs:
         run: bundle exec fastlane release
 
       - name: Upload App Store metadata and screenshots (Fastlane)
-        if: inputs.destination == 'app-store-assets'
+        if: needs.check.outputs.destination == 'app-store-assets'
         working-directory: standalone/webapp
         env:
           APP_STORE_SCREENSHOT_STYLE: ${{ inputs.screenshot_style }}
@@ -167,7 +245,7 @@ jobs:
         run: bundle exec fastlane store_assets
 
       - name: Upload App Store build, metadata, and screenshots (Fastlane)
-        if: inputs.destination == 'app-store'
+        if: needs.check.outputs.destination == 'app-store'
         working-directory: standalone/webapp
         env:
           APP_STORE_SCREENSHOT_STYLE: ${{ inputs.screenshot_style }}
@@ -184,9 +262,29 @@ jobs:
         run: bundle exec fastlane release_app_store
 
       - name: Upload IPA artifact
-        if: always() && inputs.destination != 'app-store-assets'
+        if: always() && needs.check.outputs.destination != 'app-store-assets'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ios-ipa
           path: standalone/webapp/build/*.ipa
           retention-days: 7
+
+      - name: Mark version as uploaded to TestFlight
+        if: success() && needs.check.outputs.destination == 'testflight'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REF: ${{ needs.check.outputs.source-ref }}
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          if gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/tags/ios-testflight@$VERSION" \
+            >/dev/null 2>&1; then
+            echo "::notice::ios-testflight@$VERSION already exists."
+            exit 0
+          fi
+
+          gh api \
+            --method POST \
+            "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/tags/ios-testflight@$VERSION" \
+            -f sha="$SOURCE_REF"

--- a/docs/contributor/deployment/github-actions.md
+++ b/docs/contributor/deployment/github-actions.md
@@ -15,6 +15,7 @@ Deployments are fully automatic on merge to `main`; production promotion is one 
 | Staging (auto) | successful Docker build on `main`           | `deploy-staging-after-build.yml` → `deploy-staging.yml`                         | The matching `sha-<commit>` images deploy to staging                                        |
 | Docs (auto)    | push to `main`                              | `docs.yml`                                                                      | Docusaurus site rebuilt and published to GitHub Pages                                       |
 | Release        | version change merged to `main`             | `release-library.yml`, `release-standalone.yml`, `release-vscode-extension.yml` | npm / VS Code Marketplace publish + Docker retag to `vX.Y.Z` + cosign sign + GitHub Release |
+| TestFlight     | successful new standalone `vX.Y.Z` release  | `ios-testflight-release.yml`                                                    | Matching signed iOS build uploads once to TestFlight                                        |
 | Production     | Actions → **Deploy to Production** (manual) | `deploy-prod.yml`                                                               | prod runs the selected `image-tag`                                                          |
 
 `version-monotonicity.yml` guards every PR by failing if a workspace
@@ -26,6 +27,12 @@ a failed deployment without turning a successful image build red or suppressing 
 release. If a standalone release is interrupted after its images were built, run
 **Release Standalone** manually with that build's commit SHA; its retag, signing,
 tagging, and GitHub Release steps are safe to resume.
+
+`ios-testflight-release.yml` follows a successful standalone release and uploads
+the same version to TestFlight. It records `ios-testflight@X.Y.Z` only after the
+upload succeeds, making retries idempotent. App Store metadata, screenshots,
+submission, and review remain explicit manual destinations because they include
+human and legal checks.
 
 `pr-health-checks.yml` runs the full per-PR matrix, including the visual-regression
 guard (pinned Playwright container) feeding the required **PR Health Gate** check.

--- a/docs/contributor/development/mobile-builds.md
+++ b/docs/contributor/development/mobile-builds.md
@@ -112,9 +112,16 @@ The version metadata committed under
 `standalone/webapp/fastlane/metadata/` includes the App Store name, subtitle,
 description, keywords, release notes, and support, marketing, and privacy URLs.
 
-The manual `ios-release` GitHub Actions workflow provides three destinations:
+Every new standalone `vX.Y.Z` release automatically builds the matching native
+app and uploads it to TestFlight. A successful upload creates the
+`ios-testflight@X.Y.Z` marker tag, so release retries cannot upload the same
+native version twice.
 
-- `testflight` uploads only the signed build to TestFlight.
+The `ios-release` GitHub Actions workflow remains manually dispatchable with
+three destinations:
+
+- `testflight` uploads only the signed build to TestFlight (normally automatic;
+  manual dispatch is the recovery path).
 - `app-store-assets` regenerates and uploads metadata and screenshots without a
   binary.
 - `app-store` uploads the build, metadata, and screenshots. Submission for

--- a/standalone/webapp/fastlane/APP_STORE_READINESS.md
+++ b/standalone/webapp/fastlane/APP_STORE_READINESS.md
@@ -143,7 +143,9 @@ with Apple is not required.
 
 ## Upload paths
 
-Run the manual `ios-release` workflow with:
+TestFlight uploads run automatically after the matching standalone release.
+Manually run the `ios-release` workflow only to recover an interrupted upload,
+or to use one of these explicit destinations:
 
 - `testflight` for internal testing;
 - `app-store-assets` to update metadata and screenshots without a binary; or


### PR DESCRIPTION
## Summary

- upload each new standalone `vX.Y.Z` release to TestFlight automatically
- mark successful uploads with `ios-testflight@X.Y.Z` so retries are idempotent
- keep App Store assets, submission, and review explicitly manual
- resolve semantic production image tags such as `5.2.0` to Git tag `v5.2.0` before building the matching OTA bundle
- document the low-maintenance mobile release flow

## Recovery completed

- uploaded iOS 5.2.0 build `202607270951` to TestFlight successfully
- created `ios-testflight@5.2.0` after the successful upload
- confirmed production has not yet published an OTA manifest; the first approved production deploy will publish it automatically

## Validation

- `actionlint .github/workflows/ios-testflight-release.yml .github/workflows/ios-live-update.yml`
- `pnpm lint && pnpm format:check && pnpm build && pnpm test` (1,751 passed, 1 skipped)

No changeset: CI/release automation and documentation only.