### PR TITLE
feat(library): add waypoint editing to straight edges

### DIFF
--- a/.changeset/customizable-straight-edges.md
+++ b/.changeset/customizable-straight-edges.md
@@ -3,8 +3,8 @@
 ---
 
 Shape diagonal connections by hand just like orthogonal ones. Use-case, syntax-tree,
-and petri-net connections now have filled circular waypoints: drag the subtle point on
-a segment to add one, drag an existing point to reshape the route, and double-click,
+and petri-net connections now have filled circular waypoints: drag the handle on a
+segment to add one, drag an existing point to reshape the route, and double-click,
 press Delete, or drag it magnetically back onto the line to remove it. Shift-drag locks
 to familiar 15-degree angles, endpoint reconnection preserves the custom route, and a
 single reset clears all hand-authored routing.

--- a/.changeset/customizable-straight-edges.md
+++ b/.changeset/customizable-straight-edges.md
@@ -1,0 +1,10 @@
+---
+"@tumaet/apollon": minor
+---
+
+Shape diagonal connections by hand just like orthogonal ones. Use-case, syntax-tree,
+and petri-net connections now have filled circular waypoints: drag the subtle point on
+a segment to add one, drag an existing point to reshape the route, and double-click,
+press Delete, or drag it magnetically back onto the line to remove it. Shift-drag locks
+to familiar 15-degree angles, endpoint reconnection preserves the custom route, and a
+single reset clears all hand-authored routing.

