### PR TITLE
fix(release): preserve signed OTA recovery artifacts

### DIFF
--- a/.github/workflows/ios-live-update.yml
+++ b/.github/workflows/ios-live-update.yml
@@ -88,6 +88,17 @@ jobs:
           CAPGO_MIN_NATIVE_VERSION: ${{ vars.CAPGO_MIN_NATIVE_VERSION }}
         run: pnpm run live-update:build
 
+      # Preserve the public, signed artifacts before entering the deployment
+      # transport. If the gateway is unavailable, an operator can download this
+      # artifact and copy it to the VM without handling the private signing key.
+      - name: Upload signed live-update recovery artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ios-live-update
+          path: standalone/webapp/live-updates-dist/
+          if-no-files-found: error
+          retention-days: 7
+
       # Upload the immutable bundle zip(s) FIRST so the manifest never points at
       # a file that is not yet on the host.
       - name: Copy bundle zips to the VM

--- a/docs/contributor/development/mobile-builds.md
+++ b/docs/contributor/development/mobile-builds.md
@@ -193,7 +193,10 @@ byproduct of it. Nothing new is hosted and the collaboration server is untouched
 - The `ios-live-update` workflow builds `dist/`, packages it into a versioned,
   **signed** `apollon-<version>.zip` plus a `manifest.json`
   (`standalone/webapp/scripts/build-live-update.mjs`), and copies both to
-  `/opt/apollon/app/live-updates` on the prod VM.
+  `/opt/apollon/app/live-updates` on the prod VM. It uploads the same public,
+  signed files as a seven-day recovery artifact before using the deployment
+  transport, so a gateway outage can be recovered over direct SSH without
+  exposing or moving the private signing key.
 - The **webapp container's nginx** serves that directory at
   `https://apollon.aet.cit.tum.de/live-updates/` (manifest `no-cache`, zips
   immutable, CORS). Traefik already routes the host to it — no proxy change.


### PR DESCRIPTION
## Summary

- upload the signed OTA zip and manifest as a seven-day artifact before entering the deployment transport
- allow direct-SSH recovery when the deployment gateway is unavailable
- keep the private signing key inside the protected Production workflow

## Context

Production run [30259204116](https://github.com/ls1intum/Apollon/actions/runs/30259204116) failed before copying any files because `gateway.aet.cit.tum.de:2010` timed out. The app-only 5.2.0 deployment has been recovered directly and is healthy; this artifact is needed to publish its matching signed OTA bundle safely.

## Validation

- `actionlint .github/workflows/ios-live-update.yml`
- Prettier check
- documentation markdown lint

No changeset: release recovery and documentation only.