--- a/docs/library/api/model-contract.md
+++ b/docs/library/api/model-contract.md
@@ -43,7 +43,7 @@ A v4 model is:
 
 ```ts no-check
 type UMLModel = {
-  version: `4.${number}.${number}` // wire-format version, e.g. "4.0.0"
+  version: `4.${number}.${number}` // wire-format version, currently "4.2.0"
   id: string
   title: string
   type: UMLDiagramType // "ClassDiagram" | "BPMN" | … (13 values)
@@ -79,8 +79,16 @@ normalization rules and the addressing API.
 ## Versioning policy
 
 `version` tracks the **wire-format major line (4.x)** — _not_ the npm package
-version. `importDiagram` stamps `4.0.0` when it _converts_ a v2 / v3 payload;
-an already-v4 model passes through with its existing version string untouched.
+version. The current canonical model version is `4.2.0`. `importDiagram`
+accepts every supported v2, v3, and v4 payload, migrates it in place where
+necessary, and returns the current v4 representation.
+
+The 4.2 minor adds optional, interior-only waypoints to straight connections.
+When loading a 4.0 or 4.1 model, Apollon discards `data.points` only on those
+straight edge families: older releases used that field for inert full-route
+geometry, which must not become visible user-authored bends. Orthogonal edge
+waypoints and all other model data are preserved. Models from 4.2 and later keep
+their straight-edge waypoints unchanged.
 
 | Change                | Bump  | What you do                                       |
 | --------------------- | ----- | ------------------------------------------------- |

--- a/library/lib/apollon-editor.tsx
+++ b/library/lib/apollon-editor.tsx
@@ -22,7 +22,7 @@ import {
 // incoming model onto the current schema (e.g. legacy class stereotypes) at
 // every hydration boundary, since editor load does NOT route through the public
 // `importDiagram`.
-import { normalizeModel } from "./utils/versionConverter"
+import { CURRENT_MODEL_VERSION, normalizeModel } from "./utils/versionConverter"
 import { UMLDiagramType } from "./types"
 import { createDiagramStore, type DiagramStore } from "@/store/diagramStore"
 import { createMetadataStore, type MetadataStore } from "@/store/metadataStore"
@@ -1061,7 +1061,7 @@ export class ApollonEditor {
     const interactive = this.getInteractiveForSerialization()
     return {
       id: diagramId,
-      version: "4.1.0",
+      version: CURRENT_MODEL_VERSION,
       title: diagramTitle,
       type: diagramType,
       nodes: nodes.map((node) => mapFromReactFlowNodeToApollonNode(node)),

--- a/library/lib/edges/GenericEdge.tsx
+++ b/library/lib/edges/GenericEdge.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useCallback,
   type ReactNode,
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react"
 import { BaseEdge, Position, useStore } from "@xyflow/react"
@@ -20,8 +21,10 @@ import {
 import type { DiagramEdgeType } from "./types"
 import { Assessment } from "@/typings"
 import type { BendHandle } from "@/utils/geometry/bendHandles"
+import { getSegmentGhostHandles } from "@/utils/geometry/freeWaypoints"
 import { isFreeformEdgeAnchor } from "@/utils/edgeUtils"
 import { CANVAS, EDGES } from "@/constants"
+import { useLabels } from "@/i18n/useLabels"
 
 // Edge handles live inside the zoomed React Flow viewport. We want them to
 // keep a usable MINIMUM on-screen size when zoomed out (so they never shrink to
@@ -178,7 +181,11 @@ export const getEndpointHitTargetRect = (
   // Straight (direct) edges leave the node at an angle; pass the real outward
   // edge direction so the target follows the line instead of an orthogonal side.
   outwardDir?: IPoint,
-  run: number = Number.POSITIVE_INFINITY
+  run: number = Number.POSITIVE_INFINITY,
+  /** Leave the node connection handle itself unobstructed. Straight-edge endpoint
+   * reconnect targets are intentionally large, but must begin just beyond the
+   * node border so starting a NEW connection wins at their shared endpoint. */
+  nodeGap = 0
 ) => {
   const direction = outwardDir
     ? normalizeDir(outwardDir)
@@ -191,10 +198,11 @@ export const getEndpointHitTargetRect = (
     EDGES.MIN_ENDPOINT_HIT_TARGET_PX * screenScale
   )
   const hitOffset = hitSize / 2
+  const centreOffset = hitOffset + nodeGap
 
   return {
-    x: point.x + direction.x * hitOffset - hitOffset,
-    y: point.y + direction.y * hitOffset - hitOffset,
+    x: point.x + direction.x * centreOffset - hitOffset,
+    y: point.y + direction.y * centreOffset - hitOffset,
     width: hitSize,
     height: hitSize,
     radius: hitOffset,
@@ -278,6 +286,8 @@ export const EdgeEndpointMarkers = ({
   onEndpointPointerDown,
   straight = false,
   bendHandles,
+  sourceNeighbor,
+  targetNeighbor,
 }: {
   sourcePoint: IPoint
   targetPoint: IPoint
@@ -295,6 +305,12 @@ export const EdgeEndpointMarkers = ({
   // The edge's bend handles, so a reconnect target can cap its outward reach at
   // this end's terminal bend handle instead of painting over it.
   bendHandles?: BendHandle[]
+  // The adjacent route vertex just inside each endpoint (route[1] / route[len-2]).
+  // A bent straight edge orients its grip/marker along the TERMINAL segment toward
+  // this point rather than the endpoint-to-endpoint chord. Defaults to the opposite
+  // endpoint, so an unbent 2-point edge is byte-identical to before.
+  sourceNeighbor?: IPoint
+  targetNeighbor?: IPoint
 }) => {
   const screenScale = useHandleScreenScale()
 
@@ -306,11 +322,19 @@ export const EdgeEndpointMarkers = ({
   // rotated to the edge angle — the same "along the edge, away from the node"
   // placement the orthogonal side gives a step edge. Step edges pass no
   // direction and fall back to the side.
+  const sourceAnchorNeighbor = sourceNeighbor ?? targetPoint
+  const targetAnchorNeighbor = targetNeighbor ?? sourcePoint
   const sourceOutward = straight
-    ? { x: targetPoint.x - sourcePoint.x, y: targetPoint.y - sourcePoint.y }
+    ? {
+        x: sourceAnchorNeighbor.x - sourcePoint.x,
+        y: sourceAnchorNeighbor.y - sourcePoint.y,
+      }
     : undefined
   const targetOutward = straight
-    ? { x: sourcePoint.x - targetPoint.x, y: sourcePoint.y - targetPoint.y }
+    ? {
+        x: targetAnchorNeighbor.x - targetPoint.x,
+        y: targetAnchorNeighbor.y - targetPoint.y,
+      }
     : undefined
   const sourceDir = sourceOutward
     ? normalizeDir(sourceOutward)
@@ -335,7 +359,8 @@ export const EdgeEndpointMarkers = ({
     screenScale,
     onEndpointPointerDown ? FREEFORM_ENDPOINT_HIT_TARGET_SIZE : undefined,
     sourceOutward,
-    sourceRun
+    sourceRun,
+    onEndpointPointerDown ? 10 * screenScale : 0
   )
   const targetHitTarget = getEndpointHitTargetRect(
     targetPoint,
@@ -343,7 +368,8 @@ export const EdgeEndpointMarkers = ({
     screenScale,
     onEndpointPointerDown ? FREEFORM_ENDPOINT_HIT_TARGET_SIZE : undefined,
     targetOutward,
-    targetRun
+    targetRun,
+    onEndpointPointerDown ? 10 * screenScale : 0
   )
   const className = [
     "edge-endpoint-handle",
@@ -490,6 +516,128 @@ export const EdgeBendHandle = ({
       }}
       onPointerDown={onPointerDown}
     />
+  )
+}
+
+/**
+ * Waypoint editing for straight (diagonal) edges.
+ *
+ * A straight edge is not "bent" the way a step edge is — there is no segment to
+ * slide along a fixed axis. It is a polyline through POINTS, and editing it means
+ * picking a point up and putting it somewhere else. So the affordance is a round
+ * handle on the point itself, not the step edge's elongated segment pill, and it
+ * carries a `move` cursor because it travels in two dimensions rather than one.
+ *
+ * Every authored interior vertex gets one. Segment midpoints additionally carry a
+ * faint HALF handle — the same point affordance, just not real yet — which becomes
+ * a waypoint when dragged.
+ */
+export const EdgeWaypointHandles = ({
+  route,
+  interior,
+  selectedWaypointIndex,
+  onWaypointPointerDown,
+  onWaypointDoubleClick,
+  onWaypointKeyDown,
+  onGhostPointerDown,
+}: {
+  /** Full route `[source, ...interior, target]`. */
+  route: IPoint[]
+  /** The editable authored interior vertices. */
+  interior: IPoint[]
+  selectedWaypointIndex: number | null
+  onWaypointPointerDown: (
+    event: ReactPointerEvent<SVGRectElement>,
+    index: number
+  ) => void
+  onWaypointDoubleClick: (index: number) => void
+  onWaypointKeyDown: (
+    event: ReactKeyboardEvent<SVGRectElement>,
+    index: number
+  ) => void
+  onGhostPointerDown: (
+    event: ReactPointerEvent<SVGRectElement>,
+    segmentIndex: number
+  ) => void
+}) => {
+  const t = useLabels()
+  const screenScale = useHandleScreenScale()
+  // Midpoint-create handles would be misleading while another point is actively
+  // moving (especially while its path is previewing a collapse).
+  const midpoints =
+    selectedWaypointIndex === null ? getSegmentGhostHandles(route) : []
+  const hit = EDGES.WAYPOINT_HIT_TARGET_PX * screenScale
+  const radius = EDGES.WAYPOINT_HANDLE_RADIUS_PX * screenScale
+
+  const point = (
+    centre: IPoint,
+    className: string,
+    key: string,
+    onPointerDown: (event: ReactPointerEvent<SVGRectElement>) => void,
+    accessibleName: string,
+    onDoubleClick?: () => void,
+    onKeyDown?: (event: ReactKeyboardEvent<SVGRectElement>) => void
+  ) => (
+    <g key={key}>
+      <circle
+        className={className}
+        cx={centre.x}
+        cy={centre.y}
+        r={radius}
+        style={{ strokeWidth: FREEFORM_ENDPOINT_GRIP_STROKE * screenScale }}
+        pointerEvents="none"
+      />
+      <rect
+        className="edge-waypoint-hit-target"
+        x={centre.x - hit / 2}
+        y={centre.y - hit / 2}
+        width={hit}
+        height={hit}
+        rx={hit / 2}
+        ry={hit / 2}
+        pointerEvents="all"
+        tabIndex={0}
+        role="button"
+        aria-label={accessibleName}
+        style={{ cursor: "grab", fill: "transparent", zIndex: 9999 }}
+        onPointerDown={onPointerDown}
+        onDoubleClick={(event) => {
+          if (!onDoubleClick) return
+          event.preventDefault()
+          event.stopPropagation()
+          onDoubleClick()
+        }}
+        onKeyDown={onKeyDown}
+      />
+    </g>
+  )
+
+  return (
+    <>
+      {midpoints.map((midpoint) =>
+        point(
+          midpoint.position,
+          "edge-circle edge-waypoint-handle edge-waypoint-handle--proposed",
+          `midpoint-${midpoint.segmentIndex}`,
+          (event) => onGhostPointerDown(event, midpoint.segmentIndex),
+          t.addEdgeWaypoint
+        )
+      )}
+      {interior.map((waypoint, index) =>
+        point(
+          waypoint,
+          "edge-circle edge-waypoint-handle" +
+            (selectedWaypointIndex === index
+              ? " edge-waypoint-handle--active"
+              : ""),
+          `waypoint-${index}`,
+          (event) => onWaypointPointerDown(event, index),
+          t.moveEdgeWaypoint,
+          () => onWaypointDoubleClick(index),
+          (event) => onWaypointKeyDown(event, index)
+        )
+      )}
+    </>
   )
 }
 

--- a/library/lib/edges/GenericEdge.tsx
+++ b/library/lib/edges/GenericEdge.tsx
@@ -573,7 +573,7 @@ export const EdgeWaypointHandles = ({
     className: string,
     key: string,
     onPointerDown: (event: ReactPointerEvent<SVGRectElement>) => void,
-    accessibleName: string,
+    accessibleName?: string,
     onDoubleClick?: () => void,
     onKeyDown?: (event: ReactKeyboardEvent<SVGRectElement>) => void
   ) => (
@@ -595,9 +595,9 @@ export const EdgeWaypointHandles = ({
         rx={hit / 2}
         ry={hit / 2}
         pointerEvents="all"
-        tabIndex={0}
-        role="button"
-        aria-label={accessibleName}
+        tabIndex={onKeyDown && accessibleName ? 0 : undefined}
+        role={onKeyDown && accessibleName ? "button" : undefined}
+        aria-label={onKeyDown ? accessibleName : undefined}
         style={{ cursor: "grab", fill: "transparent", zIndex: 9999 }}
         onPointerDown={onPointerDown}
         onDoubleClick={(event) => {
@@ -618,8 +618,7 @@ export const EdgeWaypointHandles = ({
           midpoint.position,
           "edge-circle edge-waypoint-handle edge-waypoint-handle--proposed",
           `midpoint-${midpoint.segmentIndex}`,
-          (event) => onGhostPointerDown(event, midpoint.segmentIndex),
-          t.addEdgeWaypoint
+          (event) => onGhostPointerDown(event, midpoint.segmentIndex)
         )
       )}
       {interior.map((waypoint, index) =>

--- a/library/lib/edges/GenericEdge.tsx
+++ b/library/lib/edges/GenericEdge.tsx
@@ -360,7 +360,7 @@ export const EdgeEndpointMarkers = ({
     onEndpointPointerDown ? FREEFORM_ENDPOINT_HIT_TARGET_SIZE : undefined,
     sourceOutward,
     sourceRun,
-    onEndpointPointerDown ? 10 * screenScale : 0
+    straight && onEndpointPointerDown ? 10 * screenScale : 0
   )
   const targetHitTarget = getEndpointHitTargetRect(
     targetPoint,
@@ -369,7 +369,7 @@ export const EdgeEndpointMarkers = ({
     onEndpointPointerDown ? FREEFORM_ENDPOINT_HIT_TARGET_SIZE : undefined,
     targetOutward,
     targetRun,
-    onEndpointPointerDown ? 10 * screenScale : 0
+    straight && onEndpointPointerDown ? 10 * screenScale : 0
   )
   const className = [
     "edge-endpoint-handle",

--- a/library/lib/edges/GenericEdge.tsx
+++ b/library/lib/edges/GenericEdge.tsx
@@ -562,9 +562,16 @@ export const EdgeWaypointHandles = ({
   const t = useLabels()
   const screenScale = useHandleScreenScale()
   // Midpoint-create handles would be misleading while another point is actively
-  // moving (especially while its path is previewing a collapse).
+  // moving (especially while its path is previewing a collapse). Counter-scale
+  // the density threshold with the handles: at low zoom their 24px targets grow
+  // in flow space, so a fixed flow-space threshold would let them fuse.
   const midpoints =
-    selectedWaypointIndex === null ? getSegmentGhostHandles(route) : []
+    selectedWaypointIndex === null
+      ? getSegmentGhostHandles(
+          route,
+          EDGES.WAYPOINT_GHOST_MIN_SEGMENT_PX * screenScale
+        )
+      : []
   const hit = EDGES.WAYPOINT_HIT_TARGET_PX * screenScale
   const radius = EDGES.WAYPOINT_HANDLE_RADIUS_PX * screenScale
 
@@ -598,7 +605,11 @@ export const EdgeWaypointHandles = ({
         tabIndex={onKeyDown && accessibleName ? 0 : undefined}
         role={onKeyDown && accessibleName ? "button" : undefined}
         aria-label={onKeyDown ? accessibleName : undefined}
-        style={{ cursor: "grab", fill: "transparent", zIndex: 9999 }}
+        // Above endpoint reconnect targets (z 10000): the exact visible point
+        // owns its centre, while the endpoint remains available at its separate
+        // node-adjacent grip. DOM order provides the same fallback in SVG engines
+        // that ignore z-index on graphics elements.
+        style={{ cursor: "grab", fill: "transparent", zIndex: 10001 }}
         onPointerDown={onPointerDown}
         onDoubleClick={(event) => {
           if (!onDoubleClick) return
@@ -638,6 +649,87 @@ export const EdgeWaypointHandles = ({
     </>
   )
 }
+
+/**
+ * One shared interaction stack for direct edges. Broad endpoint reconnect
+ * rectangles paint first; exact waypoint targets paint last and therefore own
+ * their visible circles. Keeping the order here prevents use-case, syntax-tree,
+ * and Petri-net edges from drifting into different hit-test behaviour.
+ */
+export const StraightEdgeControls = ({
+  route,
+  interior,
+  selectedWaypointIndex,
+  sourcePoint,
+  targetPoint,
+  sourcePosition,
+  targetPosition,
+  sourceNeighbor,
+  targetNeighbor,
+  isDiagramModifiable,
+  canEditEndpoint,
+  onEndpointPointerDown,
+  onWaypointPointerDown,
+  onWaypointDoubleClick,
+  onWaypointKeyDown,
+  onGhostPointerDown,
+}: {
+  route: IPoint[]
+  interior: IPoint[]
+  selectedWaypointIndex: number | null
+  sourcePoint: IPoint
+  targetPoint: IPoint
+  sourcePosition?: EndpointSide
+  targetPosition?: EndpointSide
+  sourceNeighbor?: IPoint
+  targetNeighbor?: IPoint
+  isDiagramModifiable: boolean
+  canEditEndpoint: boolean
+  onEndpointPointerDown?: (
+    event: ReactPointerEvent<SVGRectElement>,
+    endpoint: "source" | "target"
+  ) => void
+  onWaypointPointerDown: (
+    event: ReactPointerEvent<SVGRectElement>,
+    index: number
+  ) => void
+  onWaypointDoubleClick: (index: number) => void
+  onWaypointKeyDown: (
+    event: ReactKeyboardEvent<SVGRectElement>,
+    index: number
+  ) => void
+  onGhostPointerDown: (
+    event: ReactPointerEvent<SVGRectElement>,
+    segmentIndex: number
+  ) => void
+}) => (
+  <>
+    <EdgeEndpointMarkers
+      sourcePoint={sourcePoint}
+      targetPoint={targetPoint}
+      sourcePosition={sourcePosition}
+      targetPosition={targetPosition}
+      sourceNeighbor={sourceNeighbor}
+      targetNeighbor={targetNeighbor}
+      isDiagramModifiable={isDiagramModifiable}
+      canEditEndpoint={canEditEndpoint}
+      onEndpointPointerDown={onEndpointPointerDown}
+      straight
+    />
+
+    {isDiagramModifiable && (
+      <EdgeWaypointHandles
+        route={route}
+        interior={interior}
+        selectedWaypointIndex={selectedWaypointIndex}
+        onWaypointPointerDown={onWaypointPointerDown}
+        onWaypointDoubleClick={onWaypointDoubleClick}
+        onWaypointKeyDown={onWaypointKeyDown}
+        onGhostPointerDown={onGhostPointerDown}
+      />
+    )}
+  </>
+)
 
 /**
  * The shared SVG body for every orthogonal (step-path) edge: the base path,

--- a/library/lib/edges/GenericEdge.tsx
+++ b/library/lib/edges/GenericEdge.tsx
@@ -528,9 +528,8 @@ export const EdgeBendHandle = ({
  * handle on the point itself, not the step edge's elongated segment pill, and it
  * carries a `move` cursor because it travels in two dimensions rather than one.
  *
- * Every authored interior vertex gets one. Segment midpoints additionally carry a
- * faint HALF handle — the same point affordance, just not real yet — which becomes
- * a waypoint when dragged.
+ * Every authored interior vertex gets one. Segment midpoints carry the same opaque
+ * handle as step-edge bendable segments; dragging one materialises a waypoint.
  */
 export const EdgeWaypointHandles = ({
   route,

--- a/library/lib/edges/edgeRoutingBehavior.ts
+++ b/library/lib/edges/edgeRoutingBehavior.ts
@@ -10,10 +10,10 @@
  */
 
 /**
- * Edge types rendered by the straight-path hook (`useStraightPathEdge`): a plain
- * two-point line between the adjusted endpoints, with no obstacle or neighbour
- * routing. Other (step) edges still route AROUND these lines — the solver emits
- * their two-point polylines into the shared route map for that reason.
+ * Edge types rendered by the straight-path hook (`useStraightPathEdge`): a direct
+ * line through any user-authored interior waypoints, with no automatic obstacle
+ * or neighbour routing. Other (step) edges still route AROUND these polylines —
+ * the solver emits their complete authored routes into the shared map.
  */
 export const STRAIGHT_HOOK_EDGE_TYPES: ReadonlySet<string> = new Set([
   "UseCaseAssociation",

--- a/library/lib/edges/edgeTypes/PetriNetEdge.tsx
+++ b/library/lib/edges/edgeTypes/PetriNetEdge.tsx
@@ -3,6 +3,7 @@ import {
   BaseEdgeProps,
   CommonEdgeElements,
   EdgeEndpointMarkers,
+  EdgeWaypointHandles,
 } from "../GenericEdge"
 import { EdgeMiddleLabels } from "../labelTypes/EdgeMiddleLabels"
 import { useEdgeConfig } from "@/hooks/useEdgeConfig"
@@ -59,11 +60,20 @@ export const PetriNetEdge = ({
     strokeDashArray,
     sourcePoint,
     targetPoint,
+    sourceNeighbor,
+    targetNeighbor,
+    route,
+    interior,
+    selectedWaypointIndex,
     sourcePosition: renderSourcePosition,
     targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
     handleEndpointPointerDown,
+    handleWaypointPointerDown,
+    handleGhostPointerDown,
+    handleWaypointDoubleClick,
+    handleWaypointKeyDown,
   } = useStraightPathEdge({
     id,
     type,
@@ -118,11 +128,25 @@ export const PetriNetEdge = ({
             style={{ opacity: 0.4 }}
           />
 
+          {isDiagramModifiable && (
+            <EdgeWaypointHandles
+              route={route}
+              interior={interior}
+              selectedWaypointIndex={selectedWaypointIndex}
+              onWaypointPointerDown={handleWaypointPointerDown}
+              onWaypointDoubleClick={handleWaypointDoubleClick}
+              onWaypointKeyDown={handleWaypointKeyDown}
+              onGhostPointerDown={handleGhostPointerDown}
+            />
+          )}
+
           <EdgeEndpointMarkers
             sourcePoint={sourcePoint}
             targetPoint={targetPoint}
             sourcePosition={renderSourcePosition}
             targetPosition={renderTargetPosition}
+            sourceNeighbor={sourceNeighbor}
+            targetNeighbor={targetNeighbor}
             isDiagramModifiable={isDiagramModifiable}
             canEditEndpoint={canEditEndpoint}
             onEndpointPointerDown={handleEndpointPointerDown}
@@ -133,8 +157,9 @@ export const PetriNetEdge = ({
         <EdgeMiddleLabels
           label={data?.label}
           showRelationshipLabels={showRelationshipLabels}
-          sourcePoint={edgeData.sourcePoint}
-          targetPoint={edgeData.targetPoint}
+          sourcePoint={edgeData.labelSourcePoint}
+          targetPoint={edgeData.labelTargetPoint}
+          anchorPoint={edgeData.pathMiddlePosition}
           isUseCasePath={true}
           isPetriNet={true}
           textColor={textColor}

--- a/library/lib/edges/edgeTypes/PetriNetEdge.tsx
+++ b/library/lib/edges/edgeTypes/PetriNetEdge.tsx
@@ -2,8 +2,7 @@ import { BaseEdge } from "@xyflow/react"
 import {
   BaseEdgeProps,
   CommonEdgeElements,
-  EdgeEndpointMarkers,
-  EdgeWaypointHandles,
+  StraightEdgeControls,
 } from "../GenericEdge"
 import { EdgeMiddleLabels } from "../labelTypes/EdgeMiddleLabels"
 import { useEdgeConfig } from "@/hooks/useEdgeConfig"
@@ -128,19 +127,10 @@ export const PetriNetEdge = ({
             style={{ opacity: 0.4 }}
           />
 
-          {isDiagramModifiable && (
-            <EdgeWaypointHandles
-              route={route}
-              interior={interior}
-              selectedWaypointIndex={selectedWaypointIndex}
-              onWaypointPointerDown={handleWaypointPointerDown}
-              onWaypointDoubleClick={handleWaypointDoubleClick}
-              onWaypointKeyDown={handleWaypointKeyDown}
-              onGhostPointerDown={handleGhostPointerDown}
-            />
-          )}
-
-          <EdgeEndpointMarkers
+          <StraightEdgeControls
+            route={route}
+            interior={interior}
+            selectedWaypointIndex={selectedWaypointIndex}
             sourcePoint={sourcePoint}
             targetPoint={targetPoint}
             sourcePosition={renderSourcePosition}
@@ -150,7 +140,10 @@ export const PetriNetEdge = ({
             isDiagramModifiable={isDiagramModifiable}
             canEditEndpoint={canEditEndpoint}
             onEndpointPointerDown={handleEndpointPointerDown}
-            straight
+            onWaypointPointerDown={handleWaypointPointerDown}
+            onWaypointDoubleClick={handleWaypointDoubleClick}
+            onWaypointKeyDown={handleWaypointKeyDown}
+            onGhostPointerDown={handleGhostPointerDown}
           />
         </g>
 

--- a/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
+++ b/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
@@ -2,8 +2,7 @@ import { BaseEdge } from "@xyflow/react"
 import {
   BaseEdgeProps,
   CommonEdgeElements,
-  EdgeEndpointMarkers,
-  EdgeWaypointHandles,
+  StraightEdgeControls,
 } from "../GenericEdge"
 import { useStraightPathEdge } from "@/hooks/useStraightPathEdge"
 import { useDiagramStore, usePopoverStore } from "@/store/context"
@@ -114,19 +113,10 @@ export const SyntaxTreeEdge = ({
             style={{ opacity: 0.4 }}
           />
 
-          {isDiagramModifiable && (
-            <EdgeWaypointHandles
-              route={route}
-              interior={interior}
-              selectedWaypointIndex={selectedWaypointIndex}
-              onWaypointPointerDown={handleWaypointPointerDown}
-              onWaypointDoubleClick={handleWaypointDoubleClick}
-              onWaypointKeyDown={handleWaypointKeyDown}
-              onGhostPointerDown={handleGhostPointerDown}
-            />
-          )}
-
-          <EdgeEndpointMarkers
+          <StraightEdgeControls
+            route={route}
+            interior={interior}
+            selectedWaypointIndex={selectedWaypointIndex}
             sourcePoint={sourcePoint}
             targetPoint={targetPoint}
             sourcePosition={renderSourcePosition}
@@ -136,7 +126,10 @@ export const SyntaxTreeEdge = ({
             isDiagramModifiable={isDiagramModifiable}
             canEditEndpoint={canEditEndpoint}
             onEndpointPointerDown={handleEndpointPointerDown}
-            straight
+            onWaypointPointerDown={handleWaypointPointerDown}
+            onWaypointDoubleClick={handleWaypointDoubleClick}
+            onWaypointKeyDown={handleWaypointKeyDown}
+            onGhostPointerDown={handleGhostPointerDown}
           />
         </g>
 

--- a/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
+++ b/library/lib/edges/edgeTypes/SyntaxTreeEdge.tsx
@@ -3,6 +3,7 @@ import {
   BaseEdgeProps,
   CommonEdgeElements,
   EdgeEndpointMarkers,
+  EdgeWaypointHandles,
 } from "../GenericEdge"
 import { useStraightPathEdge } from "@/hooks/useStraightPathEdge"
 import { useDiagramStore, usePopoverStore } from "@/store/context"
@@ -51,11 +52,20 @@ export const SyntaxTreeEdge = ({
     strokeDashArray,
     sourcePoint,
     targetPoint,
+    sourceNeighbor,
+    targetNeighbor,
+    route,
+    interior,
+    selectedWaypointIndex,
     sourcePosition: renderSourcePosition,
     targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
     handleEndpointPointerDown,
+    handleWaypointPointerDown,
+    handleGhostPointerDown,
+    handleWaypointDoubleClick,
+    handleWaypointKeyDown,
   } = useStraightPathEdge({
     id,
     type,
@@ -104,11 +114,25 @@ export const SyntaxTreeEdge = ({
             style={{ opacity: 0.4 }}
           />
 
+          {isDiagramModifiable && (
+            <EdgeWaypointHandles
+              route={route}
+              interior={interior}
+              selectedWaypointIndex={selectedWaypointIndex}
+              onWaypointPointerDown={handleWaypointPointerDown}
+              onWaypointDoubleClick={handleWaypointDoubleClick}
+              onWaypointKeyDown={handleWaypointKeyDown}
+              onGhostPointerDown={handleGhostPointerDown}
+            />
+          )}
+
           <EdgeEndpointMarkers
             sourcePoint={sourcePoint}
             targetPoint={targetPoint}
             sourcePosition={renderSourcePosition}
             targetPosition={renderTargetPosition}
+            sourceNeighbor={sourceNeighbor}
+            targetNeighbor={targetNeighbor}
             isDiagramModifiable={isDiagramModifiable}
             canEditEndpoint={canEditEndpoint}
             onEndpointPointerDown={handleEndpointPointerDown}

--- a/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
@@ -2,8 +2,7 @@ import { BaseEdge } from "@xyflow/react"
 import {
   BaseEdgeProps,
   CommonEdgeElements,
-  EdgeEndpointMarkers,
-  EdgeWaypointHandles,
+  StraightEdgeControls,
 } from "../GenericEdge"
 import { EdgeMiddleLabels } from "../labelTypes/EdgeMiddleLabels"
 import { EdgeIncludeExtendLabel } from "../labelTypes/EdgeIncludeExtendLabel"
@@ -133,19 +132,10 @@ export const UseCaseEdge = ({
             style={{ opacity: 0.4 }}
           />
 
-          {isDiagramModifiable && (
-            <EdgeWaypointHandles
-              route={route}
-              interior={interior}
-              selectedWaypointIndex={selectedWaypointIndex}
-              onWaypointPointerDown={handleWaypointPointerDown}
-              onWaypointDoubleClick={handleWaypointDoubleClick}
-              onWaypointKeyDown={handleWaypointKeyDown}
-              onGhostPointerDown={handleGhostPointerDown}
-            />
-          )}
-
-          <EdgeEndpointMarkers
+          <StraightEdgeControls
+            route={route}
+            interior={interior}
+            selectedWaypointIndex={selectedWaypointIndex}
             sourcePoint={sourcePoint}
             targetPoint={targetPoint}
             sourcePosition={renderSourcePosition}
@@ -155,7 +145,10 @@ export const UseCaseEdge = ({
             isDiagramModifiable={isDiagramModifiable}
             canEditEndpoint={canEditEndpoint}
             onEndpointPointerDown={handleEndpointPointerDown}
-            straight
+            onWaypointPointerDown={handleWaypointPointerDown}
+            onWaypointDoubleClick={handleWaypointDoubleClick}
+            onWaypointKeyDown={handleWaypointKeyDown}
+            onGhostPointerDown={handleGhostPointerDown}
           />
         </g>
 

--- a/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
+++ b/library/lib/edges/edgeTypes/UseCaseDiagramEdge.tsx
@@ -3,6 +3,7 @@ import {
   BaseEdgeProps,
   CommonEdgeElements,
   EdgeEndpointMarkers,
+  EdgeWaypointHandles,
 } from "../GenericEdge"
 import { EdgeMiddleLabels } from "../labelTypes/EdgeMiddleLabels"
 import { EdgeIncludeExtendLabel } from "../labelTypes/EdgeIncludeExtendLabel"
@@ -64,11 +65,20 @@ export const UseCaseEdge = ({
     strokeDashArray,
     sourcePoint,
     targetPoint,
+    sourceNeighbor,
+    targetNeighbor,
+    route,
+    interior,
+    selectedWaypointIndex,
     sourcePosition: renderSourcePosition,
     targetPosition: renderTargetPosition,
     isDiagramModifiable,
     canEditEndpoint,
     handleEndpointPointerDown,
+    handleWaypointPointerDown,
+    handleGhostPointerDown,
+    handleWaypointDoubleClick,
+    handleWaypointKeyDown,
   } = useStraightPathEdge({
     id,
     type,
@@ -123,11 +133,25 @@ export const UseCaseEdge = ({
             style={{ opacity: 0.4 }}
           />
 
+          {isDiagramModifiable && (
+            <EdgeWaypointHandles
+              route={route}
+              interior={interior}
+              selectedWaypointIndex={selectedWaypointIndex}
+              onWaypointPointerDown={handleWaypointPointerDown}
+              onWaypointDoubleClick={handleWaypointDoubleClick}
+              onWaypointKeyDown={handleWaypointKeyDown}
+              onGhostPointerDown={handleGhostPointerDown}
+            />
+          )}
+
           <EdgeEndpointMarkers
             sourcePoint={sourcePoint}
             targetPoint={targetPoint}
             sourcePosition={renderSourcePosition}
             targetPosition={renderTargetPosition}
+            sourceNeighbor={sourceNeighbor}
+            targetNeighbor={targetNeighbor}
             isDiagramModifiable={isDiagramModifiable}
             canEditEndpoint={canEditEndpoint}
             onEndpointPointerDown={handleEndpointPointerDown}
@@ -138,8 +162,9 @@ export const UseCaseEdge = ({
         <EdgeMiddleLabels
           label={data?.label}
           showRelationshipLabels={showRelationshipLabels}
-          sourcePoint={edgeData.sourcePoint}
-          targetPoint={edgeData.targetPoint}
+          sourcePoint={edgeData.labelSourcePoint}
+          targetPoint={edgeData.labelTargetPoint}
+          anchorPoint={edgeData.pathMiddlePosition}
           isUseCasePath={true}
           textColor={textColor}
         />
@@ -155,8 +180,9 @@ export const UseCaseEdge = ({
           showRelationshipLabels={
             type === "UseCaseInclude" || type === "UseCaseExtend"
           }
-          sourcePoint={edgeData.sourcePoint}
-          targetPoint={edgeData.targetPoint}
+          sourcePoint={edgeData.labelSourcePoint}
+          targetPoint={edgeData.labelTargetPoint}
+          anchorPoint={edgeData.pathMiddlePosition}
           textColor={textColor}
         />
 

--- a/library/lib/edges/labelTypes/EdgeIncludeExtendLabel.tsx
+++ b/library/lib/edges/labelTypes/EdgeIncludeExtendLabel.tsx
@@ -4,6 +4,7 @@ import { computeUseCaseLabelLayout } from "@/utils/geometry/edgeLabelLayout"
 interface EdgeIncludeExtendLabelsProps {
   sourcePoint?: IPoint
   targetPoint?: IPoint
+  anchorPoint?: IPoint
   showRelationshipLabels?: boolean
   relationshipType?: "include" | "extend"
   textColor?: string
@@ -12,6 +13,7 @@ interface EdgeIncludeExtendLabelsProps {
 export const EdgeIncludeExtendLabel = ({
   sourcePoint,
   targetPoint,
+  anchorPoint,
   showRelationshipLabels = false,
   relationshipType = "include",
   textColor = "var(--apollon-foreground, #000000)",
@@ -31,7 +33,8 @@ export const EdgeIncludeExtendLabel = ({
   const { x, y, rotation } = computeUseCaseLabelLayout(
     sourcePoint,
     targetPoint,
-    0
+    0,
+    anchorPoint
   )
 
   return (

--- a/library/lib/edges/labelTypes/EdgeMiddleLabels.tsx
+++ b/library/lib/edges/labelTypes/EdgeMiddleLabels.tsx
@@ -16,6 +16,7 @@ interface EdgeMiddleLabelsProps {
   activePoints?: IPoint[]
   sourcePoint?: IPoint
   targetPoint?: IPoint
+  anchorPoint?: IPoint
   /** Every node the edge routes near, so the label avoids all of them. */
   nodeRects?: Rect[]
   neighborGeometry?: IPoint[][]
@@ -32,6 +33,7 @@ export const EdgeMiddleLabels = ({
   activePoints,
   sourcePoint,
   targetPoint,
+  anchorPoint,
   nodeRects,
   neighborGeometry,
   showRelationshipLabels = false,
@@ -51,7 +53,8 @@ export const EdgeMiddleLabels = ({
     const { x, y, rotation } = computeUseCaseLabelLayout(
       sourcePoint,
       targetPoint,
-      USE_CASE_LABEL_OFFSET
+      USE_CASE_LABEL_OFFSET,
+      anchorPoint
     )
 
     return (

--- a/library/lib/hooks/useEdgeLineJumps.ts
+++ b/library/lib/hooks/useEdgeLineJumps.ts
@@ -62,10 +62,13 @@ export function useEdgeLineJumps(
  */
 export function buildEdgePath(
   points: IPoint[],
-  lineJumps: LineJumpHit[]
+  lineJumps: LineJumpHit[],
+  labelGap?: {
+    segmentIndex: number
+    center: IPoint
+    halfSize: number
+  }
 ): string {
-  if (lineJumps.length === 0) return pointsToSvgPath(points)
-
   // Different "other" edges can report the same crossing; collapse duplicates
   // (by segment + whole-pixel point) so only one arc is drawn per crossing.
   const seen = new Set<string>()
@@ -78,6 +81,88 @@ export function buildEdgePath(
     return true
   })
 
+  if (labelGap) {
+    const segmentIndex = labelGap.segmentIndex
+    const start = points[segmentIndex]
+    const end = points[segmentIndex + 1]
+    if (start && end) {
+      const dx = end.x - start.x
+      const dy = end.y - start.y
+      const lengthSq = dx * dx + dy * dy
+      const length = Math.sqrt(lengthSq)
+      if (length > 0) {
+        // The visible arc midpoint can lie anywhere on this segment, including
+        // close to a bend. Project the rounded label anchor back onto the segment
+        // and clamp against EACH endpoint independently; `length / 2` would assume
+        // the gap is segment-centred and can reverse past a nearby corner.
+        const centerDistance = Math.max(
+          0,
+          Math.min(
+            length,
+            ((labelGap.center.x - start.x) * dx +
+              (labelGap.center.y - start.y) * dy) /
+              length
+          )
+        )
+        const halfSize = Math.min(
+          labelGap.halfSize,
+          Math.max(0, centerDistance - 1),
+          Math.max(0, length - centerDistance - 1)
+        )
+        const nx = dx / length
+        const ny = dy / length
+        const center = {
+          x: start.x + nx * centerDistance,
+          y: start.y + ny * centerDistance,
+        }
+        const gapStart = {
+          x: center.x - nx * halfSize,
+          y: center.y - ny * halfSize,
+        }
+        const gapEnd = {
+          x: center.x + nx * halfSize,
+          y: center.y + ny * halfSize,
+        }
+        const progress = (jump: LineJumpHit): number =>
+          ((jump.point.x - start.x) * dx + (jump.point.y - start.y) * dy) /
+          length
+        const gapStartDistance = centerDistance - halfSize
+        const gapEndDistance = centerDistance + halfSize
+        const beforeJumps: LineJumpHit[] = []
+        const afterJumps: LineJumpHit[] = []
+        for (const jump of uniqueJumps) {
+          if (jump.segmentIndex < segmentIndex) {
+            beforeJumps.push(jump)
+          } else if (jump.segmentIndex > segmentIndex) {
+            afterJumps.push({
+              ...jump,
+              segmentIndex: jump.segmentIndex - segmentIndex,
+            })
+          } else {
+            const distance = progress(jump)
+            if (distance < gapStartDistance) beforeJumps.push(jump)
+            else if (distance > gapEndDistance)
+              afterJumps.push({ ...jump, segmentIndex: 0 })
+          }
+        }
+        const beforePoints = [...points.slice(0, segmentIndex + 1), gapStart]
+        const afterPoints = [gapEnd, ...points.slice(segmentIndex + 1)]
+        return `${buildPathWithLineJumps(
+          beforePoints,
+          beforeJumps,
+          EDGES.EDGE_LINE_JUMP_HEIGHT,
+          EDGES.EDGE_LINE_JUMP_WIDTH
+        )} ${buildPathWithLineJumps(
+          afterPoints,
+          afterJumps,
+          EDGES.EDGE_LINE_JUMP_HEIGHT,
+          EDGES.EDGE_LINE_JUMP_WIDTH
+        )}`
+      }
+    }
+  }
+
+  if (uniqueJumps.length === 0) return pointsToSvgPath(points)
   return buildPathWithLineJumps(
     points,
     uniqueJumps,

--- a/library/lib/hooks/useStraightPathEdge.ts
+++ b/library/lib/hooks/useStraightPathEdge.ts
@@ -831,13 +831,14 @@ export const useStraightPathEdge = ({
       pointerId: number,
       pointerTarget: SVGRectElement,
       index: number,
-      startInterior: IPoint[]
+      startInterior: IPoint[],
+      movedAtStart = false
     ) => {
       if (!pointerTarget.hasPointerCapture(pointerId))
         pointerTarget.setPointerCapture(pointerId)
       const ownerDocument = pointerTarget.ownerDocument
       dragInteriorRef.current = startInterior
-      dragMovedRef.current = false
+      dragMovedRef.current = movedAtStart
       dragCollapseRef.current = false
       // Capture the endpoints at gesture start so the preview and eventual commit
       // pivot around stable attachment sites.
@@ -1002,8 +1003,10 @@ export const useStraightPathEdge = ({
           snapPoint(flowPoint)
         )
         setSelectedWaypointIndex(segmentIndex)
-        // Hand off to the shared drag routine on the same pointer/element.
-        beginWaypointDrag(pointerId, pointerTarget, segmentIndex, seeded)
+        // Hand off on the same pointer/element. Crossing the threshold is already
+        // a meaningful move: pointer-up may be the very next event on a quick
+        // mouse, touch, or stylus gesture, so preserve that state across handoff.
+        beginWaypointDrag(pointerId, pointerTarget, segmentIndex, seeded, true)
       }
 
       const handleEnd = (e: PointerEvent) => {

--- a/library/lib/hooks/useStraightPathEdge.ts
+++ b/library/lib/hooks/useStraightPathEdge.ts
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react"
 import { Position, useReactFlow, type Edge } from "@xyflow/react"
@@ -34,7 +35,17 @@ import { useDiagramModifiable } from "./useDiagramModifiable"
 import { IPoint } from "../edges/Connection"
 import { BaseEdgeProps } from "../edges/GenericEdge"
 import { computeToolbarPosition } from "@/utils/geometry/bendHandles"
-import { getMidSegment } from "@/utils/geometry/edgeLabelLayout"
+import {
+  exceedsDragThreshold,
+  insertWaypoint,
+  isWaypointCollapseCandidate,
+  moveWaypoint,
+  pruneCollinearWaypoints,
+  removeWaypoint,
+  snapPointToAngle,
+  snapPoint,
+} from "@/utils/geometry/freeWaypoints"
+import { getStraightMidSegment } from "@/utils/geometry/edgeLabelLayout"
 import { useEdgeLineJumps, buildEdgePath } from "./useEdgeLineJumps"
 import {
   useDiagramStore,
@@ -50,9 +61,41 @@ export interface StraightPathEdgeData {
   isMiddlePathHorizontal: boolean
   sourcePoint: IPoint
   targetPoint: IPoint
+  /** Endpoints of the LOCAL arc-mid segment. Labels follow this segment rather
+   * than the endpoint chord when obstacle avoidance or waypoints bend the edge. */
+  labelSourcePoint: IPoint
+  labelTargetPoint: IPoint
 }
 
+/** Stable empty interior list so an unbent edge keeps a constant reference and
+ * does not churn the downstream route memos every render. */
+const EMPTY_POINTS: IPoint[] = []
+
 type EndpointType = "source" | "target"
+
+/** Keep the selectable ribbon clear of node connection handles. Endpoint-specific
+ * reconnect targets start just outside this same gap; without it an existing edge
+ * ending on a handle steals pointer-down and turns "new connection" into "select
+ * edge", especially on occupied use-case handles. */
+const trimOverlayEndpoints = (points: IPoint[], trimPx = 10): IPoint[] => {
+  if (points.length < 2) return points
+  const trimmed = points.map((point) => ({ ...point }))
+  const moveToward = (from: IPoint, to: IPoint, maximum: number): IPoint => {
+    const dx = to.x - from.x
+    const dy = to.y - from.y
+    const length = Math.sqrt(dx * dx + dy * dy)
+    if (length === 0) return from
+    const amount = Math.min(maximum, Math.max(0, length / 3))
+    return {
+      x: from.x + (dx / length) * amount,
+      y: from.y + (dy / length) * amount,
+    }
+  }
+  trimmed[0] = moveToward(points[0], points[1], trimPx)
+  const last = points.length - 1
+  trimmed[last] = moveToward(points[last], points[last - 1], trimPx)
+  return trimmed
+}
 
 type StraightEndpointDragCommit = {
   endpoint: EndpointType
@@ -85,24 +128,46 @@ export const useStraightPathEdge = ({
   const endpointDragCommitRef = useRef<StraightEndpointDragCommit | null>(null)
   const activePointerCancelRef = useRef<(() => void) | null>(null)
   const activePointerTeardownRef = useRef<(() => void) | null>(null)
+  // Per-gesture waypoint-drag state. Refs (not a captured object) keep the drag
+  // closures React-Compiler-safe, mirroring useStepPathEdge's drag refs.
+  const dragInteriorRef = useRef<IPoint[]>([])
+  const dragMovedRef = useRef(false)
+  const dragCollapseRef = useRef(false)
   const isDiagramModifiable = useDiagramModifiable()
   const setLiveEdgeOverride = useMetadataStore(
     (state) => state.setLiveEdgeOverride
   )
-  const { getIntersectingNodes, getNode, getNodes, screenToFlowPosition } =
-    useReactFlow()
+  const {
+    getIntersectingNodes,
+    getNode,
+    getNodes,
+    getZoom,
+    screenToFlowPosition,
+  } = useReactFlow()
   const [dragPreviewPoints, setDragPreviewPoints] = useState<IPoint[] | null>(
     null
   )
+  // The grabbed waypoint must remain mounted while the PATH previews its
+  // removal. Removing the pointer-capturing SVG node cancels the browser gesture
+  // and restores the bend before pointer-up.
+  const [dragHandleRoute, setDragHandleRoute] = useState<IPoint[] | null>(null)
   const [dragPreviewPositions, setDragPreviewPositions] = useState<{
     sourcePosition: Position
     targetPosition: Position
   } | null>(null)
   const [endpointPreviewCommit, setEndpointPreviewCommit] =
     useState<StraightEndpointDragCommit | null>(null)
+  const [selectedWaypointIndex, setSelectedWaypointIndex] = useState<
+    number | null
+  >(null)
   const centralRoute = useEdgeGeometryStore(
     (state) => state.previewById[id] ?? state.geometryById[id]
   )
+  // Interior waypoints authored on this edge (JointJS "vertices" model): the route
+  // is [source, ...interior, target]. Never includes the endpoints.
+  const interiorPoints: IPoint[] = Array.isArray(data?.points)
+    ? (data.points as IPoint[])
+    : EMPTY_POINTS
 
   useEffect(
     () => () => {
@@ -307,23 +372,26 @@ export const useStraightPathEdge = ({
     sourceConnectionPointPadding
   )
 
+  const sourceEndpoint = useMemo<IPoint>(
+    () => ({
+      x: adjustedSourceCoordinates.sourceX,
+      y: adjustedSourceCoordinates.sourceY,
+    }),
+    [adjustedSourceCoordinates.sourceX, adjustedSourceCoordinates.sourceY]
+  )
+  const targetEndpoint = useMemo<IPoint>(
+    () => ({
+      x: adjustedTargetCoordinates.targetX,
+      y: adjustedTargetCoordinates.targetY,
+    }),
+    [adjustedTargetCoordinates.targetX, adjustedTargetCoordinates.targetY]
+  )
+  // The authored route is source → interior waypoints → target. Automatic
+  // straight-edge routing is deliberately a separate concern: this branch
+  // renders only user intent and the endpoint preview already present on main.
   const basePoints = useMemo<IPoint[]>(
-    () => [
-      {
-        x: adjustedSourceCoordinates.sourceX,
-        y: adjustedSourceCoordinates.sourceY,
-      },
-      {
-        x: adjustedTargetCoordinates.targetX,
-        y: adjustedTargetCoordinates.targetY,
-      },
-    ],
-    [
-      adjustedSourceCoordinates.sourceX,
-      adjustedSourceCoordinates.sourceY,
-      adjustedTargetCoordinates.targetX,
-      adjustedTargetCoordinates.targetY,
-    ]
+    () => [sourceEndpoint, ...interiorPoints, targetEndpoint],
+    [sourceEndpoint, interiorPoints, targetEndpoint]
   )
   const centralPreviewMatchesCommit =
     dragPreviewPoints !== null &&
@@ -340,9 +408,19 @@ export const useStraightPathEdge = ({
   const renderPoints = useMemo<IPoint[]>(
     () =>
       centralPreviewMatchesCommit
-        ? [centralRoute[0], centralRoute[centralRoute.length - 1]]
+        ? [
+            centralRoute[0],
+            ...interiorPoints,
+            centralRoute[centralRoute.length - 1],
+          ]
         : (dragPreviewPoints ?? basePoints),
-    [basePoints, centralPreviewMatchesCommit, centralRoute, dragPreviewPoints]
+    [
+      basePoints,
+      centralPreviewMatchesCommit,
+      centralRoute,
+      dragPreviewPoints,
+      interiorPoints,
+    ]
   )
   const renderSourcePosition =
     dragPreviewPositions?.sourcePosition ?? resolvedSourcePosition
@@ -371,17 +449,38 @@ export const useStraightPathEdge = ({
     type !== "UseCaseInclude" && type !== "UseCaseExtend"
   )
 
-  // Midpoint + orientation derived purely from the two endpoints. A straight
-  // edge's middle is analytic, so it is computed synchronously, DOM-free, and
-  // export-stable.
+  // Arc midpoint + local orientation derived from the routed polyline. This stays
+  // synchronous, DOM-free, and export-stable while following obstacle detours and
+  // authored waypoints rather than the endpoint chord.
+  const middleSegment = useMemo(
+    () =>
+      getStraightMidSegment(
+        renderPoints,
+        renderPoints[0],
+        renderPoints[renderPoints.length - 1]
+      ),
+    [renderPoints]
+  )
   const { point: pathMiddlePosition, isHorizontal: isMiddlePathHorizontal } =
-    useMemo(
-      () => getMidSegment(renderPoints, renderPoints[0], renderPoints[1]),
-      [renderPoints]
-    )
+    middleSegment
 
+  // A bent edge (interior waypoints or a bridged crossing) draws its polyline via
+  // buildEdgePath; a plain 2-point edge keeps calculateStraightPath so the marker
+  // padding / include-extend gap on its single segment is byte-identical to before.
+  const isPolyline = renderPoints.length > 2 || lineJumps.length > 0
   const currentPath = useMemo(() => {
-    if (lineJumps.length > 0) return buildEdgePath(renderPoints, lineJumps)
+    if (isPolyline)
+      return buildEdgePath(
+        renderPoints,
+        lineJumps,
+        type === "UseCaseInclude" || type === "UseCaseExtend"
+          ? {
+              segmentIndex: middleSegment.segmentIndex,
+              center: middleSegment.point,
+              halfSize: 40,
+            }
+          : undefined
+      )
     return calculateStraightPath(
       renderPoints[0].x,
       renderPoints[0].y,
@@ -389,28 +488,43 @@ export const useStraightPathEdge = ({
       renderPoints[1].y,
       type
     )
-  }, [renderPoints, type, lineJumps])
+  }, [renderPoints, type, lineJumps, isPolyline, middleSegment])
 
   const overlayPath = useMemo(() => {
-    // When bridging, the arc'd path is the hit target too, so the selectable
-    // stroke matches exactly what's drawn.
-    if (lineJumps.length > 0) return currentPath
+    const overlayPoints = trimOverlayEndpoints(renderPoints)
+    if (lineJumps.length > 0) return buildEdgePath(overlayPoints, lineJumps)
+    if (renderPoints.length > 2) return buildEdgePath(overlayPoints, [])
     return calculateOverlayPath(
-      renderPoints[0].x,
-      renderPoints[0].y,
-      renderPoints[1].x,
-      renderPoints[1].y,
+      overlayPoints[0].x,
+      overlayPoints[0].y,
+      overlayPoints[1].x,
+      overlayPoints[1].y,
       type
     )
-  }, [renderPoints, type, currentPath, lineJumps])
+  }, [renderPoints, type, lineJumps])
 
-  const [sourcePoint, targetPoint] = renderPoints
+  const sourcePoint = renderPoints[0]
+  const targetPoint = renderPoints[renderPoints.length - 1]
+  // Every authored bend is editable. Automatic detours are introduced by the
+  // separate auto-layout/routing change and can later reuse the same controls.
+  const editableWaypoints = useMemo<IPoint[]>(
+    () => (dragHandleRoute ?? renderPoints).slice(1, -1),
+    [dragHandleRoute, renderPoints]
+  )
+  const waypointHandleRoute = dragHandleRoute ?? renderPoints
+  const sourceNeighbor = renderPoints[1]
+  const targetNeighbor = renderPoints[renderPoints.length - 2]
   // Always: a straight edge has no bend handles, so a minimum-length gate would
   // leave short ones with no editable affordance at all.
   const canEditEndpoint = true
   const toolbarPosition = computeToolbarPosition(
     pathMiddlePosition,
-    isMiddlePathHorizontal
+    isMiddlePathHorizontal,
+    // A waypoint can sit exactly at the route's arc midpoint. The standard
+    // edge-toolbar offset was designed around step segments and lets the taller
+    // three-action toolbar cover that circular grip, making it impossible to
+    // pick up again. Keep the toolbar one handle target farther off the route.
+    EDGES.WAYPOINT_HIT_TARGET_PX + EDGES.WAYPOINT_HANDLE_RADIUS_PX * 2
   )
 
   const edgeData: StraightPathEdgeData = {
@@ -419,6 +533,8 @@ export const useStraightPathEdge = ({
     isMiddlePathHorizontal,
     sourcePoint,
     targetPoint,
+    labelSourcePoint: middleSegment.start,
+    labelTargetPoint: middleSegment.end,
   }
 
   const { getNodeRect, findFreeformEndpointNode } = useFreeformEndpointNode()
@@ -436,8 +552,8 @@ export const useStraightPathEdge = ({
       setEndpointPreviewCommit(null)
 
       const ownerDocument = event.currentTarget.ownerDocument
-      const currentSourceEndpoint = basePoints[0]
-      const currentTargetEndpoint = basePoints[1]
+      const currentSourceEndpoint = sourcePoint
+      const currentTargetEndpoint = targetPoint
 
       const resolveDragCommit = (
         clientX: number,
@@ -544,7 +660,12 @@ export const useStraightPathEdge = ({
         endpointDragCommitRef.current = commit
         setEndpointPreviewCommit(commit)
         if (commit) {
-          setDragPreviewPoints([commit.sourceEndpoint, commit.targetEndpoint])
+          // Reconnecting an endpoint preserves authored interior waypoints.
+          setDragPreviewPoints([
+            commit.sourceEndpoint,
+            ...interiorPoints,
+            commit.targetEndpoint,
+          ])
           setDragPreviewPositions({
             sourcePosition: commit.sourcePosition,
             targetPosition: commit.targetPosition,
@@ -558,8 +679,8 @@ export const useStraightPathEdge = ({
         const flowPoint = screenToFlowPosition({ x: e.clientX, y: e.clientY })
         setDragPreviewPoints(
           endpoint === "source"
-            ? [flowPoint, currentTargetEndpoint]
-            : [currentSourceEndpoint, flowPoint]
+            ? [flowPoint, ...interiorPoints, currentTargetEndpoint]
+            : [currentSourceEndpoint, ...interiorPoints, flowPoint]
         )
         setDragPreviewPositions(null)
       }
@@ -635,7 +756,9 @@ export const useStraightPathEdge = ({
       ownerDocument.addEventListener("pointercancel", handlePointerCancel)
     },
     [
-      basePoints,
+      sourcePoint,
+      targetPoint,
+      interiorPoints,
       data,
       findFreeformEndpointNode,
       getIntersectingNodes,
@@ -654,6 +777,275 @@ export const useStraightPathEdge = ({
     ]
   )
 
+  // Persist the interior waypoints and pin their visible endpoints when the first
+  // bend is authored. This mirrors the step-edge bend-commit behaviour and keeps
+  // later geometry updates from moving a hand-shaped route at its ends.
+  const commitWaypoints = useCallback(
+    (nextInterior: IPoint[], pinSource: IPoint, pinTarget: IPoint) => {
+      setEdges((edges) =>
+        edges.map((edge) => {
+          if (edge.id !== id) return edge
+          const nextData: Record<string, unknown> = {
+            ...((edge.data ?? {}) as Record<string, unknown>),
+            points: nextInterior,
+          }
+          if (nextInterior.length > 0) {
+            if (!isFreeformEdgeAnchor(sourceAnchor) && sourceRect) {
+              const anchor = getEdgeAnchorFromPoint(
+                sourceNode?.type,
+                pinSource,
+                sourceRect
+              )
+              if (anchor) nextData.sourceAnchor = anchor
+            }
+            if (!isFreeformEdgeAnchor(targetAnchor) && targetRect) {
+              const anchor = getEdgeAnchorFromPoint(
+                targetNode?.type,
+                pinTarget,
+                targetRect
+              )
+              if (anchor) nextData.targetAnchor = anchor
+            }
+          }
+          return { ...edge, data: nextData }
+        })
+      )
+    },
+    [
+      id,
+      setEdges,
+      sourceAnchor,
+      targetAnchor,
+      sourceRect,
+      targetRect,
+      sourceNode?.type,
+      targetNode?.type,
+    ]
+  )
+
+  // Shared drag routine for both an existing waypoint and a freshly materialised
+  // one. `startInterior` is the interior array the drag operates on; `index` is the
+  // waypoint being moved. Only pointer-up commits `data.points`.
+  const beginWaypointDrag = useCallback(
+    (
+      pointerId: number,
+      pointerTarget: SVGRectElement,
+      index: number,
+      startInterior: IPoint[]
+    ) => {
+      if (!pointerTarget.hasPointerCapture(pointerId))
+        pointerTarget.setPointerCapture(pointerId)
+      const ownerDocument = pointerTarget.ownerDocument
+      dragInteriorRef.current = startInterior
+      dragMovedRef.current = false
+      dragCollapseRef.current = false
+      // Capture the endpoints at gesture start so the preview and eventual commit
+      // pivot around stable attachment sites.
+      const routeSource = sourcePoint
+      const routeTarget = targetPoint
+      const collapseTolerance =
+        EDGES.WAYPOINT_COLLAPSE_SNAP_SCREEN_PX / Math.max(getZoom(), 0.01)
+      const routeAtStart = [routeSource, ...startInterior, routeTarget]
+      // Match tldraw's stable "next vertex first" reference rule. The final
+      // waypoint falls back to its previous neighbour.
+      const angleReference = routeAtStart[index + 2] ?? routeAtStart[index]
+
+      // Drive the preview through state; the existing layout effect republishes it
+      // to shared edge geometry and clears it when the drag ends.
+      const publish = (
+        pathInterior: IPoint[],
+        handleInterior: IPoint[] = pathInterior
+      ) => {
+        setDragPreviewPoints([routeSource, ...pathInterior, routeTarget])
+        setDragHandleRoute([routeSource, ...handleInterior, routeTarget])
+      }
+      // Seed the preview so the edge does not flicker to its committed shape on the
+      // first frame (the inserted point starts on the segment).
+      publish(dragInteriorRef.current)
+
+      const handlePointerMove = (e: PointerEvent) => {
+        if (e.pointerId !== pointerId) return
+        const flowPoint = screenToFlowPosition({ x: e.clientX, y: e.clientY })
+        const candidate = e.shiftKey
+          ? snapPointToAngle(flowPoint, angleReference)
+          : flowPoint
+        dragInteriorRef.current = moveWaypoint(
+          dragInteriorRef.current,
+          index,
+          candidate,
+          e.shiftKey ? 1 : EDGES.BEND_SNAP_GRID_PX
+        )
+        dragMovedRef.current = true
+        dragCollapseRef.current = isWaypointCollapseCandidate(
+          [routeSource, ...dragInteriorRef.current, routeTarget],
+          index + 1,
+          dragInteriorRef.current[index],
+          collapseTolerance
+        )
+        // Visibly straighten while inside the magnetic band. The document-level
+        // listeners keep the gesture alive while its handle is absent, so moving
+        // away restores the bend naturally.
+        publish(
+          dragCollapseRef.current
+            ? removeWaypoint(dragInteriorRef.current, index)
+            : dragInteriorRef.current,
+          dragInteriorRef.current
+        )
+      }
+
+      const teardown = () => {
+        ownerDocument.removeEventListener("pointermove", handlePointerMove)
+        ownerDocument.removeEventListener("pointerup", handlePointerUp)
+        ownerDocument.removeEventListener("pointercancel", handlePointerCancel)
+        if (pointerTarget.hasPointerCapture(pointerId))
+          pointerTarget.releasePointerCapture(pointerId)
+        if (activePointerTeardownRef.current === teardown) {
+          activePointerTeardownRef.current = null
+          activePointerCancelRef.current = null
+        }
+      }
+
+      const handlePointerCancel = (e?: PointerEvent) => {
+        if (e && e.pointerId !== pointerId) return
+        setDragPreviewPoints(null)
+        setDragHandleRoute(null)
+        teardown()
+      }
+
+      const handlePointerUp = (e: PointerEvent) => {
+        if (e.pointerId !== pointerId) return
+        setDragPreviewPoints(null)
+        setDragHandleRoute(null)
+        // Drag-to-collinear removes redundant bends (incl. the dragged one).
+        const releasedInterior = dragCollapseRef.current
+          ? removeWaypoint(dragInteriorRef.current, index)
+          : dragInteriorRef.current
+        const pruned = pruneCollinearWaypoints([
+          routeSource,
+          ...releasedInterior,
+          routeTarget,
+        ])
+        // Only persist when the geometry actually changed (a click that never
+        // moved must not freeze a fresh point into the model).
+        if (dragMovedRef.current || pruned.length !== startInterior.length) {
+          commitWaypoints(pruned, routeSource, routeTarget)
+        }
+        setSelectedWaypointIndex(null)
+        teardown()
+      }
+
+      activePointerCancelRef.current = handlePointerCancel
+      activePointerTeardownRef.current = teardown
+      ownerDocument.addEventListener("pointermove", handlePointerMove)
+      ownerDocument.addEventListener("pointerup", handlePointerUp)
+      ownerDocument.addEventListener("pointercancel", handlePointerCancel)
+    },
+    [commitWaypoints, getZoom, screenToFlowPosition, sourcePoint, targetPoint]
+  )
+
+  const handleWaypointPointerDown = useCallback(
+    (event: ReactPointerEvent<SVGRectElement>, index: number) => {
+      if (!event.isPrimary || event.button !== 0) return
+      event.preventDefault()
+      event.stopPropagation()
+      event.currentTarget.focus()
+      activePointerCancelRef.current?.()
+      setSelectedWaypointIndex(index)
+      beginWaypointDrag(
+        event.pointerId,
+        event.currentTarget,
+        index,
+        editableWaypoints
+      )
+    },
+    [beginWaypointDrag, editableWaypoints]
+  )
+
+  // A ghost midpoint materialises a new waypoint only once the pointer has moved
+  // past the threshold (so a stray tap never litters the edge with points); the
+  // gesture then continues as an ordinary waypoint drag on the new point.
+  const handleGhostPointerDown = useCallback(
+    (event: ReactPointerEvent<SVGRectElement>, segmentIndex: number) => {
+      if (!event.isPrimary || event.button !== 0) return
+      event.preventDefault()
+      event.stopPropagation()
+      activePointerCancelRef.current?.()
+      const pointerId = event.pointerId
+      const pointerTarget = event.currentTarget
+      pointerTarget.setPointerCapture(pointerId)
+      const ownerDocument = pointerTarget.ownerDocument
+      const origin = screenToFlowPosition({
+        x: event.clientX,
+        y: event.clientY,
+      })
+
+      const cleanup = () => {
+        ownerDocument.removeEventListener("pointermove", handleFirstMove)
+        ownerDocument.removeEventListener("pointerup", handleEnd)
+        ownerDocument.removeEventListener("pointercancel", handleEnd)
+        if (pointerTarget.hasPointerCapture(pointerId))
+          pointerTarget.releasePointerCapture(pointerId)
+        if (activePointerTeardownRef.current === cleanup) {
+          activePointerTeardownRef.current = null
+          activePointerCancelRef.current = null
+        }
+      }
+
+      const handleFirstMove = (e: PointerEvent) => {
+        if (e.pointerId !== pointerId) return
+        const flowPoint = screenToFlowPosition({ x: e.clientX, y: e.clientY })
+        if (!exceedsDragThreshold(origin, flowPoint)) return
+        cleanup()
+        const seeded = insertWaypoint(
+          editableWaypoints,
+          segmentIndex,
+          snapPoint(flowPoint)
+        )
+        setSelectedWaypointIndex(segmentIndex)
+        // Hand off to the shared drag routine on the same pointer/element.
+        beginWaypointDrag(pointerId, pointerTarget, segmentIndex, seeded)
+      }
+
+      const handleEnd = (e: PointerEvent) => {
+        if (e.pointerId !== pointerId) return
+        cleanup()
+      }
+
+      activePointerCancelRef.current = cleanup
+      activePointerTeardownRef.current = cleanup
+      ownerDocument.addEventListener("pointermove", handleFirstMove)
+      ownerDocument.addEventListener("pointerup", handleEnd)
+      ownerDocument.addEventListener("pointercancel", handleEnd)
+    },
+    [beginWaypointDrag, editableWaypoints, screenToFlowPosition]
+  )
+
+  const handleWaypointDoubleClick = useCallback(
+    (index: number) => {
+      commitWaypoints(
+        pruneCollinearWaypoints([
+          sourcePoint,
+          ...removeWaypoint(editableWaypoints, index),
+          targetPoint,
+        ]),
+        sourcePoint,
+        targetPoint
+      )
+      setSelectedWaypointIndex(null)
+    },
+    [editableWaypoints, commitWaypoints, sourcePoint, targetPoint]
+  )
+
+  const handleWaypointKeyDown = useCallback(
+    (event: ReactKeyboardEvent<SVGRectElement>, index: number) => {
+      if (event.key !== "Delete" && event.key !== "Backspace") return
+      event.preventDefault()
+      event.stopPropagation()
+      handleWaypointDoubleClick(index)
+    },
+    [handleWaypointDoubleClick]
+  )
+
   return {
     pathRef,
     edgeData,
@@ -664,9 +1056,18 @@ export const useStraightPathEdge = ({
     strokeDashArray,
     sourcePoint,
     targetPoint,
+    sourceNeighbor,
+    targetNeighbor,
+    route: waypointHandleRoute,
+    interior: editableWaypoints,
+    selectedWaypointIndex,
     isDiagramModifiable,
     canEditEndpoint,
     handleEndpointPointerDown,
+    handleWaypointPointerDown,
+    handleGhostPointerDown,
+    handleWaypointDoubleClick,
+    handleWaypointKeyDown,
     sourcePosition: renderSourcePosition,
     targetPosition: renderTargetPosition,
   }

--- a/library/lib/i18n/labels.ts
+++ b/library/lib/i18n/labels.ts
@@ -21,6 +21,10 @@ export interface ApollonLabels {
   redoHint: string
   multiSelection: string
   multiSelectionHint: string
+  /** Accessible name for a straight-edge segment midpoint create handle. */
+  addEdgeWaypoint: string
+  /** Accessible name for an authored straight-edge waypoint handle. */
+  moveEdgeWaypoint: string
 
   // Minimap
   miniMap: string
@@ -307,6 +311,9 @@ export const DEFAULT_LABELS: ApollonLabels = Object.freeze<ApollonLabels>({
   redoHint: "Redo (Ctrl+Y or Ctrl+Shift+Z)",
   multiSelection: "Select multiple elements",
   multiSelectionHint: "Select multiple: click elements to add or remove",
+  addEdgeWaypoint: "Drag to add a waypoint",
+  moveEdgeWaypoint:
+    "Waypoint: drag to move, double-click or press Delete to remove",
   miniMap: "Mini map",
   showMinimap: "Show minimap",
   showMinimapHint: "Show minimap (overview)",

--- a/library/lib/i18n/labels.ts
+++ b/library/lib/i18n/labels.ts
@@ -21,10 +21,12 @@ export interface ApollonLabels {
   redoHint: string
   multiSelection: string
   multiSelectionHint: string
-  /** Accessible name for a straight-edge segment midpoint create handle. */
-  addEdgeWaypoint: string
-  /** Accessible name for an authored straight-edge waypoint handle. */
-  moveEdgeWaypoint: string
+  /**
+   * Accessible name for an authored straight-edge waypoint handle.
+   * Optional so a complete dictionary written against an older library release
+   * remains assignable; {@link mergeLabels} always fills the English default.
+   */
+  moveEdgeWaypoint?: string
 
   // Minimap
   miniMap: string
@@ -297,8 +299,14 @@ function defaultNodeTypeLabel(nodeType?: string): string {
     .trim()
 }
 
+/**
+ * The fully resolved dictionary used inside the editor. Public host dictionaries
+ * may omit keys added in later minor releases; merging always restores them.
+ */
+export type ResolvedApollonLabels = Required<ApollonLabels>
+
 /** The shipped English strings — the fallback for any key a host doesn't override. */
-export const DEFAULT_LABELS: ApollonLabels = Object.freeze<ApollonLabels>({
+const RESOLVED_DEFAULT_LABELS: ResolvedApollonLabels = Object.freeze({
   zoomToolbar: "Zoom, history and selection controls",
   zoomIn: "Zoom in",
   zoomOut: "Zoom out",
@@ -311,7 +319,6 @@ export const DEFAULT_LABELS: ApollonLabels = Object.freeze<ApollonLabels>({
   redoHint: "Redo (Ctrl+Y or Ctrl+Shift+Z)",
   multiSelection: "Select multiple elements",
   multiSelectionHint: "Select multiple: click elements to add or remove",
-  addEdgeWaypoint: "Drag to add a waypoint",
   moveEdgeWaypoint:
     "Waypoint: drag to move, double-click or press Delete to remove",
   miniMap: "Mini map",
@@ -512,8 +519,17 @@ export const DEFAULT_LABELS: ApollonLabels = Object.freeze<ApollonLabels>({
   nodeWord: "node",
 })
 
+/**
+ * Publicly retain the historical `ApollonLabels` type. The value is fully
+ * populated, but consumers that used `typeof DEFAULT_LABELS` for a translation
+ * dictionary must not acquire new required keys in a minor release.
+ */
+export const DEFAULT_LABELS: ApollonLabels = RESOLVED_DEFAULT_LABELS
+
 /** Merge a host's partial overrides over the English defaults (shallow, per key). */
 export const mergeLabels = (
   overrides?: Partial<ApollonLabels>
-): ApollonLabels =>
-  overrides ? { ...DEFAULT_LABELS, ...overrides } : DEFAULT_LABELS
+): ResolvedApollonLabels =>
+  overrides
+    ? { ...RESOLVED_DEFAULT_LABELS, ...overrides }
+    : RESOLVED_DEFAULT_LABELS

--- a/library/lib/store/metadataStore.ts
+++ b/library/lib/store/metadataStore.ts
@@ -6,7 +6,7 @@ import { getDiagramMetadata, STORE_ORIGIN } from "@/sync/ydoc"
 import { UMLDiagramType } from "@/types"
 import { ApollonMode, ApollonView } from "@/typings"
 import { IPoint } from "@/edges/Connection"
-import { DEFAULT_LABELS, type ApollonLabels } from "@/i18n/labels"
+import { mergeLabels, type ResolvedApollonLabels } from "@/i18n/labels"
 import type { Edge } from "@xyflow/react"
 import { DISABLED_TAG_CONFIG, type TagConfig } from "@/utils/tagUtils"
 
@@ -45,7 +45,7 @@ export type MetadataStore = {
   /** Whether the editor answers `APOLLON_SHORTCUTS` at all. */
   keyboardShortcuts: boolean
   /** User-facing strings for the editor's own chrome; host-overridable for i18n. */
-  labels: ApollonLabels
+  labels: ResolvedApollonLabels
   /** Element-tag authoring config; disabled until a host opts in. */
   tagConfig: TagConfig
   scrollEnabled: boolean
@@ -73,7 +73,7 @@ export type MetadataStore = {
   setScrollLock: (scrollLock: boolean) => void
   setMultiSelectionMode: (multiSelectionMode: boolean) => void
   setKeyboardShortcuts: (keyboardShortcuts: boolean) => void
-  setLabels: (labels: ApollonLabels) => void
+  setLabels: (labels: ResolvedApollonLabels) => void
   setTagConfig: (tagConfig: TagConfig) => void
   setScrollEnabled: (scrollEnabled: boolean) => void
   startConnectionGuidance: (
@@ -101,7 +101,7 @@ type InitialMetadataState = {
   scrollLock: boolean
   multiSelectionMode: boolean
   keyboardShortcuts: boolean
-  labels: ApollonLabels
+  labels: ResolvedApollonLabels
   tagConfig: TagConfig
   scrollEnabled: boolean
   connectionGuidanceActive: boolean
@@ -124,7 +124,7 @@ const initialMetadataState: InitialMetadataState = {
   scrollLock: false,
   multiSelectionMode: false,
   keyboardShortcuts: true,
-  labels: DEFAULT_LABELS,
+  labels: mergeLabels(),
   tagConfig: DISABLED_TAG_CONFIG,
   scrollEnabled: false,
   connectionGuidanceActive: false,

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -988,6 +988,44 @@
   fill: color-mix(in srgb, var(--apollon-primary, #3e8acc) 70%, #000);
 }
 
+/* Straight-edge WAYPOINT handles: a round grip on the point itself, since a straight
+   edge is edited by moving points rather than by sliding segments. Hidden until the
+   edge is hovered or selected, like every other edge handle. A "proposed" handle sits
+   at a segment midpoint and is drawn faint — it is not a waypoint until dragged. */
+.edge-waypoint-handle {
+  opacity: 0;
+  fill: var(--apollon-primary, #3e8acc);
+  stroke: var(--apollon-primary, #3e8acc);
+  paint-order: stroke;
+  transition:
+    fill 120ms ease,
+    opacity 120ms ease,
+    stroke 120ms ease;
+}
+
+.react-flow__edge:hover .edge-waypoint-handle,
+.react-flow__edge.selected .edge-waypoint-handle {
+  opacity: 1;
+}
+
+.react-flow__edge:hover .edge-waypoint-handle--proposed,
+.react-flow__edge.selected .edge-waypoint-handle--proposed {
+  opacity: 0.34;
+}
+
+.edge-waypoint-handle--active,
+.react-flow__edge .edge-waypoint-handle:hover,
+.react-flow__edge
+  g:has(.edge-waypoint-hit-target:focus-visible)
+  .edge-waypoint-handle {
+  opacity: 1;
+  fill: color-mix(in srgb, var(--apollon-primary, #3e8acc) 70%, #000);
+}
+
+.edge-waypoint-hit-target:active {
+  cursor: grabbing !important;
+}
+
 .react-flow__edge:hover .edge-overlay {
   opacity: 0;
 }

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -988,10 +988,10 @@
   fill: color-mix(in srgb, var(--apollon-primary, #3e8acc) 70%, #000);
 }
 
-/* Straight-edge WAYPOINT handles: a round grip on the point itself, since a straight
-   edge is edited by moving points rather than by sliding segments. Hidden until the
-   edge is hovered or selected, like every other edge handle. A "proposed" handle sits
-   at a segment midpoint and is drawn faint — it is not a waypoint until dragged. */
+/* Straight-edge WAYPOINT handles follow the step-edge handle state model: hidden
+   until the edge is hovered/selected, then fully opaque primary blue. A midpoint
+   create handle is an actionable bend handle too, so fading it made the two edge
+   regimes feel inconsistent and falsely suggested that it was disabled. */
 .edge-waypoint-handle {
   opacity: 0;
   fill: var(--apollon-primary, #3e8acc);
@@ -1008,18 +1008,25 @@
   opacity: 1;
 }
 
-.react-flow__edge:hover .edge-waypoint-handle--proposed,
-.react-flow__edge.selected .edge-waypoint-handle--proposed {
-  opacity: 0.34;
-}
-
 .edge-waypoint-handle--active,
-.react-flow__edge .edge-waypoint-handle:hover,
 .react-flow__edge
-  g:has(.edge-waypoint-hit-target:focus-visible)
+  g:has(
+    .edge-waypoint-hit-target:hover,
+    .edge-waypoint-hit-target:focus-visible,
+    .edge-waypoint-hit-target:active
+  )
   .edge-waypoint-handle {
   opacity: 1;
   fill: color-mix(in srgb, var(--apollon-primary, #3e8acc) 70%, #000);
+}
+
+.edge-waypoint-hit-target,
+.edge-waypoint-hit-target:focus,
+.edge-waypoint-hit-target:focus-visible {
+  /* SVG focus defaults outline the entire invisible 24px hit rectangle. Keep
+     keyboard focus visible through the darkened circle above, not a browser-
+     specific square/ring that no step-edge handle has. */
+  outline: none;
 }
 
 .edge-waypoint-hit-target:active {

--- a/library/lib/typings.ts
+++ b/library/lib/typings.ts
@@ -105,7 +105,12 @@ export type ApollonNode = {
 
 export interface OrthogonalEdgeData {
   [key: string]: unknown
-  // Manual waypoint array used by the step-path edges.
+  // Manual waypoint array. Its semantics differ by edge regime:
+  //  • step (orthogonal) edges store the FULL committed route (endpoints included),
+  //    re-projected by the solver;
+  //  • straight-hook edges (use-case, syntax-tree, petri-net) store INTERIOR
+  //    waypoints ONLY (JointJS "vertices" model) — the route is
+  //    [source, ...points, target] connected by plain diagonal segments.
   points: IPoint[]
 }
 

--- a/library/lib/utils/geometry/bendHandles.ts
+++ b/library/lib/utils/geometry/bendHandles.ts
@@ -273,11 +273,16 @@ export function applyInnerSegmentBend(
 
 export function computeToolbarPosition(
   pathMiddlePosition: IPoint,
-  isMiddlePathHorizontal: boolean
+  isMiddlePathHorizontal: boolean,
+  extraClearance = 0
 ): IPoint {
   return {
-    x: pathMiddlePosition.x + (isMiddlePathHorizontal ? 0 : -52),
-    y: pathMiddlePosition.y + (isMiddlePathHorizontal ? -64 : 0),
+    x:
+      pathMiddlePosition.x +
+      (isMiddlePathHorizontal ? 0 : -52 - extraClearance),
+    y:
+      pathMiddlePosition.y +
+      (isMiddlePathHorizontal ? -64 - extraClearance : 0),
   }
 }
 

--- a/library/lib/utils/geometry/edgeGeometrySolver.ts
+++ b/library/lib/utils/geometry/edgeGeometrySolver.ts
@@ -276,6 +276,21 @@ function mergeManualPoints(
   return points
 }
 
+/** Straight-hook edges persist interior vertices only, unlike orthogonal edges
+ * whose manual points contain the full route. Keep that data contract visible to
+ * shared geometry so crossings and neighbouring routes see the authored bend. */
+function getStraightHookRoute(
+  edge: Edge,
+  endpoints: ResolvedEdgeEndpoints
+): IPoint[] {
+  const interior = edge.data?.points
+  return [
+    endpoints.adjustedSource,
+    ...(Array.isArray(interior) ? (interior as IPoint[]) : []),
+    endpoints.adjustedTarget,
+  ]
+}
+
 /**
  * A grid bucketing each already-routed edge's polyline by cell, so an edge finds
  * its nearby neighbours without scanning every routed edge (the walk is
@@ -1218,6 +1233,21 @@ function computeAllEdgeGeometryPass(
       reservedRouteById.set(edge.id, liveOverride.points)
       continue
     }
+    if (straightHookTypes.has(edge.type ?? "")) {
+      const endpoints = resolveEdgeEndpoints(
+        edge,
+        nodes,
+        nodeById,
+        nodeLookup,
+        connectionMode,
+        undefined,
+        undefined,
+        nodeIndex
+      )
+      if (endpoints)
+        reservedRouteById.set(edge.id, getStraightHookRoute(edge, endpoints))
+      continue
+    }
     const manual = edge.data?.points
     if (Array.isArray(manual) && manual.length >= 2) {
       const endpoints = resolveEdgeEndpoints(
@@ -1243,23 +1273,6 @@ function computeAllEdgeGeometryPass(
           : (manual as IPoint[])
       )
       continue
-    }
-    if (straightHookTypes.has(edge.type ?? "")) {
-      const endpoints = resolveEdgeEndpoints(
-        edge,
-        nodes,
-        nodeById,
-        nodeLookup,
-        connectionMode,
-        undefined,
-        undefined,
-        nodeIndex
-      )
-      if (endpoints)
-        reservedRouteById.set(edge.id, [
-          endpoints.adjustedSource,
-          endpoints.adjustedTarget,
-        ])
     }
   }
   const bandPorts = assignPorts(
@@ -1299,13 +1312,13 @@ function computeAllEdgeGeometryPass(
       continue
     }
 
-    // Straight-hook edges (use-case, syntax-tree, petri-net) are a plain line
-    // between the adjusted endpoints — no obstacle or neighbour routing — but
-    // their polyline still enters the map so step edges route around them.
+    // Straight-hook edges connect authored interior waypoints directly — no
+    // obstacle or neighbour routing — but their polyline still enters the map so
+    // crossings and neighbouring step edges see the same geometry users see.
     if (straightHookTypes.has(edge.type ?? "")) {
-      const line = [endpoints.adjustedSource, endpoints.adjustedTarget]
-      routeById[edge.id] = line
-      indexRoutePolyline(neighborGrid, edge.id, line)
+      const route = getStraightHookRoute(edge, endpoints)
+      routeById[edge.id] = route
+      indexRoutePolyline(neighborGrid, edge.id, route)
       continue
     }
 

--- a/library/lib/utils/geometry/edgeLabelLayout.ts
+++ b/library/lib/utils/geometry/edgeLabelLayout.ts
@@ -135,6 +135,62 @@ export function getMidSegment(
   }
 }
 
+/**
+ * Arc-length midpoint for an arbitrary-angle polyline. Unlike `getMidSegment`,
+ * this keeps the original segment indices (needed to carve a label gap in the
+ * rendered path) and uses Euclidean length, which is the visible length of a
+ * straight-hook segment rather than an orthogonal routing proxy.
+ */
+export function getStraightMidSegment(
+  renderPoints: IPoint[],
+  fallbackSource: IPoint,
+  fallbackTarget: IPoint
+): MidSegment {
+  const usable = renderPoints
+    .slice(1)
+    .map((end, index) => {
+      const start = renderPoints[index]
+      return {
+        start,
+        end,
+        segmentIndex: index,
+        length: Math.sqrt((end.x - start.x) ** 2 + (end.y - start.y) ** 2),
+      }
+    })
+    .filter((segment) => segment.length > 0)
+  if (usable.length === 0)
+    return getMidSegment(
+      [fallbackSource, fallbackTarget],
+      fallbackSource,
+      fallbackTarget
+    )
+
+  const total = usable.reduce((sum, segment) => sum + segment.length, 0)
+  const half = total / 2
+  let running = 0
+  let selected = usable[usable.length - 1]
+  for (const segment of usable) {
+    if (running + segment.length >= half) {
+      selected = segment
+      break
+    }
+    running += segment.length
+  }
+  const t = (half - running) / selected.length
+  const dx = selected.end.x - selected.start.x
+  const dy = selected.end.y - selected.start.y
+  return {
+    point: {
+      x: round(selected.start.x + dx * t),
+      y: round(selected.start.y + dy * t),
+    },
+    isHorizontal: Math.abs(dx) >= Math.abs(dy),
+    segmentIndex: selected.segmentIndex,
+    start: selected.start,
+    end: selected.end,
+  }
+}
+
 const rectsIntersect = (a: Rect, b: Rect): boolean =>
   a.x < b.x + b.width &&
   a.x + a.width > b.x &&
@@ -465,15 +521,16 @@ export interface RotatedLabelPlacement {
 export function computeUseCaseLabelLayout(
   source: IPoint,
   target: IPoint,
-  perpendicularOffset: number
+  perpendicularOffset: number,
+  anchor?: IPoint
 ): RotatedLabelPlacement {
   const dx = target.x - source.x
   const dy = target.y - source.y
   const angle = Math.atan2(dy, dx) * (180 / Math.PI)
   const rotation = angle > 90 || angle < -90 ? angle + 180 : angle
 
-  const midX = (source.x + target.x) / 2
-  const midY = (source.y + target.y) / 2
+  const midX = anchor?.x ?? (source.x + target.x) / 2
+  const midY = anchor?.y ?? (source.y + target.y) / 2
   const length = Math.sqrt(dx * dx + dy * dy)
   if (length === 0 || perpendicularOffset === 0) {
     return { x: midX, y: midY, rotation }

--- a/library/lib/utils/geometry/freeWaypoints.ts
+++ b/library/lib/utils/geometry/freeWaypoints.ts
@@ -1,0 +1,201 @@
+/**
+ * Free-2D waypoint geometry for straight (diagonal) edges.
+ *
+ * Unlike the orthogonal `bendHandles.ts` (H/V staircase jogs), a straight-hook
+ * edge bends at arbitrary 2D points. Following the JointJS "vertices" model, the
+ * persisted `data.points` for these edges holds INTERIOR waypoints ONLY; the
+ * rendered route is `[source, ...interior, target]`. This module owns the pure,
+ * deterministic math for editing that interior list.
+ *
+ * These are document data (authored, persisted), not memoryless auto-geometry, so
+ * they need not be byte-identical across engines — but we still keep the math
+ * integer/grid-snapped and use integer cross-products (never `atan2`) to match the
+ * rest of the geometry kernel and to snap cleanly onto the canvas grid.
+ */
+import { IPoint } from "@/edges/Connection"
+import { EDGES } from "@/utils/geometry/routingConstants"
+
+export interface SegmentGhostHandle {
+  /** Index of the route segment this ghost sits on: route[i] → route[i+1]. */
+  segmentIndex: number
+  /** Integer midpoint of the segment. */
+  position: IPoint
+  /** Squared length of the segment, so the renderer can hide a ghost on a stub. */
+  segmentLengthSq: number
+}
+
+const snap = (value: number, grid: number): number =>
+  grid > 0 ? Math.round(value / grid) * grid : Math.round(value)
+
+/** Snap a free 2D point to the bend grid. */
+export const snapPoint = (
+  point: IPoint,
+  grid: number = EDGES.BEND_SNAP_GRID_PX
+): IPoint => ({ x: snap(point.x, grid), y: snap(point.y, grid) })
+
+/**
+ * A faint ghost handle at the midpoint of every route segment. Dragging one past
+ * `exceedsDragThreshold` materialises a new interior waypoint (see `insertWaypoint`).
+ * Segments shorter than `WAYPOINT_GHOST_MIN_SEGMENT_PX` are skipped so a ghost never
+ * fuses with an endpoint or an adjacent waypoint handle.
+ */
+export const getSegmentGhostHandles = (
+  route: readonly IPoint[]
+): SegmentGhostHandle[] => {
+  const handles: SegmentGhostHandle[] = []
+  const minLenSq =
+    EDGES.WAYPOINT_GHOST_MIN_SEGMENT_PX * EDGES.WAYPOINT_GHOST_MIN_SEGMENT_PX
+  for (let i = 0; i < route.length - 1; i++) {
+    const a = route[i]
+    const b = route[i + 1]
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const lengthSq = dx * dx + dy * dy
+    if (lengthSq < minLenSq) continue
+    handles.push({
+      segmentIndex: i,
+      position: {
+        x: Math.round((a.x + b.x) / 2),
+        y: Math.round((a.y + b.y) / 2),
+      },
+      segmentLengthSq: lengthSq,
+    })
+  }
+  return handles
+}
+
+/**
+ * Materialise a new interior waypoint on route segment `segmentIndex`. Because the
+ * route is `[source, ...interior, target]`, segment `i` lies between `route[i]` and
+ * `route[i+1]`, so the new interior index is exactly `segmentIndex` (segment 0 →
+ * before the current first interior point; the last segment → appended).
+ */
+export const insertWaypoint = (
+  interior: readonly IPoint[],
+  segmentIndex: number,
+  point: IPoint,
+  grid: number = EDGES.BEND_SNAP_GRID_PX
+): IPoint[] => {
+  const index = Math.max(0, Math.min(segmentIndex, interior.length))
+  const next = interior.slice()
+  next.splice(index, 0, snapPoint(point, grid))
+  return next
+}
+
+/** Move interior waypoint `index` to a new (snapped) 2D point. */
+export const moveWaypoint = (
+  interior: readonly IPoint[],
+  index: number,
+  point: IPoint,
+  grid: number = EDGES.BEND_SNAP_GRID_PX
+): IPoint[] => {
+  if (index < 0 || index >= interior.length) return interior.slice()
+  const next = interior.slice()
+  next[index] = snapPoint(point, grid)
+  return next
+}
+
+/**
+ * Shift-drag angle lock, matching the 15° increments used by established canvas
+ * editors. `reference` remains the stable pivot for the whole gesture.
+ */
+export const snapPointToAngle = (
+  point: IPoint,
+  reference: IPoint,
+  divisions: number = 24
+): IPoint => {
+  const dx = point.x - reference.x
+  const dy = point.y - reference.y
+  const distance = Math.sqrt(dx * dx + dy * dy)
+  if (distance === 0 || divisions <= 0) return { ...reference }
+  const increment = (Math.PI * 2) / divisions
+  const angle = Math.round(Math.atan2(dy, dx) / increment) * increment
+  return {
+    x: Math.round(reference.x + Math.cos(angle) * distance),
+    y: Math.round(reference.y + Math.sin(angle) * distance),
+  }
+}
+
+/**
+ * Whether moving route vertex `routeIndex` to `point` would put it inside the
+ * magnetic straightening band around the finite chord between its neighbours.
+ * Projection is clamped to the segment so pulling beyond an endpoint cannot
+ * unexpectedly remove the waypoint.
+ */
+export const isWaypointCollapseCandidate = (
+  route: readonly IPoint[],
+  routeIndex: number,
+  point: IPoint,
+  tolerancePx: number
+): boolean => {
+  if (routeIndex <= 0 || routeIndex >= route.length - 1) return false
+  const before = route[routeIndex - 1]
+  const after = route[routeIndex + 1]
+  const dx = after.x - before.x
+  const dy = after.y - before.y
+  const lengthSq = dx * dx + dy * dy
+  if (lengthSq === 0) return true
+  const projection =
+    ((point.x - before.x) * dx + (point.y - before.y) * dy) / lengthSq
+  if (projection < 0 || projection > 1) return false
+  const distanceX = point.x - (before.x + projection * dx)
+  const distanceY = point.y - (before.y + projection * dy)
+  return (
+    distanceX * distanceX + distanceY * distanceY <= tolerancePx * tolerancePx
+  )
+}
+
+/** Remove interior waypoint `index`. */
+export const removeWaypoint = (
+  interior: readonly IPoint[],
+  index: number
+): IPoint[] => {
+  if (index < 0 || index >= interior.length) return interior.slice()
+  const next = interior.slice()
+  next.splice(index, 1)
+  return next
+}
+
+/**
+ * Continuous redundancy removal: drop any interior waypoint whose perpendicular
+ * distance from the line through its two route-neighbours is within tolerance
+ * (near-collinear). Uses an integer cross-product — no `atan2`/`hypot`: a point `c`
+ * is collinear with `a`,`b` when `cross(a,b,c)² <= tol² · |b-a|²`.
+ *
+ * Takes the full route `[source, ...interior, target]` so terminal waypoints are
+ * measured against the fixed endpoints; returns the pruned interior list.
+ */
+export const pruneCollinearWaypoints = (
+  route: readonly IPoint[],
+  tolerancePx: number = EDGES.WAYPOINT_COLLINEAR_TOLERANCE_PX
+): IPoint[] => {
+  if (route.length <= 2) return []
+  const tolSq = tolerancePx * tolerancePx
+  const kept: IPoint[] = [route[0]]
+  for (let i = 1; i < route.length - 1; i++) {
+    const a = kept[kept.length - 1]
+    const b = route[i]
+    const c = route[i + 1]
+    const abx = c.x - a.x
+    const aby = c.y - a.y
+    const spanSq = abx * abx + aby * aby
+    const cross = (b.x - a.x) * aby - (b.y - a.y) * abx
+    // Collinear (or a as good as on the a→c line): drop b. spanSq === 0 means the
+    // two neighbours coincide, so b is redundant regardless.
+    if (spanSq === 0 || cross * cross <= tolSq * spanSq) continue
+    kept.push(b)
+  }
+  // `kept` currently begins with the source; interior is everything after it.
+  return kept.slice(1)
+}
+
+/** Did the pointer travel far enough from a grabbed ghost to materialise a bend? */
+export const exceedsDragThreshold = (
+  from: IPoint,
+  to: IPoint,
+  thresholdPx: number = EDGES.WAYPOINT_DRAG_THRESHOLD_PX
+): boolean => {
+  const dx = to.x - from.x
+  const dy = to.y - from.y
+  return dx * dx + dy * dy > thresholdPx * thresholdPx
+}

--- a/library/lib/utils/geometry/freeWaypoints.ts
+++ b/library/lib/utils/geometry/freeWaypoints.ts
@@ -34,17 +34,18 @@ export const snapPoint = (
 ): IPoint => ({ x: snap(point.x, grid), y: snap(point.y, grid) })
 
 /**
- * A faint ghost handle at the midpoint of every route segment. Dragging one past
+ * A ghost handle at the midpoint of every route segment. Dragging one past
  * `exceedsDragThreshold` materialises a new interior waypoint (see `insertWaypoint`).
- * Segments shorter than `WAYPOINT_GHOST_MIN_SEGMENT_PX` are skipped so a ghost never
- * fuses with an endpoint or an adjacent waypoint handle.
+ * Short segments are skipped so a ghost never fuses with an endpoint or an adjacent
+ * waypoint handle. The renderer supplies a zoom-adjusted minimum; pure geometry
+ * callers default to the natural-scale value.
  */
 export const getSegmentGhostHandles = (
-  route: readonly IPoint[]
+  route: readonly IPoint[],
+  minimumSegmentLength: number = EDGES.WAYPOINT_GHOST_MIN_SEGMENT_PX
 ): SegmentGhostHandle[] => {
   const handles: SegmentGhostHandle[] = []
-  const minLenSq =
-    EDGES.WAYPOINT_GHOST_MIN_SEGMENT_PX * EDGES.WAYPOINT_GHOST_MIN_SEGMENT_PX
+  const minLenSq = minimumSegmentLength * minimumSegmentLength
   for (let i = 0; i < route.length - 1; i++) {
     const a = route[i]
     const b = route[i + 1]

--- a/library/lib/utils/geometry/routingConstants.ts
+++ b/library/lib/utils/geometry/routingConstants.ts
@@ -90,7 +90,8 @@ export const EDGES = Object.freeze({
   WAYPOINT_HANDLE_RADIUS_PX: 5,
   /** Invisible hit target around a waypoint handle (touch-friendly). */
   WAYPOINT_HIT_TARGET_PX: 24,
-  /** Shortest segment (flow px) that still shows a ghost midpoint handle, so two
-   * handles never fuse on a tiny segment. */
-  WAYPOINT_GHOST_MIN_SEGMENT_PX: 24,
+  /** Shortest segment at natural zoom that still shows a ghost midpoint handle.
+   * The renderer counter-scales this threshold below 1× so fixed-screen waypoint
+   * and endpoint targets retain distinct grab centres. */
+  WAYPOINT_GHOST_MIN_SEGMENT_PX: 64,
 } as const)

--- a/library/lib/utils/geometry/routingConstants.ts
+++ b/library/lib/utils/geometry/routingConstants.ts
@@ -76,4 +76,21 @@ export const EDGES = Object.freeze({
   LABEL_LINE_HEIGHT: 14,
   /** Nominal label half-width used by placement scoring. */
   LABEL_NOMINAL_HALF_EXTENT: 40,
+  /** Flow-space distance a straight-edge ghost midpoint must travel before it
+   * materialises a real waypoint (Excalidraw DRAGGING_THRESHOLD analogue). */
+  WAYPOINT_DRAG_THRESHOLD_PX: 6,
+  /** A straight-edge interior waypoint within this perpendicular distance of the
+   * line through its neighbours is treated as collinear and pruned. */
+  WAYPOINT_COLLINEAR_TOLERANCE_PX: 4,
+  /** Screen-space magnetic band around the neighbour-to-neighbour chord. Dragging
+   * a waypoint into this band previews its removal, so making a bent route straight
+   * again is a visible gesture rather than a release-time surprise. */
+  WAYPOINT_COLLAPSE_SNAP_SCREEN_PX: 10,
+  /** Radius of the round handle drawn on a route waypoint. */
+  WAYPOINT_HANDLE_RADIUS_PX: 5,
+  /** Invisible hit target around a waypoint handle (touch-friendly). */
+  WAYPOINT_HIT_TARGET_PX: 24,
+  /** Shortest segment (flow px) that still shows a ghost midpoint handle, so two
+   * handles never fuse on a tiny segment. */
+  WAYPOINT_GHOST_MIN_SEGMENT_PX: 24,
 } as const)

--- a/library/lib/utils/versionConverter.ts
+++ b/library/lib/utils/versionConverter.ts
@@ -5,6 +5,7 @@
  * isn't in scope here. */
 import type { UMLModel, ApollonNode, ApollonEdge, Assessment } from "../typings"
 import { transformEdges } from "../services/migration/EdgeTransformer"
+import { STRAIGHT_HOOK_EDGE_TYPES } from "../edges/edgeRoutingBehavior"
 import { UMLDiagramType } from "../types/DiagramType"
 import { ClassStereotype } from "../types/nodes/enums"
 import type { IPoint } from "../edges/Connection"
@@ -36,6 +37,12 @@ import type {
   ReachabilityGraphMarkingProps,
 } from "../types/nodes/NodeProps"
 import type { MessageData } from "@/edges/EdgeProps"
+
+/** Version 4.2 introduces authored INTERIOR waypoints for straight-hook edges.
+ * Earlier 4.x files stored a full computed/rendered route in `data.points`; those
+ * values must not be reinterpreted as user-authored bends. */
+export const CURRENT_MODEL_VERSION = "4.2.0" as const
+const STRAIGHT_WAYPOINT_MODEL_MINOR = 2
 
 function normalizeImportedInterfaceGeometry(
   nodeType: string,
@@ -745,6 +752,13 @@ function convertV3RelationshipToV4Edge(
       y: point.y + relationship.bounds.y,
     }))
   }
+  // Straight-hook edges (use-case, syntax-tree, petri-net) render as diagonal lines
+  // through INTERIOR waypoints only. The legacy v3 `path` is the full rendered
+  // polyline including endpoints and was inert for these types, so importing it as
+  // waypoints would sprout spurious (double-endpoint) bends. Clear it.
+  if (STRAIGHT_HOOK_EDGE_TYPES.has(edgeType as string)) {
+    points = []
+  }
 
   const edge: ApollonEdge = {
     id: relationship.id,
@@ -836,7 +850,7 @@ export function convertV3ToV4(v3Data: V3DiagramFormat | V3UMLModel): UMLModel {
   }
 
   return {
-    version: "4.0.0",
+    version: CURRENT_MODEL_VERSION,
     id,
     title,
     type: model.type as UMLDiagramType,
@@ -965,6 +979,31 @@ export function normalizeElementTags(model: UMLModel): UMLModel {
 }
 
 /**
+ * Clear pre-feature straight-edge route caches before they can become authored
+ * waypoints. Versions 4.0 and 4.1 used `data.points` as full rendered geometry for
+ * these edge types; 4.2 changes the same field to interior-only user intent.
+ *
+ * This mutates in place like the other import normalizers and is idempotent.
+ */
+export function normalizeStraightEdgeWaypoints(model: UMLModel): UMLModel {
+  const match = /^4\.(\d+)\.(\d+)$/.exec(model.version)
+  if (!match) return model
+  const minor = Number(match[1])
+  if (minor < STRAIGHT_WAYPOINT_MODEL_MINOR) {
+    for (const edge of model.edges) {
+      if (!STRAIGHT_HOOK_EDGE_TYPES.has(edge.type ?? "")) continue
+      const data = edge.data as
+        | (Record<string, unknown> & { points?: unknown })
+        | null
+        | undefined
+      if (data && Array.isArray(data.points)) data.points = []
+    }
+    model.version = CURRENT_MODEL_VERSION
+  }
+  return model
+}
+
+/**
  * Remove React Flow interaction state that older exports and captured fixtures
  * could persist. Imported models should contain only durable diagram data, not
  * the selection or drag state of the editor that produced the file.
@@ -1014,7 +1053,9 @@ function stripRuntimeInteractionState(model: UMLModel): UMLModel {
  */
 export function normalizeModel(model: UMLModel): UMLModel {
   return stripRuntimeInteractionState(
-    normalizeElementTags(normalizeClassStereotypes(model))
+    normalizeElementTags(
+      normalizeClassStereotypes(normalizeStraightEdgeWaypoints(model))
+    )
   )
 }
 

--- a/library/package.json
+++ b/library/package.json
@@ -80,7 +80,7 @@
     {
       "name": "main entry (published JS, deps externalized)",
       "path": "dist/index.js",
-      "limit": "118 kB",
+      "limit": "121 kB",
       "disablePlugins": [
         "@size-limit/webpack",
         "@size-limit/time"

--- a/library/tests/unit/EdgeEndpointMarkers.test.tsx
+++ b/library/tests/unit/EdgeEndpointMarkers.test.tsx
@@ -13,6 +13,7 @@ const renderEndpointMarkers = ({
   onEndpointPointerDown,
   sourcePoint = { x: 10, y: 20 },
   targetPoint = { x: 110, y: 120 },
+  straight = false,
 }: {
   isDiagramModifiable?: boolean
   canEditEndpoint?: boolean
@@ -21,6 +22,7 @@ const renderEndpointMarkers = ({
   >["onEndpointPointerDown"]
   sourcePoint?: { x: number; y: number }
   targetPoint?: { x: number; y: number }
+  straight?: boolean
 } = {}) =>
   render(
     <ReactFlowProvider>
@@ -34,7 +36,7 @@ const renderEndpointMarkers = ({
             isDiagramModifiable={isDiagramModifiable}
             canEditEndpoint={canEditEndpoint}
             onEndpointPointerDown={onEndpointPointerDown}
-            diagramType="step"
+            straight={straight}
           />
         </g>
       </svg>
@@ -115,7 +117,7 @@ describe("EdgeEndpointMarkers", () => {
     expect(sourceHandle).toHaveAttribute("pointer-events", "none")
   })
 
-  it("uses a larger invisible hit target for freeform endpoint dragging", () => {
+  it("uses a larger invisible hit target for endpoint dragging", () => {
     const { container } = renderEndpointMarkers({
       onEndpointPointerDown: vi.fn(),
     })
@@ -128,10 +130,30 @@ describe("EdgeEndpointMarkers", () => {
 
     expect(sourceHandle).toHaveAttribute("width", "44")
     expect(sourceHandle).toHaveAttribute("height", "44")
-    expect(sourceHandle).toHaveAttribute("x", "20")
+    expect(sourceHandle).toHaveAttribute("x", "10")
     expect(sourceHandle).toHaveAttribute("y", "-2")
-    expect(targetHandle).toHaveAttribute("x", "56")
+    expect(targetHandle).toHaveAttribute("x", "66")
     expect(targetHandle).toHaveAttribute("y", "98")
+  })
+
+  it("leaves a node-handle gap only for straight-edge endpoint dragging", () => {
+    const { container } = renderEndpointMarkers({
+      onEndpointPointerDown: vi.fn(),
+      sourcePoint: { x: 0, y: 0 },
+      targetPoint: { x: 100, y: 0 },
+      straight: true,
+    })
+    const sourceHandle = container.querySelector(
+      ".edge-endpoint-handle--source"
+    )
+    const targetHandle = container.querySelector(
+      ".edge-endpoint-handle--target"
+    )
+
+    expect(sourceHandle).toHaveAttribute("x", "10")
+    expect(sourceHandle).toHaveAttribute("y", "-22")
+    expect(targetHandle).toHaveAttribute("x", "46")
+    expect(targetHandle).toHaveAttribute("y", "-22")
   })
 
   it("anchors the visible endpoint grips to the endpoints, just clear of the heads", () => {

--- a/library/tests/unit/EdgeEndpointMarkers.test.tsx
+++ b/library/tests/unit/EdgeEndpointMarkers.test.tsx
@@ -128,9 +128,9 @@ describe("EdgeEndpointMarkers", () => {
 
     expect(sourceHandle).toHaveAttribute("width", "44")
     expect(sourceHandle).toHaveAttribute("height", "44")
-    expect(sourceHandle).toHaveAttribute("x", "10")
+    expect(sourceHandle).toHaveAttribute("x", "20")
     expect(sourceHandle).toHaveAttribute("y", "-2")
-    expect(targetHandle).toHaveAttribute("x", "66")
+    expect(targetHandle).toHaveAttribute("x", "56")
     expect(targetHandle).toHaveAttribute("y", "98")
   })
 

--- a/library/tests/unit/EdgeWaypointHandles.test.tsx
+++ b/library/tests/unit/EdgeWaypointHandles.test.tsx
@@ -1,0 +1,66 @@
+import { render } from "@testing-library/react"
+import { ReactFlowProvider } from "@xyflow/react"
+import { describe, expect, it, vi } from "vitest"
+import * as Y from "yjs"
+import { EdgeWaypointHandles } from "@/edges/GenericEdge"
+import { MetadataStoreContext } from "@/store/context"
+import { createMetadataStore } from "@/store/metadataStore"
+
+const renderHandles = ({
+  route,
+  interior,
+}: {
+  route: { x: number; y: number }[]
+  interior: { x: number; y: number }[]
+}) =>
+  render(
+    <MetadataStoreContext value={createMetadataStore(new Y.Doc())}>
+      <ReactFlowProvider>
+        <svg>
+          <EdgeWaypointHandles
+            route={route}
+            interior={interior}
+            selectedWaypointIndex={null}
+            onWaypointPointerDown={vi.fn()}
+            onWaypointDoubleClick={vi.fn()}
+            onWaypointKeyDown={vi.fn()}
+            onGhostPointerDown={vi.fn()}
+          />
+        </svg>
+      </ReactFlowProvider>
+    </MetadataStoreContext>
+  )
+
+describe("EdgeWaypointHandles", () => {
+  it("keeps pointer-only midpoint handles out of the keyboard tab order", () => {
+    const { container } = renderHandles({
+      route: [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+      ],
+      interior: [],
+    })
+    const midpoint = container.querySelector(".edge-waypoint-hit-target")
+
+    expect(midpoint).not.toHaveAttribute("tabindex")
+    expect(midpoint).not.toHaveAttribute("role")
+    expect(midpoint).not.toHaveAttribute("aria-label")
+  })
+
+  it("keeps authored waypoints keyboard focusable and named", () => {
+    const waypoint = { x: 50, y: 40 }
+    const { container } = renderHandles({
+      route: [{ x: 0, y: 0 }, waypoint, { x: 100, y: 0 }],
+      interior: [waypoint],
+    })
+    const target = container.querySelector(
+      '.edge-waypoint-hit-target[role="button"]'
+    )
+
+    expect(target).toHaveAttribute("tabindex", "0")
+    expect(target).toHaveAttribute(
+      "aria-label",
+      "Waypoint: drag to move, double-click or press Delete to remove"
+    )
+  })
+})

--- a/library/tests/unit/EdgeWaypointHandles.test.tsx
+++ b/library/tests/unit/EdgeWaypointHandles.test.tsx
@@ -45,6 +45,7 @@ describe("EdgeWaypointHandles", () => {
     expect(midpoint).not.toHaveAttribute("tabindex")
     expect(midpoint).not.toHaveAttribute("role")
     expect(midpoint).not.toHaveAttribute("aria-label")
+    expect(midpoint).toHaveStyle({ zIndex: 10001 })
   })
 
   it("keeps authored waypoints keyboard focusable and named", () => {

--- a/library/tests/unit/edgeGeometrySolver.test.ts
+++ b/library/tests/unit/edgeGeometrySolver.test.ts
@@ -209,6 +209,36 @@ describe("computeAllEdgeGeometry", () => {
     expect(routeById["e1"]).toHaveLength(2)
   })
 
+  it("publishes authored straight-hook waypoints as interior route vertices", () => {
+    const a = makeNode("a", 0, 0)
+    const b = makeNode("b", 300, 0)
+    const waypoint = { x: 180, y: 160 }
+    const nodeLookup = new Map<string, InternalNode>([
+      ["a", a.internal],
+      ["b", b.internal],
+    ])
+    const edges: Edge[] = [
+      {
+        id: "e1",
+        source: "a",
+        target: "b",
+        type: "SyntaxTreeLink",
+        data: { points: [waypoint] },
+      },
+    ]
+    const { routeById } = computeAllEdgeGeometry({
+      nodes: [a.node, b.node],
+      nodeLookup,
+      connectionMode: ConnectionMode.Loose,
+      edges,
+      straightPathTypes: STRAIGHT_PATH_STEP_EDGE_TYPES,
+      straightHookTypes: STRAIGHT_HOOK_EDGE_TYPES,
+    })
+
+    expect(routeById.e1).toHaveLength(3)
+    expect(routeById.e1[1]).toEqual(waypoint)
+  })
+
   it("routes all edges when their ids arrive out of order", () => {
     const a = makeNode("a", 0, 0)
     const b = makeNode("b", 300, 0)

--- a/library/tests/unit/edgeLabelLayout.test.ts
+++ b/library/tests/unit/edgeLabelLayout.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest"
 import {
   getMidSegment,
+  getStraightMidSegment,
   computeMiddleLabelLayout,
   computeUseCaseLabelLayout,
   collectNeighborPolylines,
@@ -92,6 +93,23 @@ describe("getMidSegment", () => {
     const mid = getMidSegment([p(0, 0), p(15, 0)], p(0, 0), p(15, 0))
     expect(Number.isInteger(mid.point.x)).toBe(true)
     expect(mid.point.x).toBe(8) // round(7.5)
+  })
+})
+
+describe("getStraightMidSegment", () => {
+  it("uses Euclidean arc length and returns the original local segment", () => {
+    const mid = getStraightMidSegment(
+      [p(0, 0), p(100, 0), p(100, 300)],
+      p(0, 0),
+      p(100, 300)
+    )
+    expect(mid).toEqual({
+      point: p(100, 100),
+      isHorizontal: false,
+      segmentIndex: 1,
+      start: p(100, 0),
+      end: p(100, 300),
+    })
   })
 })
 
@@ -248,6 +266,11 @@ describe("computeUseCaseLabelLayout", () => {
   it("keeps a moderate downward-right diagonal un-flipped", () => {
     const r = computeUseCaseLabelLayout(p(0, 0), p(100, 100), 0)
     expect(r.rotation).toBeCloseTo(45)
+  })
+
+  it("uses a local arc-mid anchor instead of the endpoint chord midpoint", () => {
+    const r = computeUseCaseLabelLayout(p(100, 0), p(100, 300), 0, p(100, 100))
+    expect(r).toEqual({ x: 100, y: 100, rotation: 90 })
   })
 })
 

--- a/library/tests/unit/freeWaypoints.test.ts
+++ b/library/tests/unit/freeWaypoints.test.ts
@@ -39,6 +39,12 @@ describe("freeWaypoints", () => {
       const ghosts = getSegmentGhostHandles(route)
       expect(ghosts.map((g) => g.segmentIndex)).toEqual([1])
     })
+    it("accepts the renderer's zoom-adjusted spacing threshold", () => {
+      const route = [p(0, 0), p(100, 0)]
+
+      expect(getSegmentGhostHandles(route, 101)).toEqual([])
+      expect(getSegmentGhostHandles(route, 100)).toHaveLength(1)
+    })
   })
 
   describe("insert/move/remove", () => {

--- a/library/tests/unit/freeWaypoints.test.ts
+++ b/library/tests/unit/freeWaypoints.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest"
+import {
+  exceedsDragThreshold,
+  getSegmentGhostHandles,
+  insertWaypoint,
+  isWaypointCollapseCandidate,
+  moveWaypoint,
+  pruneCollinearWaypoints,
+  removeWaypoint,
+  snapPoint,
+  snapPointToAngle,
+} from "@/utils/geometry/freeWaypoints"
+import { EDGES } from "@/utils/geometry/routingConstants"
+
+const p = (x: number, y: number) => ({ x, y })
+
+describe("freeWaypoints", () => {
+  describe("snapPoint", () => {
+    it("snaps to the bend grid", () => {
+      expect(snapPoint(p(11, 3), 5)).toEqual(p(10, 5))
+      expect(snapPoint(p(13, 7), 5)).toEqual(p(15, 5))
+    })
+    it("defaults to the configured grid and is deterministic", () => {
+      expect(snapPoint(p(2, 2))).toEqual(snapPoint(p(2, 2)))
+    })
+  })
+
+  describe("getSegmentGhostHandles", () => {
+    it("returns one integer midpoint per long-enough segment", () => {
+      const route = [p(0, 0), p(100, 0), p(100, 100)]
+      const ghosts = getSegmentGhostHandles(route)
+      expect(ghosts.map((g) => g.segmentIndex)).toEqual([0, 1])
+      expect(ghosts[0].position).toEqual(p(50, 0))
+      expect(ghosts[1].position).toEqual(p(100, 50))
+    })
+    it("skips segments shorter than the min length so handles never fuse", () => {
+      const short = EDGES.WAYPOINT_GHOST_MIN_SEGMENT_PX - 1
+      const route = [p(0, 0), p(short, 0), p(short + 100, 0)]
+      const ghosts = getSegmentGhostHandles(route)
+      expect(ghosts.map((g) => g.segmentIndex)).toEqual([1])
+    })
+  })
+
+  describe("insert/move/remove", () => {
+    it("inserts on segment i at interior index i", () => {
+      // route = [source, target]; segment 0 → interior index 0
+      expect(insertWaypoint([], 0, p(51, 49))).toEqual([p(50, 50)])
+      // route = [source, w0, target]; last segment index 1 → append
+      expect(insertWaypoint([p(50, 50)], 1, p(80, 20))).toEqual([
+        p(50, 50),
+        p(80, 20),
+      ])
+      // route = [source, w0, target]; segment 0 → before w0
+      expect(insertWaypoint([p(50, 50)], 0, p(20, 20))).toEqual([
+        p(20, 20),
+        p(50, 50),
+      ])
+    })
+    it("moves and snaps a waypoint, no-op out of range", () => {
+      expect(moveWaypoint([p(0, 0), p(50, 50)], 1, p(72, 68))).toEqual([
+        p(0, 0),
+        p(70, 70),
+      ])
+      expect(moveWaypoint([p(0, 0)], 5, p(1, 1))).toEqual([p(0, 0)])
+    })
+    it("removes a waypoint by index", () => {
+      expect(removeWaypoint([p(0, 0), p(1, 1), p(2, 2)], 1)).toEqual([
+        p(0, 0),
+        p(2, 2),
+      ])
+    })
+  })
+
+  describe("pruneCollinearWaypoints", () => {
+    it("drops a near-collinear interior point but keeps a genuine bend", () => {
+      const source = p(0, 0)
+      const target = p(100, 0)
+      // Exactly on the line → pruned.
+      expect(pruneCollinearWaypoints([source, p(50, 0), target])).toEqual([])
+      // Within tolerance → pruned.
+      expect(pruneCollinearWaypoints([source, p(50, 2), target])).toEqual([])
+      // A real bend survives.
+      expect(pruneCollinearWaypoints([source, p(50, 40), target])).toEqual([
+        p(50, 40),
+      ])
+    })
+    it("prunes a collinear point on a straight run but keeps the corner", () => {
+      // (50,0) lies on source→(100,0); (100,0) is a genuine corner into (100,50).
+      const route = [p(0, 0), p(50, 0), p(100, 0), p(100, 50)]
+      expect(pruneCollinearWaypoints(route)).toEqual([p(100, 0)])
+    })
+    it("returns [] for a two-point route", () => {
+      expect(pruneCollinearWaypoints([p(0, 0), p(10, 10)])).toEqual([])
+    })
+  })
+
+  describe("straightening and angle affordances", () => {
+    it("magnetically collapses only onto the finite neighbour chord", () => {
+      const route = [p(0, 0), p(50, 30), p(100, 0)]
+      expect(isWaypointCollapseCandidate(route, 1, p(50, 7), 8)).toBe(true)
+      expect(isWaypointCollapseCandidate(route, 1, p(50, 9), 8)).toBe(false)
+      expect(isWaypointCollapseCandidate(route, 1, p(120, 0), 8)).toBe(false)
+    })
+
+    it("locks a dragged waypoint to 15-degree increments around its neighbour", () => {
+      expect(snapPointToAngle(p(100, 5), p(0, 0))).toEqual(p(100, 0))
+      expect(snapPointToAngle(p(90, 52), p(0, 0))).toEqual(p(90, 52))
+    })
+  })
+
+  describe("exceedsDragThreshold", () => {
+    it("is false below and true above the threshold", () => {
+      const t = EDGES.WAYPOINT_DRAG_THRESHOLD_PX
+      expect(exceedsDragThreshold(p(0, 0), p(t - 1, 0))).toBe(false)
+      expect(exceedsDragThreshold(p(0, 0), p(t + 1, 0))).toBe(true)
+    })
+  })
+})

--- a/library/tests/unit/labels.test.ts
+++ b/library/tests/unit/labels.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest"
+import { DEFAULT_LABELS, mergeLabels } from "@/i18n/labels"
+
+describe("mergeLabels", () => {
+  it("fills labels introduced after a host's partial dictionary was written", () => {
+    const labels = mergeLabels({ zoomIn: "Vergrößern" })
+
+    expect(labels.zoomIn).toBe("Vergrößern")
+    expect(labels.moveEdgeWaypoint).toBe(DEFAULT_LABELS.moveEdgeWaypoint)
+  })
+})

--- a/library/tests/unit/legacyIosMigration.test.ts
+++ b/library/tests/unit/legacyIosMigration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { importDiagram } from "@/utils/versionConverter"
+import { CURRENT_MODEL_VERSION, importDiagram } from "@/utils/versionConverter"
 
 // ===========================================================================
 // Legacy Apollon iOS -> v4 migration fidelity
@@ -157,7 +157,7 @@ describe("legacy iOS class diagram", () => {
     expect(model.id).toBe("diagram-ClassDiagram")
     expect(model.title).toBe("My ClassDiagram")
     expect(model.type).toBe("ClassDiagram")
-    expect(model.version).toBe("4.0.0")
+    expect(model.version).toBe(CURRENT_MODEL_VERSION)
   })
 
   it("folds attribute/method children into the parent node (not standalone nodes)", () => {

--- a/library/tests/unit/useEdgeLineJumps.test.ts
+++ b/library/tests/unit/useEdgeLineJumps.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+import { buildEdgePath } from "@/hooks/useEdgeLineJumps"
+
+describe("buildEdgePath label gap", () => {
+  it("carves an include/extend gap from the local arc-mid segment", () => {
+    const path = buildEdgePath(
+      [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 300 },
+      ],
+      [],
+      {
+        segmentIndex: 1,
+        center: { x: 100, y: 100 },
+        halfSize: 40,
+      }
+    )
+    expect(path).toBe("M 0 0 L 100 0 L 100 60 M 100 140 L 100 300")
+  })
+
+  it("clamps the gap so a short segment never reverses", () => {
+    const path = buildEdgePath(
+      [
+        { x: 0, y: 0 },
+        { x: 20, y: 0 },
+      ],
+      [],
+      {
+        segmentIndex: 0,
+        center: { x: 10, y: 0 },
+        halfSize: 40,
+      }
+    )
+    expect(path).toBe("M 0 0 L 1 0 M 19 0 L 20 0")
+  })
+
+  it("keeps bridge jumps outside the label gap", () => {
+    const path = buildEdgePath(
+      [
+        { x: 0, y: 0 },
+        { x: 200, y: 0 },
+        { x: 200, y: 300 },
+      ],
+      [
+        {
+          segmentIndex: 0,
+          point: { x: 80, y: 0 },
+          orientation: "horizontal",
+        },
+      ],
+      {
+        segmentIndex: 1,
+        center: { x: 200, y: 100 },
+        halfSize: 40,
+      }
+    )
+    expect(path).toContain("L 72 0 Q 80 -10 88 0")
+    expect(path).toContain("L 200 60 M 200 140")
+  })
+
+  it("clamps against a nearby bend instead of reversing through it", () => {
+    const path = buildEdgePath(
+      [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 300 },
+      ],
+      [],
+      {
+        segmentIndex: 1,
+        center: { x: 100, y: 10 },
+        halfSize: 40,
+      }
+    )
+    expect(path).toBe("M 0 0 L 100 0 L 100 1 M 100 19 L 100 300")
+  })
+})

--- a/library/tests/unit/versionConverter.test.ts
+++ b/library/tests/unit/versionConverter.test.ts
@@ -1564,6 +1564,24 @@ describe("normalizeStraightEdgeWaypoints", () => {
     )
   })
 
+  it("does not rewrite or discard waypoints from a future v4 minor", () => {
+    const model = makeV4Model({
+      version: "4.9.0",
+      edges: [
+        {
+          id: "straight",
+          type: "UseCaseAssociation",
+          data: { points: [...points] },
+        },
+      ],
+    })
+    normalizeStraightEdgeWaypoints(model)
+    expect(model.version).toBe("4.9.0")
+    expect((model.edges[0].data as { points: unknown[] }).points).toEqual(
+      points
+    )
+  })
+
   it("runs on the universal import path", () => {
     const model = makeV4Model({
       version: "4.0.0",

--- a/library/tests/unit/versionConverter.test.ts
+++ b/library/tests/unit/versionConverter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest"
 import {
+  CURRENT_MODEL_VERSION,
   convertV2ToV4,
   isV2Format,
   convertV3HandleToV4,
@@ -12,6 +13,7 @@ import {
   importDiagram,
   normalizeClassStereotypes,
   normalizeElementTags,
+  normalizeStraightEdgeWaypoints,
 } from "@/utils/versionConverter"
 import { ClassStereotype } from "@/types/nodes/enums"
 
@@ -428,7 +430,7 @@ describe("convertV3MessagesToV4", () => {
 describe("convertV3ToV4", () => {
   it("produces a V4 model with version 4.0.0", () => {
     const result = convertV3ToV4(makeV3Wrapped())
-    expect(result.version).toBe("4.0.0")
+    expect(result.version).toBe(CURRENT_MODEL_VERSION)
   })
 
   it("preserves id and title from wrapped V3", () => {
@@ -647,6 +649,27 @@ describe("convertV3ToV4", () => {
     // Points are offset by bounds
     expect((edge.data.points as unknown[])[0]).toEqual({ x: 5, y: 5 })
     expect((edge.data.points as unknown[])[1]).toEqual({ x: 15, y: 25 })
+  })
+
+  it("clears legacy path points on straight-hook edges", () => {
+    // v3 stored the full rendered polyline (endpoints included) in `path`. Under
+    // the interior-waypoint model these were inert, so importing them as waypoints
+    // would sprout spurious bends — the converter must drop them.
+    const rel = makeV3Relationship({
+      id: "r2",
+      type: "SyntaxTreeLink",
+      source: { element: "n1", direction: "Down" },
+      target: { element: "n2", direction: "Up" },
+      path: [
+        { x: 0, y: 0 },
+        { x: 10, y: 20 },
+        { x: 30, y: 40 },
+      ],
+      bounds: { x: 5, y: 5, width: 0, height: 0 },
+    })
+    const result = convertV3ToV4(makeV3Wrapped({ relationships: { r2: rel } }))
+    expect(result.edges[0].type).toBe("SyntaxTreeLink")
+    expect(result.edges[0].data.points).toEqual([])
   })
 
   it("defaults missing relationship fields gracefully", () => {
@@ -1019,7 +1042,7 @@ describe("convertV2ToV4", () => {
   it("converts a minimal V2 diagram to V4", () => {
     const v2 = makeV2Data()
     const result = convertV2ToV4(v2)
-    expect(result.version).toBe("4.0.0")
+    expect(result.version).toBe(CURRENT_MODEL_VERSION)
     expect(result.type).toBe("ClassDiagram")
     expect(result.nodes).toEqual([])
     expect(result.edges).toEqual([])
@@ -1048,7 +1071,7 @@ describe("convertV2ToV4", () => {
       interactive: { elements: ["c1"], relationships: ["r1"] },
     })
     const result = convertV2ToV4(v2)
-    expect(result.version).toBe("4.0.0")
+    expect(result.version).toBe(CURRENT_MODEL_VERSION)
     expect(result.nodes.length).toBeGreaterThanOrEqual(1)
     expect(result.nodes[0].id).toBe("c1")
   })
@@ -1070,7 +1093,7 @@ describe("convertV2ToV4", () => {
     delete (v2 as Record<string, unknown>).interactive
     // Should not throw
     const result = convertV2ToV4(v2)
-    expect(result.version).toBe("4.0.0")
+    expect(result.version).toBe(CURRENT_MODEL_VERSION)
   })
 
   it("handles V2 with missing elements/relationships/assessments", () => {
@@ -1313,34 +1336,34 @@ describe("importDiagram", () => {
   it("converts V3 wrapped format", () => {
     const v3 = makeV3Wrapped()
     const result = importDiagram(v3)
-    expect(result.version).toBe("4.0.0")
+    expect(result.version).toBe(CURRENT_MODEL_VERSION)
     expect(result.id).toBe("diagram-1")
   })
 
   it("converts flat V3 model", () => {
     const v3 = makeV3Model()
     const result = importDiagram(v3)
-    expect(result.version).toBe("4.0.0")
+    expect(result.version).toBe(CURRENT_MODEL_VERSION)
   })
 
   it("converts V2 format", () => {
     const v2 = makeV2Data()
     const result = importDiagram(v2)
-    expect(result.version).toBe("4.0.0")
+    expect(result.version).toBe(CURRENT_MODEL_VERSION)
   })
 
   it("unwraps playground { model: ... } wrapper with V3 inside", () => {
     const v3 = makeV3Wrapped()
     const playground = { model: v3 }
     const result = importDiagram(playground)
-    expect(result.version).toBe("4.0.0")
+    expect(result.version).toBe(CURRENT_MODEL_VERSION)
   })
 
   it("unwraps playground { model: ... } wrapper with V4 inside", () => {
     const v4 = makeV4Model()
     const playground = { model: v4 }
     const result = importDiagram(playground)
-    expect(result.version).toBe("4.0.0")
+    expect(result.version).toBe(CURRENT_MODEL_VERSION)
   })
 
   it("throws for completely unsupported format", () => {
@@ -1380,7 +1403,7 @@ describe("importDiagram", () => {
     }
     const result = importDiagram(hybrid)
     // Returns as-is since isV4Format matches first
-    expect(result.version).toBe("4.0.0")
+    expect(result.version).toBe(CURRENT_MODEL_VERSION)
   })
 })
 
@@ -1491,6 +1514,70 @@ describe("normalizeClassStereotypes (legacy 4.x class nodes)", () => {
     }
     expect(data.isAbstract).toBe(true)
     expect(data.stereotype).toBeUndefined()
+  })
+})
+
+describe("normalizeStraightEdgeWaypoints", () => {
+  const points = [
+    { x: 10, y: 20 },
+    { x: 30, y: 40 },
+  ]
+
+  it("clears cached full routes from straight edges saved before 4.2", () => {
+    const model = makeV4Model({
+      version: "4.1.0",
+      edges: [
+        {
+          id: "straight",
+          type: "SyntaxTreeLink",
+          data: { points: [...points] },
+        },
+        {
+          id: "step",
+          type: "ClassUnidirectional",
+          data: { points: [...points] },
+        },
+      ],
+    })
+    normalizeStraightEdgeWaypoints(model)
+    expect(model.version).toBe(CURRENT_MODEL_VERSION)
+    expect((model.edges[0].data as { points: unknown[] }).points).toEqual([])
+    expect((model.edges[1].data as { points: unknown[] }).points).toEqual(
+      points
+    )
+  })
+
+  it("preserves authored interior waypoints from 4.2 onward", () => {
+    const model = makeV4Model({
+      version: CURRENT_MODEL_VERSION,
+      edges: [
+        {
+          id: "straight",
+          type: "UseCaseAssociation",
+          data: { points: [...points] },
+        },
+      ],
+    })
+    normalizeStraightEdgeWaypoints(model)
+    expect((model.edges[0].data as { points: unknown[] }).points).toEqual(
+      points
+    )
+  })
+
+  it("runs on the universal import path", () => {
+    const model = makeV4Model({
+      version: "4.0.0",
+      edges: [
+        {
+          id: "straight",
+          type: "PetriNetArc",
+          data: { points: [...points] },
+        },
+      ],
+    })
+    const imported = importDiagram(model)
+    expect(imported.version).toBe(CURRENT_MODEL_VERSION)
+    expect((imported.edges[0].data as { points: unknown[] }).points).toEqual([])
   })
 })
 

--- a/standalone/webapp/tests/e2e/edge-line-jump-integrity.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-line-jump-integrity.spec.ts
@@ -363,7 +363,7 @@ test.describe("Line-jump geometry integrity", () => {
 
     const beforeRelease = await readPerf(page, true)
     await page.mouse.up()
-    let duringSettlement: Awaited<ReturnType<typeof checkIntegrity>> | undefined
+    let afterRelease: Awaited<ReturnType<typeof checkIntegrity>> | undefined
     await expect
       .poll(
         async () => {
@@ -371,29 +371,30 @@ test.describe("Line-jump geometry integrity", () => {
           if (
             snapshot.perf &&
             snapshot.perf.workerReleaseExactMaxMs >
-              beforeRelease.workerReleaseExactMaxMs &&
-            snapshot.perf.routingPreviewCount > 0
+              beforeRelease.workerReleaseExactMaxMs
           ) {
-            duringSettlement = snapshot
+            afterRelease = snapshot
             return true
           }
           return false
         },
         // Poll gently: a 5ms interval re-ran the full DOM integrity scan ~200×/s
-        // and starved the very Worker message-handling it was waiting on.
+        // and starved the very Worker message-handling it was waiting on. The
+        // release-exact result and preview teardown may commit atomically, so do
+        // not require a painted frame where both telemetry states overlap.
         { intervals: [100, 250, 500], timeout: 15_000 }
       )
       .toBe(true)
 
-    expect(duringSettlement).toBeDefined()
+    expect(afterRelease).toBeDefined()
     expect(
-      duringSettlement!.crossings.length,
-      "fixture no longer produces crossings during settlement"
+      afterRelease!.crossings.length,
+      "fixture no longer produces crossings after settlement"
     ).toBeGreaterThan(0)
     expect(
-      duringSettlement!.floating,
-      `bridges floating during settlement: ${JSON.stringify(
-        duringSettlement!.floatingDiagnostics
+      afterRelease!.floating,
+      `bridges floating after settlement: ${JSON.stringify(
+        afterRelease!.floatingDiagnostics
       )}`
     ).toEqual([])
   })

--- a/standalone/webapp/tests/e2e/straight-edge-waypoint-ux.spec.ts
+++ b/standalone/webapp/tests/e2e/straight-edge-waypoint-ux.spec.ts
@@ -209,6 +209,27 @@ test("a waypoint handle wins its circle without blocking endpoint grips", async 
   await expect.poll(() => persistedPoints(page)).not.toEqual(before)
 })
 
+test("one threshold-crossing move is enough to create a waypoint", async ({
+  page,
+}) => {
+  const edge = page.locator(`.react-flow__edge[data-id="${edgeId}"]`)
+  const midpoint = edge.locator(midpointHandleSelector).first()
+  const box = await midpoint.boundingBox()
+  if (!box) throw new Error("midpoint handle has no bounding box")
+  const x = box.x + box.width / 2
+  const y = box.y + box.height / 2
+
+  await page.mouse.move(x, y)
+  await page.mouse.down()
+  // Keep this deliberately to one move followed immediately by pointer-up. The
+  // threshold-to-waypoint handoff must not require a second browser event.
+  await page.mouse.move(x + 55, y + 55)
+  await page.mouse.up()
+
+  await expect.poll(() => persistedPoints(page)).toHaveLength(1)
+  await expect(edge.getByRole("button", { name: /^Waypoint:/ })).toHaveCount(1)
+})
+
 test("straight waypoints feel editable and collapse live back to a line", async ({
   page,
 }) => {

--- a/standalone/webapp/tests/e2e/straight-edge-waypoint-ux.spec.ts
+++ b/standalone/webapp/tests/e2e/straight-edge-waypoint-ux.spec.ts
@@ -21,6 +21,12 @@ const crowdedFixture = JSON.parse(
   )
 ) as StraightEdgeFixture
 crowdedFixture.version = "4.2.0"
+const stepFixture = JSON.parse(
+  fs.readFileSync(
+    path.join(directory, "..", "fixtures", "class-diagram.json"),
+    "utf-8"
+  )
+) as Record<string, unknown>
 
 const fixture = structuredClone(crowdedFixture)
 fixture.version = "4.2.0"
@@ -88,6 +94,47 @@ test.beforeEach(async ({ page }) => {
   await selectEdgeOnPath(page, edgeId)
 })
 
+test("straight and step bend handles share one opaque visual state", async ({
+  page,
+}) => {
+  const edge = page.locator(`.react-flow__edge[data-id="${edgeId}"]`)
+  const createTarget = edge
+    .getByRole("button", { name: "Drag to add a waypoint" })
+    .first()
+  const createCircle = edge.locator(".edge-waypoint-handle--proposed").first()
+
+  // Selection clicks the route midpoint, so the newly-mounted midpoint handle
+  // initially appears under the stationary pointer. Move clear before measuring
+  // its resting state rather than accidentally sampling its hover color.
+  await page.mouse.move(280, 680)
+  await expect(createCircle).toHaveCSS("opacity", "1")
+  const straightFill = await createCircle.evaluate(
+    (element) => getComputedStyle(element).fill
+  )
+
+  await createTarget.hover()
+  await expect(createCircle).not.toHaveCSS("fill", straightFill)
+  await page.mouse.move(280, 680)
+  await expect(createCircle).toHaveCSS("fill", straightFill)
+
+  // Keyboard users retain a clear darkened-circle focus state, but the browser
+  // must not draw a square/ring around the invisible hit rectangle.
+  await createTarget.focus()
+  await expect(createTarget).toHaveCSS("outline-style", "none")
+  await expect(createCircle).not.toHaveCSS("fill", straightFill)
+
+  await openFixtureInLocalEditor(page, structuredClone(stepFixture))
+  await waitForCanvasReady(page)
+  const stepEdgeId = "edge-bidirectional-dog-imovable"
+  await selectEdgeOnPath(page, stepEdgeId)
+  const stepHandle = page
+    .locator(`.react-flow__edge[data-id="${stepEdgeId}"] .edge-bend-handle`)
+    .first()
+
+  await expect(stepHandle).toHaveCSS("opacity", "1")
+  await expect(stepHandle).toHaveCSS("fill", straightFill)
+})
+
 test("straight waypoints feel editable and collapse live back to a line", async ({
   page,
 }) => {
@@ -107,6 +154,15 @@ test("straight waypoints feel editable and collapse live back to a line", async 
   )
   await expect(visiblePoint).toHaveCSS("opacity", "1")
   await expect(visiblePoint).not.toHaveCSS("fill", "rgb(255, 255, 255)")
+  await expect
+    .poll(() =>
+      edge
+        .locator(".edge-waypoint-handle--proposed")
+        .evaluateAll((handles) =>
+          handles.every((handle) => getComputedStyle(handle).opacity === "1")
+        )
+    )
+    .toBe(true)
 
   const midpoint = await directChordMidpoint(page)
   if (!midpoint) throw new Error("edge path is not measurable")

--- a/standalone/webapp/tests/e2e/straight-edge-waypoint-ux.spec.ts
+++ b/standalone/webapp/tests/e2e/straight-edge-waypoint-ux.spec.ts
@@ -10,7 +10,7 @@ import {
 
 const directory = path.dirname(fileURLToPath(import.meta.url))
 type StraightEdgeFixture = Record<string, unknown> & {
-  nodes: unknown[]
+  nodes: Array<{ position: { x: number; y: number } }>
   edges: Array<{ id: string; data: { points: unknown[] } }>
 }
 
@@ -34,6 +34,9 @@ fixture.nodes = fixture.nodes.slice(0, 2)
 fixture.edges = fixture.edges.slice(0, 1)
 
 const edgeId = fixture.edges[0].id
+const closeHandleFixture = structuredClone(fixture)
+closeHandleFixture.nodes[0].position = { x: 200, y: 0 }
+closeHandleFixture.nodes[1].position = { x: 200, y: 180 }
 const midpointHandleSelector =
   ".edge-waypoint-handle--proposed + .edge-waypoint-hit-target"
 
@@ -131,6 +134,9 @@ test("straight and step bend handles share one opaque visual state", async ({
   // its resting state rather than accidentally sampling its hover color.
   await page.mouse.move(280, 680)
   await expect(createCircle).toHaveCSS("opacity", "1")
+  // Firefox exposes the interpolated `color(srgb …)` value while the declared
+  // 120ms fill transition is active; sample the actual resting state.
+  await page.waitForTimeout(150)
   const straightFill = await createCircle.evaluate(
     (element) => getComputedStyle(element).fill
   )
@@ -138,6 +144,7 @@ test("straight and step bend handles share one opaque visual state", async ({
   await createTarget.hover()
   await expect(createCircle).not.toHaveCSS("fill", straightFill)
   await page.mouse.move(280, 680)
+  await page.waitForTimeout(150)
   await expect(createCircle).toHaveCSS("fill", straightFill)
 
   await openFixtureInLocalEditor(page, structuredClone(stepFixture))
@@ -150,6 +157,56 @@ test("straight and step bend handles share one opaque visual state", async ({
 
   await expect(stepHandle).toHaveCSS("opacity", "1")
   await expect(stepHandle).toHaveCSS("fill", straightFill)
+})
+
+test("a waypoint handle wins its circle without blocking endpoint grips", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, structuredClone(closeHandleFixture))
+  await waitForCanvasReady(page)
+  await selectEdgeOnPath(page, edgeId)
+
+  const edge = page.locator(`.react-flow__edge[data-id="${edgeId}"]`)
+  const midpoint = edge.locator(midpointHandleSelector)
+  await expect(midpoint).toHaveCount(1)
+
+  const owners = await edge.evaluate((root, selector) => {
+    const ownerAtCenter = (element: Element | null) => {
+      if (!element) return null
+      const box = element.getBoundingClientRect()
+      return document
+        .elementFromPoint(box.x + box.width / 2, box.y + box.height / 2)
+        ?.getAttribute("class")
+    }
+    return {
+      midpoint: ownerAtCenter(root.querySelector(selector)),
+      source: ownerAtCenter(root.querySelector(".edge-endpoint-grip--source")),
+      target: ownerAtCenter(root.querySelector(".edge-endpoint-grip--target")),
+    }
+  }, midpointHandleSelector)
+
+  expect(owners.midpoint).toContain("edge-waypoint-hit-target")
+  expect(owners.source).toContain("edge-endpoint-handle--source")
+  expect(owners.target).toContain("edge-endpoint-handle--target")
+
+  // Real pointer input—not a dispatched event—proves the visible midpoint owns
+  // its grab centre even where the broad endpoint rectangles meet nearby.
+  await dragBy(page, midpoint, 55, 0)
+  await expect.poll(() => persistedPoints(page)).toHaveLength(1)
+  const waypoint = edge.getByRole("button", { name: /^Waypoint:/ })
+  await expect(waypoint).toHaveCount(1)
+  expect(
+    await waypoint.evaluate((element) => {
+      const box = element.getBoundingClientRect()
+      return document
+        .elementFromPoint(box.x + box.width / 2, box.y + box.height / 2)
+        ?.getAttribute("class")
+    })
+  ).toContain("edge-waypoint-hit-target")
+
+  const before = await persistedPoints(page)
+  await dragBy(page, waypoint, 20, 10)
+  await expect.poll(() => persistedPoints(page)).not.toEqual(before)
 })
 
 test("straight waypoints feel editable and collapse live back to a line", async ({

--- a/standalone/webapp/tests/e2e/straight-edge-waypoint-ux.spec.ts
+++ b/standalone/webapp/tests/e2e/straight-edge-waypoint-ux.spec.ts
@@ -34,6 +34,8 @@ fixture.nodes = fixture.nodes.slice(0, 2)
 fixture.edges = fixture.edges.slice(0, 1)
 
 const edgeId = fixture.edges[0].id
+const midpointHandleSelector =
+  ".edge-waypoint-handle--proposed + .edge-waypoint-hit-target"
 
 async function persistedPoints(page: Page): Promise<unknown[] | null> {
   return page.evaluate((id) => {
@@ -94,13 +96,34 @@ test.beforeEach(async ({ page }) => {
   await selectEdgeOnPath(page, edgeId)
 })
 
+test("legacy straight-edge route caches do not become visible bends", async ({
+  page,
+}) => {
+  const legacyFixture = structuredClone(fixture)
+  legacyFixture.version = "4.1.0"
+  legacyFixture.edges[0].data.points = [
+    { x: 40, y: 40 },
+    { x: 180, y: 220 },
+  ]
+
+  await openFixtureInLocalEditor(page, legacyFixture)
+  await waitForCanvasReady(page)
+  await selectEdgeOnPath(page, edgeId)
+
+  await expect.poll(() => persistedPoints(page)).toEqual([])
+  await expect.poll(() => pathExcessLength(page)).toBeLessThan(1)
+  await expect(
+    page
+      .locator(`.react-flow__edge[data-id="${edgeId}"]`)
+      .getByRole("button", { name: /^Waypoint:/ })
+  ).toHaveCount(0)
+})
+
 test("straight and step bend handles share one opaque visual state", async ({
   page,
 }) => {
   const edge = page.locator(`.react-flow__edge[data-id="${edgeId}"]`)
-  const createTarget = edge
-    .getByRole("button", { name: "Drag to add a waypoint" })
-    .first()
+  const createTarget = edge.locator(midpointHandleSelector).first()
   const createCircle = edge.locator(".edge-waypoint-handle--proposed").first()
 
   // Selection clicks the route midpoint, so the newly-mounted midpoint handle
@@ -116,12 +139,6 @@ test("straight and step bend handles share one opaque visual state", async ({
   await expect(createCircle).not.toHaveCSS("fill", straightFill)
   await page.mouse.move(280, 680)
   await expect(createCircle).toHaveCSS("fill", straightFill)
-
-  // Keyboard users retain a clear darkened-circle focus state, but the browser
-  // must not draw a square/ring around the invisible hit rectangle.
-  await createTarget.focus()
-  await expect(createTarget).toHaveCSS("outline-style", "none")
-  await expect(createCircle).not.toHaveCSS("fill", straightFill)
 
   await openFixtureInLocalEditor(page, structuredClone(stepFixture))
   await waitForCanvasReady(page)
@@ -139,9 +156,7 @@ test("straight waypoints feel editable and collapse live back to a line", async 
   page,
 }) => {
   const edge = page.locator(`.react-flow__edge[data-id="${edgeId}"]`)
-  const createHandle = edge.getByRole("button", {
-    name: "Drag to add a waypoint",
-  })
+  const createHandle = edge.locator(midpointHandleSelector)
   await expect(createHandle.first()).toBeVisible()
   await dragBy(page, createHandle.first(), 70, 70)
 
@@ -186,15 +201,13 @@ test("a focused waypoint can be removed with the keyboard", async ({
   page,
 }) => {
   const edge = page.locator(`.react-flow__edge[data-id="${edgeId}"]`)
-  await dragBy(
-    page,
-    edge.getByRole("button", { name: "Drag to add a waypoint" }).first(),
-    70,
-    70
-  )
+  await dragBy(page, edge.locator(midpointHandleSelector).first(), 70, 70)
 
   const waypoint = edge.getByRole("button", { name: /^Waypoint:/ })
   await waypoint.focus()
+  // Authored points are keyboard actions. Their circle provides the focus
+  // feedback; the invisible SVG hit rectangle must never acquire a square ring.
+  await expect(waypoint).toHaveCSS("outline-style", "none")
   await page.keyboard.press("Delete")
 
   await expect(waypoint).toHaveCount(0)
@@ -209,12 +222,7 @@ test("the edge toolbar never traps a waypoint underneath it", async ({
   await selectEdgeOnPath(page, edgeId)
 
   const edge = page.locator(`.react-flow__edge[data-id="${edgeId}"]`)
-  await dragBy(
-    page,
-    edge.getByRole("button", { name: "Drag to add a waypoint" }).first(),
-    -70,
-    -70
-  )
+  await dragBy(page, edge.locator(midpointHandleSelector).first(), -70, -70)
 
   const waypoint = edge.getByRole("button", { name: /^Waypoint:/ })
   await expect(waypoint).toHaveCount(1)

--- a/standalone/webapp/tests/e2e/straight-edge-waypoint-ux.spec.ts
+++ b/standalone/webapp/tests/e2e/straight-edge-waypoint-ux.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test, type Locator, type Page } from "@playwright/test"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+import {
+  openFixtureInLocalEditor,
+  selectEdgeOnPath,
+  waitForCanvasReady,
+} from "../helpers/canvas"
+
+const directory = path.dirname(fileURLToPath(import.meta.url))
+type StraightEdgeFixture = Record<string, unknown> & {
+  nodes: unknown[]
+  edges: Array<{ id: string; data: { points: unknown[] } }>
+}
+
+const crowdedFixture = JSON.parse(
+  fs.readFileSync(
+    path.join(directory, "..", "fixtures", "syntax-tree.json"),
+    "utf-8"
+  )
+) as StraightEdgeFixture
+crowdedFixture.version = "4.2.0"
+
+const fixture = structuredClone(crowdedFixture)
+fixture.version = "4.2.0"
+fixture.nodes = fixture.nodes.slice(0, 2)
+fixture.edges = fixture.edges.slice(0, 1)
+
+const edgeId = fixture.edges[0].id
+
+async function persistedPoints(page: Page): Promise<unknown[] | null> {
+  return page.evaluate((id) => {
+    const raw = localStorage.getItem("persistenceModelStore")
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    const modelId = parsed.state.currentModelId
+    const edges = parsed.state.models[modelId]?.model?.edges ?? []
+    return edges.find((edge: { id: string }) => edge.id === id)?.data?.points
+  }, edgeId)
+}
+
+async function dragBy(page: Page, handle: Locator, dx: number, dy: number) {
+  const box = await handle.boundingBox()
+  if (!box) throw new Error("waypoint handle has no bounding box")
+  const x = box.x + box.width / 2
+  const y = box.y + box.height / 2
+  await page.mouse.move(x, y)
+  await page.mouse.down()
+  await page.mouse.move(x + dx, y + dy, { steps: 12 })
+  await page.mouse.up()
+}
+
+async function directChordMidpoint(page: Page) {
+  return page.evaluate((id) => {
+    const path = document.querySelector(
+      `.react-flow__edge[data-id="${id}"] path.react-flow__edge-path`
+    ) as SVGPathElement | null
+    if (!path) return null
+    const transform = path.getScreenCTM()
+    if (!transform) return null
+    const start = path.getPointAtLength(0)
+    const end = path.getPointAtLength(path.getTotalLength())
+    const point = new DOMPoint(
+      (start.x + end.x) / 2,
+      (start.y + end.y) / 2
+    ).matrixTransform(transform)
+    return { x: point.x, y: point.y }
+  }, edgeId)
+}
+
+async function pathExcessLength(page: Page) {
+  return page.evaluate((id) => {
+    const path = document.querySelector(
+      `.react-flow__edge[data-id="${id}"] path.react-flow__edge-path`
+    ) as SVGPathElement | null
+    if (!path) return null
+    const length = path.getTotalLength()
+    const start = path.getPointAtLength(0)
+    const end = path.getPointAtLength(length)
+    return length - Math.hypot(end.x - start.x, end.y - start.y)
+  }, edgeId)
+}
+
+test.beforeEach(async ({ page }) => {
+  await openFixtureInLocalEditor(page, structuredClone(fixture))
+  await waitForCanvasReady(page)
+  await selectEdgeOnPath(page, edgeId)
+})
+
+test("straight waypoints feel editable and collapse live back to a line", async ({
+  page,
+}) => {
+  const edge = page.locator(`.react-flow__edge[data-id="${edgeId}"]`)
+  const createHandle = edge.getByRole("button", {
+    name: "Drag to add a waypoint",
+  })
+  await expect(createHandle.first()).toBeVisible()
+  await dragBy(page, createHandle.first(), 70, 70)
+
+  const waypoint = edge.getByRole("button", { name: /^Waypoint:/ })
+  await expect(waypoint).toHaveCount(1)
+  await expect.poll(() => persistedPoints(page)).toHaveLength(1)
+
+  const visiblePoint = edge.locator(
+    ".edge-waypoint-handle:not(.edge-waypoint-handle--proposed)"
+  )
+  await expect(visiblePoint).toHaveCSS("opacity", "1")
+  await expect(visiblePoint).not.toHaveCSS("fill", "rgb(255, 255, 255)")
+
+  const midpoint = await directChordMidpoint(page)
+  if (!midpoint) throw new Error("edge path is not measurable")
+  const box = await waypoint.boundingBox()
+  if (!box) throw new Error("waypoint handle has no bounding box")
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(midpoint.x, midpoint.y, { steps: 12 })
+
+  // Entering the magnetic band removes the kink before pointer-up. The handle
+  // stays mounted until release so it retains pointer capture and the gesture
+  // remains reversible.
+  await expect(waypoint).toHaveCount(1)
+  await expect.poll(() => pathExcessLength(page)).toBeLessThan(1)
+  await page.mouse.up()
+  await expect(waypoint).toHaveCount(0)
+  await expect.poll(() => persistedPoints(page)).toEqual([])
+})
+
+test("a focused waypoint can be removed with the keyboard", async ({
+  page,
+}) => {
+  const edge = page.locator(`.react-flow__edge[data-id="${edgeId}"]`)
+  await dragBy(
+    page,
+    edge.getByRole("button", { name: "Drag to add a waypoint" }).first(),
+    70,
+    70
+  )
+
+  const waypoint = edge.getByRole("button", { name: /^Waypoint:/ })
+  await waypoint.focus()
+  await page.keyboard.press("Delete")
+
+  await expect(waypoint).toHaveCount(0)
+  await expect.poll(() => persistedPoints(page)).toEqual([])
+})
+
+test("the edge toolbar never traps a waypoint underneath it", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, structuredClone(crowdedFixture))
+  await waitForCanvasReady(page)
+  await selectEdgeOnPath(page, edgeId)
+
+  const edge = page.locator(`.react-flow__edge[data-id="${edgeId}"]`)
+  await dragBy(
+    page,
+    edge.getByRole("button", { name: "Drag to add a waypoint" }).first(),
+    -70,
+    -70
+  )
+
+  const waypoint = edge.getByRole("button", { name: /^Waypoint:/ })
+  await expect(waypoint).toHaveCount(1)
+  const before = await persistedPoints(page)
+
+  // A sharp bend puts the route's arc midpoint close to its waypoint, which is
+  // also where React Flow anchors the edge action toolbar. Exercise this with a
+  // real pointer gesture: focusing or dispatching the event would not detect a
+  // toolbar layered over the handle.
+  await dragBy(page, waypoint, 0, -35)
+
+  await expect.poll(() => persistedPoints(page)).not.toEqual(before)
+  await expect(waypoint).toHaveCount(1)
+})


### PR DESCRIPTION
### Summary

Straight connections in use-case, syntax-tree, and Petri-net diagrams currently offer no way to correct a route without moving its nodes. This PR gives those edges a direct, discoverable waypoint-editing workflow:

- Select or hover a straight edge to reveal filled circular bend handles.
- Drag a segment handle to create a waypoint, then drag that waypoint freely in two dimensions.
- Hold Shift while dragging to snap to familiar 15-degree angles.
- Remove a waypoint by double-clicking it, focusing it and pressing Delete, or dragging it back onto the straight route.
- Reconnect an endpoint without losing the route, or reset the edge once to clear every custom waypoint.

The handles intentionally share the opaque blue visual state of step-edge bend handles. They remain circular because a straight-edge waypoint moves in two dimensions, while a step-edge capsule represents a segment constrained to one axis.

This PR is deliberately limited to manual editing. Automatic routing and syntax-tree layout are separated into the follow-up PR #835 so each change can be reviewed and released independently.

### Release note

Shape diagonal connections by hand just like orthogonal ones. Use-case, syntax-tree,
and petri-net connections now have filled circular waypoints: drag the handle on a
segment to add one, drag an existing point to reshape the route, and double-click,
press Delete, or drag it magnetically back onto the line to remove it. Shift-drag locks
to familiar 15-degree angles, endpoint reconnection preserves the custom route, and a
single reset clears all hand-authored routing.

### Implementation notes

- Stores only user-authored interior waypoints. Existing diagrams without waypoints keep their current route.
- Advances the additive wire format to 4.2.0. Imports from 4.0/4.1 discard only inert straight-edge route caches so they cannot appear as new bends; orthogonal waypoints and all other model data remain intact, while future 4.x waypoint data is left untouched.
- Feeds the resulting polyline through the existing label and line-jump geometry instead of treating each segment as an unrelated edge.
- Keeps endpoint reconnection, undo/redo, serialization, and diagram-version conversion aware of custom routes.
- Keeps the published TypeScript surface source-compatible. A declaration-level comparison against `main` contains only the new optional `moveEdgeWaypoint` label; complete translation dictionaries written for earlier releases still compile and receive the English fallback internally.
- Uses an invisible 24 px hit target for comfortable pointer and keyboard interaction while rendering a compact circular handle.
- Gives a visible waypoint ownership of its exact grab centre even when a nearby endpoint's larger reconnect target overlaps it; the endpoint grip remains independently reachable beside the node.
- Scales midpoint spacing with zoom so fixed-screen hit targets do not merge into an ambiguous interaction area when zoomed out.
- Keeps pointer-only midpoint handles out of the keyboard tab order; authored waypoints remain named and focusable for Delete/Backspace removal.
- Replaces the browser's square SVG focus outline with a visible darkened-circle focus state. This preserves keyboard feedback without introducing a focus treatment that step-edge handles do not have.
- Offsets only straight-edge reconnect targets from node handles. Existing orthogonal/step-edge reconnect geometry remains unchanged; the full E2E suite caught and now guards that boundary.
- Keeps automatic route selection out of this PR. The editor does not add or move waypoints unless the user directly manipulates the edge.
- Accounts explicitly for the feature's eager bundle cost: the Node 22 CI measurement is 119.56 kB brotli, so the main-entry budget moves from 118 kB to 121 kB. This adds 1.44 kB of headroom without adding a runtime dependency.

### Steps for testing

1. Open a use-case, syntax-tree, or Petri-net diagram and create or select a straight connection.
2. Confirm that its circular handles are fully opaque blue on hover/selection and that no square focus ring appears when a handle receives keyboard focus.
3. Drag a segment handle away from the line; confirm that it becomes a persistent waypoint and that labels and line jumps follow the reshaped path.
4. Drag a waypoint with and without Shift; confirm free movement and 15-degree snapping.
5. Remove a waypoint by each supported path: Delete, double-click, and dragging it back onto the line.
6. Reconnect either endpoint and confirm the interior route is retained.
7. Use the edge's reset action and confirm all custom waypoints are cleared in one undoable change.
8. Import a 4.0/4.1 straight-edge model with legacy `data.points`; confirm it remains visually straight, while an orthogonal edge retains its existing manual bends.
9. Run `pnpm lint && pnpm format:check && pnpm build && pnpm test`.
10. Run `pnpm exec playwright test tests/e2e/straight-edge-waypoint-ux.spec.ts --project chromium --project firefox` from `standalone/webapp`.
11. Run `pnpm --filter @tumaet/apollon run size`; the main entry should remain below 121 kB brotli.

Local verification on this branch after rebasing onto current `main`: 88 unit-test files passed (1,781 tests; 1 skipped), and the main published entry is 119.71 kB brotli against its 121 kB budget. The focused production interaction and legacy-import suite passed all 7 tests in both Chromium and Firefox (14 browser runs total), including real pointer drags where waypoint and endpoint targets are close together and a one-move quick-drag regression.

### Screenshots / screencasts

![A selected syntax-tree connection with an added circular waypoint and opaque segment handles](https://raw.githubusercontent.com/ls1intum/Apollon/pr-834-835-assets/docs/static/img/pr-assets/waypoint-editing.png)

Captured from this branch's production build after adding a waypoint. The focused Playwright suite covers what the still cannot show: drag, magnetic collapse, overlapping-target ownership, hover, keyboard removal, and a computed-style comparison against step-edge handles.

### Checklist

- [x] Linked to a related issue (not applicable; no issue captures the manual-editing scope)
- [x] Added a changeset whose summary is written in the user's voice (`pnpm changeset`, [how](https://ls1intum.github.io/Apollon/contributor/development/release-notes/))
- [x] PR title's Conventional Commit type (`feat`) matches the user-visible feature and release-note group
- [x] Tests added or updated
- [x] Ran `pnpm lint && pnpm format:check && pnpm build && pnpm test` locally — green
- [x] Documentation updated (the model contract now documents 4.2 migration and compatibility behavior)
- [x] Screenshots or screencasts attached
