### PR TITLE
feat(library): route straight edges and tidy syntax trees

### DIFF
--- a/.changeset/curly-cats-rescue.md
+++ b/.changeset/curly-cats-rescue.md
@@ -5,5 +5,5 @@
 Keep straight connections clear automatically. They now choose facing sides, spread
 sibling links across shared borders, and route around nodes and nearby connections
 without adding unnecessary bends; clear shots remain straight and hand-placed
-waypoints stay authoritative. Syntax trees also gain a one-click tidy layout that
+routes stay exactly as drawn. Syntax trees also gain a one-click tidy layout that
 arranges valid parent-child forests while leaving malformed portions untouched.

--- a/.changeset/curly-cats-rescue.md
+++ b/.changeset/curly-cats-rescue.md
@@ -2,8 +2,9 @@
 "@tumaet/apollon": minor
 ---
 
-Keep straight connections clear automatically. They now choose facing sides, spread
-sibling links across shared borders, and route around nodes and nearby connections
-without adding unnecessary bends; clear shots remain straight and hand-placed
-routes stay exactly as drawn. Syntax trees also gain a one-click tidy layout that
-arranges valid parent-child forests while leaving malformed portions untouched.
+Keep straight connections clear, stable, and responsive automatically. They now
+choose facing sides, spread sibling links across shared borders, and route around
+nodes without reorganizing when other connections cross them; clear shots remain
+straight and hand-placed routes stay exactly as drawn. Syntax trees also gain a
+one-click tidy layout that arranges valid parent-child forests while leaving
+malformed portions untouched.

--- a/.changeset/curly-cats-rescue.md
+++ b/.changeset/curly-cats-rescue.md
@@ -1,0 +1,9 @@
+---
+"@tumaet/apollon": minor
+---
+
+Keep straight connections clear automatically. They now choose facing sides, spread
+sibling links across shared borders, and route around nodes and nearby connections
+without adding unnecessary bends; clear shots remain straight and hand-placed
+waypoints stay authoritative. Syntax trees also gain a one-click tidy layout that
+arranges valid parent-child forests while leaving malformed portions untouched.

--- a/library/lib/apollon-editor.tsx
+++ b/library/lib/apollon-editor.tsx
@@ -405,6 +405,23 @@ export class ApollonEditor {
     requestAnimationFrame(attempt)
   }
 
+  /**
+   * Arrange a syntax-tree diagram into a tidy hierarchical layout, so straight
+   * parent→child links no longer overlap sibling nodes (issue #282). Derives the
+   * hierarchy from `SyntaxTreeLink` edges; malformed graphs (forests, cycles,
+   * multi-parent) are laid out where clean and left untouched elsewhere. It is a
+   * single undo step and a no-op on non-syntax-tree diagrams.
+   */
+  public layoutSyntaxTree(): void {
+    if (
+      this.metadataStore.getState().diagramType !== UMLDiagramType.SyntaxTree
+    ) {
+      return
+    }
+    this.diagramStore.getState().layoutSyntaxTree()
+    this.fitView()
+  }
+
   // ---- Canvas overlay / control API -------------------------------------
   // A library-owned overlay engine: host chrome (header, rails, banners) and the
   // editor's own overlays share one measured, inset-aware layout. Controls

--- a/library/lib/chrome/builtins/ZoomControls.tsx
+++ b/library/lib/chrome/builtins/ZoomControls.tsx
@@ -28,6 +28,21 @@ export interface ZoomControlsProps {
 }
 
 /**
+ * Apply controlled node positions, then wait two paint boundaries before fitting.
+ * The first lets React publish the new node array; the second lets React Flow
+ * measure and index it. Kept injectable for a deterministic toolbar regression
+ * test.
+ */
+export const runTidyLayoutAndFit = (
+  layout: () => void,
+  fit: () => void,
+  schedule: (callback: FrameRequestCallback) => number = requestAnimationFrame
+): void => {
+  layout()
+  schedule(() => schedule(() => fit()))
+}
+
+/**
  * The canvas cluster: a [zoom-out][%-reset][zoom-in][fit][multi-select] island and
  * a separate [undo][redo] history island. The fit button reserves the current insets
  * so content frames clear of the chrome. `history: false` drops the history island.
@@ -137,7 +152,11 @@ export function ZoomControls({ history = true }: ZoomControlsProps) {
             <button
               type="button"
               className="apollon-chrome-iconbtn"
-              onClick={() => layoutSyntaxTree()}
+              onClick={() =>
+                runTidyLayoutAndFit(layoutSyntaxTree, () =>
+                  insetAwareFitView(rf, insets, safeArea, { duration: 200 })
+                )
+              }
               aria-label={t.tidyLayout}
             >
               <ListTree width={18} height={18} aria-hidden="true" />

--- a/library/lib/chrome/builtins/ZoomControls.tsx
+++ b/library/lib/chrome/builtins/ZoomControls.tsx
@@ -1,6 +1,7 @@
 import { useReactFlow, useStore } from "@xyflow/react"
 import { useShallow } from "zustand/shallow"
 import {
+  ListTree,
   Maximize,
   Redo2,
   SquareMousePointer,
@@ -13,6 +14,8 @@ import {
   useMetadataStore,
   useOverlayStore,
 } from "@/store/context"
+import { useDiagramModifiable } from "@/hooks/useDiagramModifiable"
+import { UMLDiagramType } from "@/types"
 import { insetAwareFitView } from "@/overlay/fitView"
 import { ariaKeyshortcuts } from "@/keyboard"
 import { Tooltip } from "@/components/ui"
@@ -48,12 +51,17 @@ export function ZoomControls({ history = true }: ZoomControlsProps) {
     }))
   )
 
-  const { multiSelectionMode, setMultiSelectionMode } = useMetadataStore(
-    useShallow((state) => ({
-      multiSelectionMode: state.multiSelectionMode,
-      setMultiSelectionMode: state.setMultiSelectionMode,
-    }))
-  )
+  const { multiSelectionMode, setMultiSelectionMode, isSyntaxTree } =
+    useMetadataStore(
+      useShallow((state) => ({
+        multiSelectionMode: state.multiSelectionMode,
+        setMultiSelectionMode: state.setMultiSelectionMode,
+        isSyntaxTree: state.diagramType === UMLDiagramType.SyntaxTree,
+      }))
+    )
+  const layoutSyntaxTree = useDiagramStore((state) => state.layoutSyntaxTree)
+  const isModifiable = useDiagramModifiable()
+  const showTidyLayout = isSyntaxTree && isModifiable
 
   const { ref: toolbarRef, onKeyDown: onToolbarKeyDown } =
     useRovingToolbar<HTMLDivElement>()
@@ -124,6 +132,18 @@ export function ZoomControls({ history = true }: ZoomControlsProps) {
             <SquareMousePointer width={18} height={18} aria-hidden="true" />
           </button>
         </Tooltip>
+        {showTidyLayout && (
+          <Tooltip title={t.tidyLayoutHint}>
+            <button
+              type="button"
+              className="apollon-chrome-iconbtn"
+              onClick={() => layoutSyntaxTree()}
+              aria-label={t.tidyLayout}
+            >
+              <ListTree width={18} height={18} aria-hidden="true" />
+            </button>
+          </Tooltip>
+        )}
       </div>
 
       {history && undoManagerExist && (

--- a/library/lib/components/ConnectionPreviewLine.tsx
+++ b/library/lib/components/ConnectionPreviewLine.tsx
@@ -28,6 +28,7 @@ import {
   getConnectionMode,
   getEdgeAnchorFromPoint,
   getEdgeAnchorPoint,
+  getNativeConnectionAnchor,
 } from "@/utils/connectionModes"
 import { computeConnectionPreviewRoute } from "@/utils/geometry/edgeGeometrySolver"
 import { STRAIGHT_PATH_STEP_EDGE_TYPES } from "@/edges/edgeRoutingBehavior"
@@ -127,17 +128,12 @@ export const ConnectionPreviewLine = ({
     // A valid native handle is an exact attachment point, not merely a side hint.
     // Resolve that point into the pending edge too, so the central solver cannot
     // replace the native ghost endpoint with an automatic facing-side anchor.
-    const nativeDropTarget = hasNativeTarget
-      ? resolveDropTarget({ x: toX, y: toY }, fromNodeId)
+    const nativeAnchor = hasNativeTarget
+      ? getNativeConnectionAnchor({
+          to: { x: toX, y: toY },
+          toNode,
+        })
       : null
-    const nativeAnchor =
-      nativeDropTarget && nativeDropTarget.id === nativeTargetId
-        ? getEdgeAnchorFromPoint(
-            nativeDropTarget.type,
-            { x: toX, y: toY },
-            nativeDropTarget.rect
-          )
-        : null
     const target = hasNativeTarget
       ? null
       : resolveDropTarget(pointer, fromNodeId)
@@ -190,6 +186,7 @@ export const ConnectionPreviewLine = ({
     nativeTargetId,
     nativeTargetHandleId,
     nativeTargetPosition,
+    toNode,
   ])
 
   const pinnedTargetAnchor = newConnection.targetId

--- a/library/lib/components/ConnectionPreviewLine.tsx
+++ b/library/lib/components/ConnectionPreviewLine.tsx
@@ -29,6 +29,7 @@ import {
   getEdgeAnchorFromPoint,
   getEdgeAnchorPoint,
   getNativeConnectionAnchor,
+  getNativeConnectionRect,
 } from "@/utils/connectionModes"
 import { computeConnectionPreviewRoute } from "@/utils/geometry/edgeGeometrySolver"
 import { STRAIGHT_PATH_STEP_EDGE_TYPES } from "@/edges/edgeRoutingBehavior"
@@ -87,6 +88,7 @@ export const ConnectionPreviewLine = ({
   connectionStatus,
   toNode,
   toHandle,
+  pointer: panePointer,
 }: ConnectionLineComponentProps) => {
   const fromNodeId = fromNode?.id
   const nativeTargetId = toNode?.id
@@ -95,6 +97,7 @@ export const ConnectionPreviewLine = ({
   const resolveDropTarget = useFreeformDropTarget()
   const allNodes = useDiagramStore((state) => state.nodes)
   const nodeLookup = useStore((state) => state.nodeLookup)
+  const transform = useStore((state) => state.transform)
   const connectionMode = useStore((state) => state.connectionMode)
   const diagramType = useMetadataStore((state) => state.diagramType)
   const previewEdgeType = getDefaultEdgeType(diagramType)
@@ -115,16 +118,33 @@ export const ConnectionPreviewLine = ({
   const newConnection = useMemo(() => {
     const snap = (v: number) =>
       Math.round(v / CANVAS.SNAP_TO_GRID_PX) * CANVAS.SNAP_TO_GRID_PX
-    const pointer: XYPosition = { x: snap(toX), y: snap(toY) }
+    // Unlike `toX`/`toY`, React Flow exposes `pointer` in pane-relative
+    // screen pixels. Apply only the viewport transform here: screenToFlowPosition
+    // would subtract the pane's page offset a second time.
+    const livePointer = {
+      x: (panePointer.x - transform[0]) / transform[2],
+      y: (panePointer.y - transform[1]) / transform[2],
+    }
+    const pointer: XYPosition = {
+      x: snap(livePointer.x),
+      y: snap(livePointer.y),
+    }
 
     // React Flow still reports the nearest handle for an invalid drop. Only a
     // valid handle is committed through onConnect; invalid drops use the same
     // shape-aware freeform path as onConnectEnd.
-    const hasNativeTarget =
+    // Continuous outlines are the exception even when React Flow happens to
+    // validate a nearby hidden handle: their visible snap circle follows the
+    // actual pointer angle, so treating that handle centre as authoritative
+    // would make the ghost jump away from the aimed curve.
+    const hasValidNativeTarget =
       connectionStatus === "valid" &&
       nativeTargetId !== undefined &&
       nativeTargetId !== fromNodeId &&
       nativeTargetPosition !== undefined
+    const targetIsAimedOutline =
+      hasValidNativeTarget && dropAnchorIsAimed(toNode?.type)
+    const hasNativeTarget = hasValidNativeTarget && !targetIsAimedOutline
     // A valid native handle is an exact attachment point, not merely a side hint.
     // Resolve that point into the pending edge too, so the central solver cannot
     // replace the native ghost endpoint with an automatic facing-side anchor.
@@ -134,11 +154,26 @@ export const ConnectionPreviewLine = ({
           toNode,
         })
       : null
-    const target = hasNativeTarget
+    // Validation owns target identity. In particular, a use case nested inside
+    // a system overlaps its container, so re-running a scene-wide hit test can
+    // silently replace the oval with that container. Only the anchor remains
+    // continuous for an aimed outline.
+    const aimedTargetRect =
+      targetIsAimedOutline && toNode ? getNativeConnectionRect(toNode) : null
+    const aimedTarget =
+      aimedTargetRect && toNode
+        ? {
+            id: toNode.id,
+            type: toNode.type,
+            rect: aimedTargetRect,
+          }
+        : null
+    const target = hasValidNativeTarget
       ? null
       : resolveDropTarget(pointer, fromNodeId)
     // Empty space resolves to the source node, which is not a preview target.
-    const hit = target && target.id !== fromNodeId ? target : null
+    const hit =
+      aimedTarget ?? (target && target.id !== fromNodeId ? target : null)
     const anchor = hit
       ? getEdgeAnchorFromPoint(hit.type, pointer, hit.rect)
       : null
@@ -153,7 +188,8 @@ export const ConnectionPreviewLine = ({
         : null
 
     const draggedFar =
-      Math.hypot(toX - fromX, toY - fromY) >= GHOST_MIN_DRAG_DISTANCE_PX
+      Math.hypot(pointer.x - fromX, pointer.y - fromY) >=
+      GHOST_MIN_DRAG_DISTANCE_PX
 
     return {
       from: { x: fromX, y: fromY },
@@ -186,6 +222,8 @@ export const ConnectionPreviewLine = ({
     nativeTargetId,
     nativeTargetHandleId,
     nativeTargetPosition,
+    panePointer,
+    transform,
     toNode,
   ])
 
@@ -237,27 +275,47 @@ export const ConnectionPreviewLine = ({
     if (!newConnection.visible) return { d: "", snapPoint: null }
 
     if (fromNodeId && newConnection.targetId) {
-      if (pendingSolvedRoute && pendingSolvedRoute.length >= 2) {
+      const pendingTarget =
+        pendingSolvedRoute?.[pendingSolvedRoute.length - 1] ?? null
+      // The worker may still hold the route for a target crossed earlier in
+      // the same gesture. A pinned endpoint must never display that stale route:
+      // use the immediate pointer route until the worker catches up. Automatic
+      // targets are allowed to choose their own seat, so endpoint equality is
+      // intentionally required only when an anchor is pinned.
+      const pendingRouteMatchesPinnedTarget =
+        !pinnedTargetAnchor ||
+        (pendingTarget !== null &&
+          Math.hypot(
+            pendingTarget.x - newConnection.to.x,
+            pendingTarget.y - newConnection.to.y
+          ) <= 0.5)
+      if (
+        pendingSolvedRoute &&
+        pendingSolvedRoute.length >= 2 &&
+        pendingRouteMatchesPinnedTarget
+      ) {
         return {
           d: pointsToSvgPath(pendingSolvedRoute),
           snapPoint: pendingSolvedRoute[pendingSolvedRoute.length - 1],
         }
       }
-      const previewRoute = computeConnectionPreviewRoute({
-        sourceId: fromNodeId,
-        targetId: newConnection.targetId,
-        edgeType: previewEdgeType,
-        enableStraightPath: previewEnableStraightPath,
-        nodes: allNodes,
-        nodeLookup,
-        connectionMode,
-        obstacles,
-        neighborEdges,
-      })
-      if (previewRoute && previewRoute.length >= 2) {
-        return {
-          d: pointsToSvgPath(previewRoute),
-          snapPoint: previewRoute[previewRoute.length - 1],
+      if (!pinnedTargetAnchor) {
+        const previewRoute = computeConnectionPreviewRoute({
+          sourceId: fromNodeId,
+          targetId: newConnection.targetId,
+          edgeType: previewEdgeType,
+          enableStraightPath: previewEnableStraightPath,
+          nodes: allNodes,
+          nodeLookup,
+          connectionMode,
+          obstacles,
+          neighborEdges,
+        })
+        if (previewRoute && previewRoute.length >= 2) {
+          return {
+            d: pointsToSvgPath(previewRoute),
+            snapPoint: previewRoute[previewRoute.length - 1],
+          }
         }
       }
     }
@@ -272,7 +330,7 @@ export const ConnectionPreviewLine = ({
         obstacles,
         neighborEdges
       ),
-      snapPoint: null,
+      snapPoint: newConnection.snapPoint,
     }
   }, [
     connectionLineType,

--- a/library/lib/components/ConnectionPreviewLine.tsx
+++ b/library/lib/components/ConnectionPreviewLine.tsx
@@ -124,6 +124,20 @@ export const ConnectionPreviewLine = ({
       nativeTargetId !== undefined &&
       nativeTargetId !== fromNodeId &&
       nativeTargetPosition !== undefined
+    // A valid native handle is an exact attachment point, not merely a side hint.
+    // Resolve that point into the pending edge too, so the central solver cannot
+    // replace the native ghost endpoint with an automatic facing-side anchor.
+    const nativeDropTarget = hasNativeTarget
+      ? resolveDropTarget({ x: toX, y: toY }, fromNodeId)
+      : null
+    const nativeAnchor =
+      nativeDropTarget && nativeDropTarget.id === nativeTargetId
+        ? getEdgeAnchorFromPoint(
+            nativeDropTarget.type,
+            { x: toX, y: toY },
+            nativeDropTarget.rect
+          )
+        : null
     const target = hasNativeTarget
       ? null
       : resolveDropTarget(pointer, fromNodeId)
@@ -159,7 +173,8 @@ export const ConnectionPreviewLine = ({
         : freeformTarget
           ? getSideHandleIdForPosition(freeformTarget.position)
           : undefined,
-      targetAnchor: hit && dropAnchorIsAimed(hit.type) ? anchor : null,
+      targetAnchor:
+        nativeAnchor ?? (hit && dropAnchorIsAimed(hit.type) ? anchor : null),
       snapPoint: freeformTarget?.showSnapCircle ? freeformTarget.point : null,
       visible: draggedFar || hasNativeTarget || freeformTarget !== null,
     }

--- a/library/lib/components/EdgeGeometrySolver.tsx
+++ b/library/lib/components/EdgeGeometrySolver.tsx
@@ -144,6 +144,7 @@ export const EdgeGeometrySolver = () => {
     >()
   )
   const interactionActiveRef = useRef(false)
+  const nodeInteractionActiveRef = useRef(false)
   const interactionStartedAtRef = useRef<number | null>(null)
   const lastHolisticPreviewAtRef = useRef<number | null>(null)
   const releaseStartedAtRef = useRef<number | null>(null)
@@ -295,6 +296,8 @@ export const EdgeGeometrySolver = () => {
       nodeInteractionActive ||
       liveEdgeOverride !== null ||
       pendingConnectionEdge !== null
+    const nodeInteractionJustReleased =
+      nodeInteractionActiveRef.current && !nodeInteractionActive
     const interactionChangedAt = performance.now()
     if (!interactionActiveRef.current && interacting) {
       interactionStartedAtRef.current = interactionChangedAt
@@ -303,6 +306,7 @@ export const EdgeGeometrySolver = () => {
     } else if (interactionActiveRef.current && !interacting)
       releaseStartedAtRef.current = interactionChangedAt
     interactionActiveRef.current = interacting
+    nodeInteractionActiveRef.current = nodeInteractionActive
 
     const solveSynchronously = (solveInput: SolverInput) => {
       const startedAt =
@@ -362,11 +366,18 @@ export const EdgeGeometrySolver = () => {
       geometryStore?.getState().setSolving(false)
     }
 
+    const hasStraightHookEdges = solverEdges.some((edge) =>
+      STRAIGHT_HOOK_EDGE_TYPES.has(edge.type ?? "")
+    )
+    const forceStraightInteractionWorker =
+      hasStraightHookEdges &&
+      (nodeInteractionActive || nodeInteractionJustReleased)
     const useWorker = shouldUseEdgeGeometryWorker({
       hasRunInitialSolve: hasRunInitialSolveRef.current,
       edgeCount: solverEdges.length,
       threshold: EDGE_GEOMETRY_WORKER_EDGE_THRESHOLD,
       disabled: workerDisabledRef.current,
+      force: forceStraightInteractionWorker,
     })
 
     if (!useWorker) {
@@ -394,7 +405,8 @@ export const EdgeGeometrySolver = () => {
 
     // Keep every settled route attached to its moving/resizing endpoints while
     // the Worker proves the new optimum. This projection is display-only and
-    // orthogonal; the accepted exact generation replaces it atomically.
+    // preserves each edge family's path geometry; the accepted exact generation
+    // replaces it atomically.
     const publishProjectedPreview = (
       baseRoutes: Readonly<Record<string, IPoint[]>>,
       baseNodes: EdgeGeometryNodeSnapshot | null
@@ -407,7 +419,8 @@ export const EdgeGeometrySolver = () => {
             baseRoutes,
             latestInput.edges,
             baseNodes,
-            latestNodes
+            latestNodes,
+            STRAIGHT_HOOK_EDGE_TYPES
           )
         : baseRoutes
       const currentOverride = latestInput.liveOverride
@@ -492,6 +505,43 @@ export const EdgeGeometrySolver = () => {
       lastHolisticPreviewAtRef.current = now
     }
 
+    const publishWorkerInteractionResult = (
+      result: EdgeGeometrySolveResult
+    ) => {
+      const submittedNodeGeometry = submittedNodeGeometryRef.current.get(
+        result.revision
+      )
+      submittedNodeGeometryRef.current.delete(result.revision)
+      if (!submittedNodeGeometry) return
+      const latestInput = latestSolverInputRef.current
+      const latestNodes = latestNodeGeometryRef.current
+      if (!latestInput || !latestNodes) return
+      const candidateAtPointer = projectRoutesWhileSolving(
+        result.routeById,
+        latestInput.edges,
+        submittedNodeGeometry,
+        latestNodes,
+        STRAIGHT_HOOK_EDGE_TYPES
+      )
+      const stabilization = stabilizeProvisionalRoutes({
+        displayedById:
+          geometryStore?.getState().previewById ?? settledRoutesRef.current,
+        candidateById: candidateAtPointer,
+        edges: latestInput.edges,
+        nodes: latestNodes,
+        pendingDecisionById: provisionalDecisionRef.current,
+        holdDecisionEdgeTypes: nodeInteractionActiveRef.current
+          ? STRAIGHT_HOOK_EDGE_TYPES
+          : undefined,
+      })
+      if (import.meta.env.DEV || import.meta.env.VITE_E2E === "true")
+        recordPreviewDecisionStabilization(stabilization)
+      provisionalRoutesRef.current = stabilization.routeById
+      provisionalNodeGeometryRef.current = latestNodes
+      publishProjectedPreview(stabilization.routeById, latestNodes)
+      observeHolisticPreview(performance.now())
+    }
+
     let controller = workerControllerRef.current
     if (!controller) {
       if (typeof Worker === "undefined") {
@@ -518,6 +568,14 @@ export const EdgeGeometrySolver = () => {
               if (snapshotRevision !== undefined)
                 recordWorkerRevision("accepted", snapshotRevision)
               recordWorkerSolve()
+            }
+            // A current Worker response may arrive while the pointer merely
+            // pauses. Treat it as a display refinement, not as permission to
+            // reorganize valid straight routes mid-gesture. Pointer-up submits
+            // one final exact generation which settles normally below.
+            if (nodeInteractionActiveRef.current) {
+              publishWorkerInteractionResult(result)
+              return
             }
             const releaseStartedAt = releaseStartedAtRef.current
             if (releaseStartedAt !== null)
@@ -601,39 +659,10 @@ export const EdgeGeometrySolver = () => {
           },
           onProvisionalResult: (result) => {
             observeWorkerResult(result)
-            const submittedNodeGeometry = submittedNodeGeometryRef.current.get(
-              result.revision
-            )
-            submittedNodeGeometryRef.current.delete(result.revision)
-            if (!submittedNodeGeometry) return
-            const latestInput = latestSolverInputRef.current
-            const latestNodes = latestNodeGeometryRef.current
-            if (!latestInput || !latestNodes) return
-            const candidateAtPointer = projectRoutesWhileSolving(
-              result.routeById,
-              latestInput.edges,
-              submittedNodeGeometry,
-              latestNodes
-            )
-            const stabilization = stabilizeProvisionalRoutes({
-              displayedById:
-                geometryStore?.getState().previewById ??
-                settledRoutesRef.current,
-              candidateById: candidateAtPointer,
-              edges: latestInput.edges,
-              nodes: latestNodes,
-              pendingDecisionById: provisionalDecisionRef.current,
-            })
-            if (import.meta.env.DEV || import.meta.env.VITE_E2E === "true")
-              recordPreviewDecisionStabilization(stabilization)
             // The version gate still prevents this sampled generation from
             // settling. Its coordinate refinements can flow immediately, while
-            // a changed side/port/route decision must survive the next exact
-            // sample before it replaces the display baseline.
-            provisionalRoutesRef.current = stabilization.routeById
-            provisionalNodeGeometryRef.current = latestNodes
-            publishProjectedPreview(stabilization.routeById, latestNodes)
-            observeHolisticPreview(performance.now())
+            // straight routes keep valid topology for the complete node gesture.
+            publishWorkerInteractionResult(result)
           },
           onFailure: fallbackToLatestSnapshot,
           onIdle: () => submitLatestWorkerSnapshotRef.current?.(),
@@ -741,6 +770,7 @@ export const EdgeGeometrySolver = () => {
       shouldSampleEdgeGeometryWorker({
         edgeCount: solverEdges.length,
         interacting,
+        force: forceStraightInteractionWorker,
       })
     ) {
       // Keep the earliest timer instead of restarting it on every pointer frame.
@@ -789,6 +819,7 @@ export const EdgeGeometrySolver = () => {
       latestSnapshotDirtyRef.current = false
       workerRequestTimingRef.current.clear()
       interactionActiveRef.current = false
+      nodeInteractionActiveRef.current = false
       interactionStartedAtRef.current = null
       lastHolisticPreviewAtRef.current = null
       releaseStartedAtRef.current = null

--- a/library/lib/components/EdgeGeometrySolver.tsx
+++ b/library/lib/components/EdgeGeometrySolver.tsx
@@ -318,19 +318,32 @@ export const EdgeGeometrySolver = () => {
       const acceptedNodeGeometry = snapshotEdgeGeometryNodes(
         solveInput.nodeLookup
       )
+      const geometryState = geometryStore?.getState()
+      const stabilization = interacting
+        ? stabilizeProvisionalRoutes({
+            displayedById:
+              Object.keys(geometryState?.previewById ?? {}).length > 0
+                ? (geometryState?.previewById ?? {})
+                : (geometryState?.geometryById ?? {}),
+            candidateById: routeById,
+            edges: solveInput.edges,
+            nodes: acceptedNodeGeometry,
+            pendingDecisionById: provisionalDecisionRef.current,
+          })
+        : null
+      if (!interacting) provisionalDecisionRef.current.clear()
       if (
         !setAllGeometry(
           routeById,
           routingEpoch,
           acceptedNodeGeometry,
-          undefined
+          stabilization?.routeById
         )
       )
         return
       releasedEdgePreviewRef.current = null
       provisionalRoutesRef.current = null
       provisionalNodeGeometryRef.current = null
-      provisionalDecisionRef.current.clear()
       settledRoutesRef.current =
         geometryStore?.getState().geometryById ?? routeById
       settledNodeGeometryRef.current = acceptedNodeGeometry

--- a/library/lib/components/EdgeGeometrySolver.tsx
+++ b/library/lib/components/EdgeGeometrySolver.tsx
@@ -326,7 +326,15 @@ export const EdgeGeometrySolver = () => {
                 ? (geometryState?.previewById ?? {})
                 : (geometryState?.geometryById ?? {}),
             candidateById: routeById,
-            edges: solveInput.edges,
+            // Synchronous hysteresis is new for the automatically routed
+            // straight-polyline families. Keep legacy step-edge interaction
+            // immediate: required-interface socket bundling, reconnect previews,
+            // and other route-sensitive adornments rely on the exact live route.
+            // Large-diagram Worker previews retain their existing holistic
+            // stabilization below.
+            edges: solveInput.edges.filter((edge) =>
+              STRAIGHT_HOOK_EDGE_TYPES.has(edge.type ?? "")
+            ),
             nodes: acceptedNodeGeometry,
             pendingDecisionById: provisionalDecisionRef.current,
           })

--- a/library/lib/edges/GenericEdge.tsx
+++ b/library/lib/edges/GenericEdge.tsx
@@ -528,8 +528,10 @@ export const EdgeBendHandle = ({
  * handle on the point itself, not the step edge's elongated segment pill, and it
  * carries a `move` cursor because it travels in two dimensions rather than one.
  *
- * Every authored interior vertex gets one. Segment midpoints carry the same opaque
- * handle as step-edge bendable segments; dragging one materialises a waypoint.
+ * Every interior vertex of the rendered route gets one, whether the user placed it
+ * or the router did: dragging an automatic bend is how you take ownership of a route
+ * the solver chose. Segment midpoints carry the same opaque handle as step-edge
+ * bendable segments; dragging one materialises a waypoint.
  */
 export const EdgeWaypointHandles = ({
   route,
@@ -542,7 +544,7 @@ export const EdgeWaypointHandles = ({
 }: {
   /** Full route `[source, ...interior, target]`. */
   route: IPoint[]
-  /** The editable authored interior vertices. */
+  /** The editable interior vertices — every bend on the rendered route. */
   interior: IPoint[]
   selectedWaypointIndex: number | null
   onWaypointPointerDown: (

--- a/library/lib/hooks/useConnect.ts
+++ b/library/lib/hooks/useConnect.ts
@@ -226,11 +226,16 @@ export const useConnect = () => {
           // central solver can immediately move the endpoint to an automatic seat.
           const edgeId = pendingConnectionId.current
           if (edgeId && connectionState.toNode) {
-            // `FinalConnectionState.to` is the exact validated handle centre in
-            // screen coordinates; convert that point, rather than the release
-            // event's potentially offset pointer, into the node's flow-space rect.
+            // Continuous outlines intentionally follow the aimed drop point that
+            // their snap circle previews. Other native targets use the validated
+            // handle centre, so an off-centre release inside a handle cannot shift
+            // the committed endpoint. In both cases `toNode` remains authoritative:
+            // overlapping scene nodes never replace React Flow's validated target.
+            const targetPoint = dropAnchorIsAimed(connectionState.toNode.type)
+              ? getDropPosition(event)
+              : screenToFlowPosition(connectionState.to)
             const anchor = getNativeConnectionAnchor({
-              to: screenToFlowPosition(connectionState.to),
+              to: targetPoint,
               toNode: connectionState.toNode,
             })
             if (anchor) {

--- a/library/lib/hooks/useConnect.ts
+++ b/library/lib/hooks/useConnect.ts
@@ -17,6 +17,7 @@ import {
 import {
   dropAnchorIsAimed,
   getEdgeAnchorFromPoint,
+  getNativeConnectionAnchor,
 } from "@/utils/connectionModes"
 import { HandleId } from "@/nodes/wrappers"
 import { useDiagramStore, useMetadataStore } from "@/store/context"
@@ -224,17 +225,14 @@ export const useConnect = () => {
           // hint. Persist the preview's resolved anchor on commit; otherwise the
           // central solver can immediately move the endpoint to an automatic seat.
           const edgeId = pendingConnectionId.current
-          const dropPosition = getDropPosition(event)
-          const nodeOnTop = resolveDropTarget(
-            dropPosition,
-            connectionState.fromNode?.id
-          )
-          if (edgeId && nodeOnTop) {
-            const anchor = getEdgeAnchorFromPoint(
-              nodeOnTop.type,
-              dropPosition,
-              nodeOnTop.rect
-            )
+          if (edgeId && connectionState.toNode) {
+            // `FinalConnectionState.to` is the exact validated handle centre in
+            // screen coordinates; convert that point, rather than the release
+            // event's potentially offset pointer, into the node's flow-space rect.
+            const anchor = getNativeConnectionAnchor({
+              to: screenToFlowPosition(connectionState.to),
+              toNode: connectionState.toNode,
+            })
             if (anchor) {
               const endpoint =
                 connectionStartParams.current?.handleType === "target"
@@ -372,6 +370,7 @@ export const useConnect = () => {
       edges,
       getDropPosition,
       resolveDropTarget,
+      screenToFlowPosition,
       setEdges,
       stopConnectionGuidance,
       setPendingConnectionEdge,

--- a/library/lib/hooks/useConnect.ts
+++ b/library/lib/hooks/useConnect.ts
@@ -219,7 +219,40 @@ export const useConnect = () => {
   const onConnectEnd: OnConnectEnd = useCallback(
     (event, connectionState) => {
       try {
-        if (!connectionState.isValid) {
+        if (connectionState.isValid) {
+          // A valid native handle is an exact attachment point, not merely a side
+          // hint. Persist the preview's resolved anchor on commit; otherwise the
+          // central solver can immediately move the endpoint to an automatic seat.
+          const edgeId = pendingConnectionId.current
+          const dropPosition = getDropPosition(event)
+          const nodeOnTop = resolveDropTarget(
+            dropPosition,
+            connectionState.fromNode?.id
+          )
+          if (edgeId && nodeOnTop) {
+            const anchor = getEdgeAnchorFromPoint(
+              nodeOnTop.type,
+              dropPosition,
+              nodeOnTop.rect
+            )
+            if (anchor) {
+              const endpoint =
+                connectionStartParams.current?.handleType === "target"
+                  ? "source"
+                  : "target"
+              setEdges((eds) =>
+                eds.map((edge) =>
+                  edge.id === edgeId
+                    ? {
+                        ...edge,
+                        data: withEndpointAnchor(edge.data, endpoint, anchor),
+                      }
+                    : edge
+                )
+              )
+            }
+          }
+        } else {
           const dropPosition = getDropPosition(event)
           const nodeOnTop = resolveDropTarget(
             dropPosition,

--- a/library/lib/hooks/useStraightPathEdge.ts
+++ b/library/lib/hooks/useStraightPathEdge.ts
@@ -386,41 +386,23 @@ export const useStraightPathEdge = ({
     }),
     [adjustedTargetCoordinates.targetX, adjustedTargetCoordinates.targetY]
   )
-  // The authored route is source → interior waypoints → target. Automatic
-  // straight-edge routing is deliberately a separate concern: this branch
-  // renders only user intent and the endpoint preview already present on main.
+  // The synchronous truth: source → interior waypoints → target. Used as the
+  // fallback before the solver's route lands and whenever the solver route is
+  // stale (its endpoints no longer match, e.g. mid node-move) so the edge never
+  // detaches from its nodes.
   const basePoints = useMemo<IPoint[]>(
     () => [sourceEndpoint, ...interiorPoints, targetEndpoint],
     [sourceEndpoint, interiorPoints, targetEndpoint]
   )
-  const centralPreviewMatchesCommit =
-    dragPreviewPoints !== null &&
-    endpointPreviewCommit !== null &&
-    centralRoute !== undefined &&
-    centralRoute.length >= 2 &&
-    (endpointPreviewCommit.endpoint === "source"
-      ? centralRoute[0].x === endpointPreviewCommit.sourceEndpoint.x &&
-        centralRoute[0].y === endpointPreviewCommit.sourceEndpoint.y
-      : centralRoute[centralRoute.length - 1].x ===
-          endpointPreviewCommit.targetEndpoint.x &&
-        centralRoute[centralRoute.length - 1].y ===
-          endpointPreviewCommit.targetEndpoint.y)
+  // The solver's committed route is the source of truth: its endpoints are the
+  // facing-side attachment sites the port assignment chose (not the drawn handle),
+  // and it carries any automatic obstacle-avoidance bends. Fall back to the analytic
+  // base polyline only before the first solve lands (never painted after that).
   const renderPoints = useMemo<IPoint[]>(
     () =>
-      centralPreviewMatchesCommit
-        ? [
-            centralRoute[0],
-            ...interiorPoints,
-            centralRoute[centralRoute.length - 1],
-          ]
-        : (dragPreviewPoints ?? basePoints),
-    [
-      basePoints,
-      centralPreviewMatchesCommit,
-      centralRoute,
-      dragPreviewPoints,
-      interiorPoints,
-    ]
+      dragPreviewPoints ??
+      (centralRoute && centralRoute.length >= 2 ? centralRoute : basePoints),
+    [basePoints, centralRoute, dragPreviewPoints]
   )
   const renderSourcePosition =
     dragPreviewPositions?.sourcePosition ?? resolvedSourcePosition
@@ -505,8 +487,10 @@ export const useStraightPathEdge = ({
 
   const sourcePoint = renderPoints[0]
   const targetPoint = renderPoints[renderPoints.length - 1]
-  // Every authored bend is editable. Automatic detours are introduced by the
-  // separate auto-layout/routing change and can later reuse the same controls.
+  // Every bend on the RENDERED route is editable, not only the authored ones. An
+  // automatic detour is a perfectly good starting point for a hand-placed route:
+  // dragging one of its bends is how the user takes ownership of it, exactly as
+  // dragging a computed step edge freezes its path into manual points.
   const editableWaypoints = useMemo<IPoint[]>(
     () => (dragHandleRoute ?? renderPoints).slice(1, -1),
     [dragHandleRoute, renderPoints]
@@ -777,9 +761,11 @@ export const useStraightPathEdge = ({
     ]
   )
 
-  // Persist the interior waypoints and pin their visible endpoints when the first
-  // bend is authored. This mirrors the step-edge bend-commit behaviour and keeps
-  // later geometry updates from moving a hand-shaped route at its ends.
+  // Persist the interior waypoints. A bend customises the whole visible route,
+  // including the facing-side attachment sites the port assignment chose, so on the
+  // first bend the endpoints are pinned to `pinSource`/`pinTarget` (when still
+  // automatic) — otherwise a newly-bent edge would snap its endpoints back to the
+  // drawn handle. Mirrors the step-edge bend-commit behaviour.
   const commitWaypoints = useCallback(
     (nextInterior: IPoint[], pinSource: IPoint, pinTarget: IPoint) => {
       setEdges((edges) =>
@@ -825,7 +811,8 @@ export const useStraightPathEdge = ({
 
   // Shared drag routine for both an existing waypoint and a freshly materialised
   // one. `startInterior` is the interior array the drag operates on; `index` is the
-  // waypoint being moved. Only pointer-up commits `data.points`.
+  // waypoint being moved. The live route is published so neighbouring step edges
+  // reflow around the dragged diagonal, and only pointer-up commits `data.points`.
   const beginWaypointDrag = useCallback(
     (
       pointerId: number,
@@ -840,8 +827,10 @@ export const useStraightPathEdge = ({
       dragInteriorRef.current = startInterior
       dragMovedRef.current = movedAtStart
       dragCollapseRef.current = false
-      // Capture the endpoints at gesture start so the preview and eventual commit
-      // pivot around stable attachment sites.
+      // The endpoints the drag pivots around are the CURRENTLY RENDERED attachment
+      // sites (the solver's facing-side ports), captured at gesture start — not the
+      // drawn handle — so the route and the pinned commit keep the edge attached
+      // exactly where it is on screen.
       const routeSource = sourcePoint
       const routeTarget = targetPoint
       const collapseTolerance =
@@ -852,7 +841,8 @@ export const useStraightPathEdge = ({
       const angleReference = routeAtStart[index + 2] ?? routeAtStart[index]
 
       // Drive the preview through state; the existing layout effect republishes it
-      // to shared edge geometry and clears it when the drag ends.
+      // as an authoritative live override so neighbouring step edges reflow around
+      // the dragged diagonal, and clears it when the drag ends.
       const publish = (
         pathInterior: IPoint[],
         handleInterior: IPoint[] = pathInterior

--- a/library/lib/i18n/labels.ts
+++ b/library/lib/i18n/labels.ts
@@ -27,6 +27,12 @@ export interface ApollonLabels {
    * remains assignable; {@link mergeLabels} always fills the English default.
    */
   moveEdgeWaypoint?: string
+  /** Syntax-tree tidy-layout button (accessible name). */
+  tidyLayout?: string
+  /** Syntax-tree tidy-layout tooltip. */
+  tidyLayoutHint?: string
+  /** Accessible name for a straight-edge segment midpoint create handle. */
+  addEdgeWaypoint?: string
 
   // Minimap
   miniMap: string
@@ -319,6 +325,9 @@ const RESOLVED_DEFAULT_LABELS: ResolvedApollonLabels = Object.freeze({
   redoHint: "Redo (Ctrl+Y or Ctrl+Shift+Z)",
   multiSelection: "Select multiple elements",
   multiSelectionHint: "Select multiple: click elements to add or remove",
+  tidyLayout: "Tidy tree layout",
+  tidyLayoutHint: "Arrange the syntax tree so links no longer overlap nodes",
+  addEdgeWaypoint: "Drag to add a waypoint",
   moveEdgeWaypoint:
     "Waypoint: drag to move, double-click or press Delete to remove",
   miniMap: "Mini map",

--- a/library/lib/store/diagramStore.ts
+++ b/library/lib/store/diagramStore.ts
@@ -19,6 +19,7 @@ import {
   STORE_ORIGIN,
 } from "@/sync/ydoc"
 import { recordStoreNodeWrite } from "@/sync/perfCounters"
+import { computeTidyLayout } from "@/utils/tidyTree"
 import { deepEqual } from "@/utils/storeUtils"
 import { Assessment, DraggingNode, InteractiveElements } from "@/typings"
 import {
@@ -153,6 +154,9 @@ export type DiagramStore = {
    */
   endTransientNodeBroadcast: () => void
   setNodes: (payload: Node[] | ((nodes: Node[]) => Node[])) => void
+  /** Reposition syntax-tree nodes into a tidy hierarchical layout (issue #282).
+   * A single undo step; a no-op on non-syntax-tree or already-tidy diagrams. */
+  layoutSyntaxTree: () => void
   setEdges: (payload: Edge[] | ((edges: Edge[]) => Edge[])) => void
   setNodesAndEdges: (nodes: Node[], edges: Edge[]) => void
   addEdge: (edge: Edge) => void
@@ -501,6 +505,13 @@ export const createDiagramStore = (
               undefined,
               "setNodes"
             )
+          },
+
+          layoutSyntaxTree: () => {
+            // Tidy the syntax tree by repositioning nodes (issue #282). Routed
+            // through `setNodes`, so it is a single Yjs transaction / one undo step
+            // and the deep-equal guard makes an already-tidy layout a no-op.
+            get().setNodes(computeTidyLayout(get().nodes, get().edges))
           },
 
           setEdges: (payload) => {

--- a/library/lib/utils/connectionModes.ts
+++ b/library/lib/utils/connectionModes.ts
@@ -1,4 +1,9 @@
-import { Position, type Rect, type XYPosition } from "@xyflow/system"
+import {
+  Position,
+  type InternalNodeBase,
+  type Rect,
+  type XYPosition,
+} from "@xyflow/system"
 import {
   type FreeformEdgeAnchor,
   getFreeformAnchorFromPoint,
@@ -266,6 +271,31 @@ export function getEdgeAnchorFromPoint(
     default:
       return getFreeformAnchorFromPoint(point, rect)
   }
+}
+
+/**
+ * Resolve a valid React Flow native-handle target from its authoritative
+ * connection state. The release pointer and scene hit-testing are intentionally
+ * absent: a pointer may sit anywhere inside the handle, and overlapping nodes must
+ * not replace `toNode`, which is the target React Flow actually validated.
+ */
+export function getNativeConnectionAnchor({
+  to,
+  toNode,
+}: {
+  to: XYPosition
+  toNode: InternalNodeBase | null
+}): FreeformEdgeAnchor | null {
+  if (!toNode) return null
+  const width = toNode.measured.width ?? toNode.width
+  const height = toNode.measured.height ?? toNode.height
+  if (width === undefined || height === undefined || width <= 0 || height <= 0)
+    return null
+  return getEdgeAnchorFromPoint(toNode.type, to, {
+    ...toNode.internals.positionAbsolute,
+    width,
+    height,
+  })
 }
 
 /**

--- a/library/lib/utils/connectionModes.ts
+++ b/library/lib/utils/connectionModes.ts
@@ -286,16 +286,24 @@ export function getNativeConnectionAnchor({
   to: XYPosition
   toNode: InternalNodeBase | null
 }): FreeformEdgeAnchor | null {
+  const rect = getNativeConnectionRect(toNode)
+  return rect ? getEdgeAnchorFromPoint(toNode?.type, to, rect) : null
+}
+
+/** Flow-space bounds for the node React Flow validated during a connection. */
+export function getNativeConnectionRect(
+  toNode: InternalNodeBase | null
+): Rect | null {
   if (!toNode) return null
   const width = toNode.measured.width ?? toNode.width
   const height = toNode.measured.height ?? toNode.height
   if (width === undefined || height === undefined || width <= 0 || height <= 0)
     return null
-  return getEdgeAnchorFromPoint(toNode.type, to, {
+  return {
     ...toNode.internals.positionAbsolute,
     width,
     height,
-  })
+  }
 }
 
 /**

--- a/library/lib/utils/geometry/edgeGeometryPreview.ts
+++ b/library/lib/utils/geometry/edgeGeometryPreview.ts
@@ -141,9 +141,12 @@ const routeDirectionKey = (points: readonly IPoint[]): string | null => {
       directions.push(point.x > previous.x ? "R" : "L")
     else if (previous.x === point.x)
       directions.push(point.y > previous.y ? "D" : "U")
-    else return null
+    else
+      directions.push(
+        `${point.y > previous.y ? "D" : "U"}${point.x > previous.x ? "R" : "L"}`
+      )
   }
-  return directions.join("")
+  return directions.length > 0 ? directions.join(",") : null
 }
 
 const relativeEndpointKey = (
@@ -180,22 +183,25 @@ const segmentIntersectsRect = (
   b: IPoint,
   rect: EdgeGeometryNodeRect
 ): boolean => {
-  const right = rect.x + rect.width
-  const bottom = rect.y + rect.height
-  if (a.y === b.y)
-    return (
-      a.y >= rect.y &&
-      a.y <= bottom &&
-      Math.max(a.x, b.x) >= rect.x &&
-      Math.min(a.x, b.x) <= right
-    )
-  if (a.x === b.x)
-    return (
-      a.x >= rect.x &&
-      a.x <= right &&
-      Math.max(a.y, b.y) >= rect.y &&
-      Math.min(a.y, b.y) <= bottom
-    )
+  // Slab intersection works for orthogonal and diagonal segments alike. The
+  // preview safety check is inclusive: a held route touching a node border should
+  // yield immediately to the new exact route rather than flicker beneath the node.
+  let entry = 0
+  let exit = 1
+  for (const [start, delta, min, max] of [
+    [a.x, b.x - a.x, rect.x, rect.x + rect.width],
+    [a.y, b.y - a.y, rect.y, rect.y + rect.height],
+  ] as const) {
+    if (delta === 0) {
+      if (start < min || start > max) return false
+      continue
+    }
+    const first = (min - start) / delta
+    const second = (max - start) / delta
+    entry = Math.max(entry, Math.min(first, second))
+    exit = Math.min(exit, Math.max(first, second))
+    if (entry > exit) return false
+  }
   return true
 }
 
@@ -344,11 +350,52 @@ const normalizeSettlementRoute = (
   return normalized
 }
 
+const interpolate = (from: number, to: number, progress: number): number =>
+  from + (to - from) * progress
+
 /**
- * Pair two orthogonal routes so point-wise interpolation stays orthogonal even
- * when their first direction or bend count differs. Zero-length leading/trailing
- * segments align both alternating H/V sequences; simplifying either endpoint
- * yields the original route exactly.
+ * Sample a polyline at equal arc-length intervals. This is used only for the
+ * display handoff of arbitrary-angle routes; exact routing stays integer and
+ * history-independent.
+ */
+const sampleSettlementRoute = (
+  route: readonly IPoint[],
+  pointCount: number
+): IPoint[] => {
+  const points = simplify(route)
+  const lengths: number[] = []
+  let total = 0
+  for (let index = 1; index < points.length; index++) {
+    total += Math.hypot(
+      points[index].x - points[index - 1].x,
+      points[index].y - points[index - 1].y
+    )
+    lengths.push(total)
+  }
+  if (total === 0)
+    return Array.from({ length: pointCount }, () => ({ ...points[0] }))
+
+  return Array.from({ length: pointCount }, (_, index) => {
+    const distance = (total * index) / (pointCount - 1)
+    let segment = lengths.findIndex((end) => end >= distance)
+    if (segment < 0) segment = lengths.length - 1
+    const startDistance = segment === 0 ? 0 : lengths[segment - 1]
+    const endDistance = lengths[segment]
+    const progress =
+      endDistance === startDistance
+        ? 0
+        : (distance - startDistance) / (endDistance - startDistance)
+    return {
+      x: interpolate(points[segment].x, points[segment + 1].x, progress),
+      y: interpolate(points[segment].y, points[segment + 1].y, progress),
+    }
+  })
+}
+
+/**
+ * Pair two routes for point-wise display interpolation. Orthogonal pairs keep the
+ * orientation-preserving zero-segment normalization. If either route is diagonal,
+ * equal arc-length samples let bends appear, disappear, or change side smoothly.
  */
 const normalizeSettlementPair = (
   fromRoute: readonly IPoint[],
@@ -370,8 +417,13 @@ const normalizeSettlementPair = (
       (orientation, index) =>
         index > 0 && orientation === toOrientations[index - 1]
     )
-  )
-    return null
+  ) {
+    const pointCount = Math.max(from.length, to.length, 3)
+    return {
+      from: sampleSettlementRoute(from, pointCount),
+      to: sampleSettlementRoute(to, pointCount),
+    }
+  }
 
   const canonicalStart = fromOrientations[0]
   const fromLeading = 0
@@ -387,9 +439,9 @@ const normalizeSettlementPair = (
 }
 
 /**
- * Capture only routes whose accepted result differs from the current display and
- * can be morphed without ever drawing a diagonal. Exact geometry is free to
- * settle immediately; these pairs are a short display-only handoff.
+ * Capture routes whose accepted result differs from the current display.
+ * Orthogonal routes remain orthogonal throughout the handoff; arbitrary-angle
+ * routes use arc-length sampling so topology changes do not snap into place.
  */
 export const prepareEdgeGeometrySettlement = (
   displayedById: Readonly<Record<string, IPoint[]>>,
@@ -416,13 +468,11 @@ export const prepareEdgeGeometrySettlement = (
   return transitions
 }
 
-const interpolate = (from: number, to: number, progress: number): number =>
-  from + (to - from) * progress
-
 /**
  * Return the transient display routes for one settlement frame. The cubic ease
  * moves decisively away from the stale preview and arrives gently at the exact
- * route. Every intermediate segment remains horizontal or vertical.
+ * route. Orthogonal transitions stay orthogonal; straight-edge polylines can
+ * interpolate at arbitrary angles.
  */
 export const interpolateEdgeGeometrySettlement = (
   transitions: EdgeGeometrySettlementTransition,

--- a/library/lib/utils/geometry/edgeGeometryPreview.ts
+++ b/library/lib/utils/geometry/edgeGeometryPreview.ts
@@ -34,6 +34,7 @@ export type EdgeGeometrySettlementTransition = Readonly<
 >
 
 export type ProvisionalRouteDecisionState = Map<string, string>
+const NO_EDGE_TYPES: ReadonlySet<string> = new Set()
 
 /**
  * Keep the just-authored display route across pointer-up until the release solve
@@ -260,12 +261,17 @@ export const stabilizeProvisionalRoutes = ({
   edges,
   nodes,
   pendingDecisionById,
+  holdDecisionEdgeTypes,
 }: {
   displayedById: Readonly<Record<string, IPoint[]>>
   candidateById: Readonly<Record<string, IPoint[]>>
   edges: readonly Edge[]
   nodes: EdgeGeometryNodeSnapshot
   pendingDecisionById: ProvisionalRouteDecisionState
+  /** During direct node manipulation, keep a valid displayed topology for these
+   * edge types until release. Coordinate refinements still flow immediately and
+   * an old route that enters another node is still replaced without delay. */
+  holdDecisionEdgeTypes?: ReadonlySet<string>
 }): {
   routeById: Record<string, IPoint[]>
   heldDecisionCount: number
@@ -314,7 +320,11 @@ export const stabilizeProvisionalRoutes = ({
       if (displayedInvalid) invalidatedDecisionCount++
       continue
     }
-    if (pendingDecisionById.get(edgeId) === candidateDecision) {
+    const holdForGesture = holdDecisionEdgeTypes?.has(edge.type ?? "") ?? false
+    if (
+      !holdForGesture &&
+      pendingDecisionById.get(edgeId) === candidateDecision
+    ) {
       stabilized[edgeId] = candidate
       pendingDecisionById.delete(edgeId)
       confirmedDecisionCount++
@@ -515,7 +525,8 @@ export const projectRoutesWhileSolving = (
   routeById: Readonly<Record<string, IPoint[]>>,
   edges: readonly Edge[],
   settledNodes: EdgeGeometryNodeSnapshot,
-  currentNodes: EdgeGeometryNodeSnapshot
+  currentNodes: EdgeGeometryNodeSnapshot,
+  straightEdgeTypes: ReadonlySet<string> = NO_EDGE_TYPES
 ): Record<string, IPoint[]> => {
   const edgeById = new Map(edges.map((edge) => [edge.id, edge]))
   const projected: Record<string, IPoint[]> = {}
@@ -551,6 +562,15 @@ export const projectRoutesWhileSolving = (
         fromTarget,
         toTarget
       )
+
+    // Straight-hook routes deliberately contain arbitrary-angle segments. Keep
+    // their settled bends fixed and attach only the terminals to the moving node.
+    // Running them through the orthogonal projection below turns a two-point
+    // diagonal into a four-segment step route until the Worker responds.
+    if (straightEdgeTypes.has(edge.type ?? "")) {
+      projected[edgeId] = simplify(desired)
+      continue
+    }
 
     if (desired.length === 2) {
       const source = desired[0]

--- a/library/lib/utils/geometry/edgeGeometrySolver.ts
+++ b/library/lib/utils/geometry/edgeGeometrySolver.ts
@@ -1552,87 +1552,32 @@ function computeAllEdgeGeometryPass(
       let straightTarget = endpoints.adjustedTarget
       let straightSourceSide = endpoints.sourcePosition
       let straightTargetSide = endpoints.targetPosition
-      const sourceType = nodeById.get(edge.source)?.type
-      const targetType = nodeById.get(edge.target)?.type
-      const { edgeRoutes: neighborEdges } = collectNeighbors(
+      // Straight sides and fan seats were already selected jointly above. They
+      // are authoritative here: sending this single fixed pair through the
+      // orthogonal joint-anchor A* cannot choose a different endpoint, yet makes
+      // every straight edge pay for a lattice containing all corridor nodes.
+      const selectedEndpoints = resolveEdgeEndpoints(
         edge,
-        endpoints,
         nodes,
-        nodeIndex,
-        straightObstacles,
-        routeById,
-        neighborGrid,
-        edgeById
+        nodeById,
+        nodeLookup,
+        connectionMode,
+        {
+          sourceAnchor:
+            asFreeformAnchor(edge.data?.sourceAnchor) ??
+            coordinatedStraightPort(edge.id, "source"),
+          targetAnchor:
+            asFreeformAnchor(edge.data?.targetAnchor) ??
+            coordinatedStraightPort(edge.id, "target"),
+        },
+        true,
+        nodeIndex
       )
-      const selected = selectEdgeAnchors({
-        sourceRect: rectFromEndpoint(
-          endpoints.sourceAbsolutePosition,
-          endpoints.sourceSize
-        ),
-        targetRect: rectFromEndpoint(
-          endpoints.targetAbsolutePosition,
-          endpoints.targetSize
-        ),
-        sourceType,
-        targetType,
-        // On a node side shared with other connectors the coordinated seat is
-        // AUTHORITATIVE, not a suggestion. A straight edge can always shorten
-        // itself by aiming its port straight at the partner, so a soft
-        // preference loses every time — and the whole fan collapses onto one or
-        // two points, which is how two edges end up leaving from the SAME pixel.
-        // Pinning the seat is what keeps the fan evenly spread and symmetric.
-        // Lone ends are absent from the band and stay free to optimise.
-        sourceCustom:
-          asFreeformAnchor(edge.data?.sourceAnchor) ??
-          coordinatedStraightPort(edge.id, "source"),
-        targetCustom:
-          asFreeformAnchor(edge.data?.targetAnchor) ??
-          coordinatedStraightPort(edge.id, "target"),
-        resolve: (overrides) =>
-          resolveEdgeEndpoints(
-            edge,
-            nodes,
-            nodeById,
-            nodeLookup,
-            connectionMode,
-            overrides,
-            true,
-            nodeIndex
-          ),
-        // Side selection stays obstacle-aware for EVERY straight edge, so a
-        // stacked node makes the edge pick a side that clears it (a straight line
-        // that avoids the overlap) rather than one that runs through it. Only the
-        // bend-generating router below is gated per type.
-        obstacles: straightObstacles,
-        thirdPartyObstacles: straightObstacles.filter(
-          (o) => !o.soft && o.id !== edge.source && o.id !== edge.target
-        ),
-        neighborEdges,
-        enableStraightPath: true,
-      })
-      // Sibling carve-out (the same one the orthogonal neighbour scan makes):
-      // connectors that share a node with this edge are MEANT to fan out from it
-      // side by side. Pricing that as crowding makes the search shove the
-      // departure sideways into exactly the grazing exit we are trying to remove.
-      // Unrelated edges still contribute crossing/overlap/crowding cost.
-      const shares = (other: Edge): boolean =>
-        other.source === edge.source ||
-        other.source === edge.target ||
-        other.target === edge.source ||
-        other.target === edge.target
-      const straightNeighbors: IPoint[][] = []
-      const straightSiblings: IPoint[][] = []
-      for (const [otherId, route] of Object.entries(routeById)) {
-        if (otherId === edge.id || route.length < 2) continue
-        const other = edgeById.get(otherId)
-        if (other && shares(other)) straightSiblings.push(route)
-        else straightNeighbors.push(route)
-      }
-      if (selected) {
-        straightSource = selected.endpoints.adjustedSource
-        straightTarget = selected.endpoints.adjustedTarget
-        straightSourceSide = selected.endpoints.sourcePosition
-        straightTargetSide = selected.endpoints.targetPosition
+      if (selectedEndpoints) {
+        straightSource = selectedEndpoints.adjustedSource
+        straightTarget = selectedEndpoints.adjustedTarget
+        straightSourceSide = selectedEndpoints.sourcePosition
+        straightTargetSide = selectedEndpoints.targetPosition
       }
       const line = routeStraightPolyline({
         source: straightSource,
@@ -1643,8 +1588,6 @@ function computeAllEdgeGeometryPass(
         obstacles: straightObstacles.filter(
           (o) => o.id !== edge.source && o.id !== edge.target
         ),
-        neighborRoutes: straightNeighbors,
-        siblingRoutes: straightSiblings,
         // Outer members of a fan turn on the outer corner ring, so siblings
         // clearing one obstacle nest instead of stacking on a single elbow.
         // `|ratio - 1/2|` is mirror-invariant, so the two halves of a symmetric

--- a/library/lib/utils/geometry/edgeGeometrySolver.ts
+++ b/library/lib/utils/geometry/edgeGeometrySolver.ts
@@ -96,26 +96,6 @@ const nodeWidth = (node: Node): number | undefined =>
 const nodeHeight = (node: Node): number | undefined =>
   node.height ?? node.measured?.height
 
-/** Expand a source/target corridor to include authored straight-edge checkpoints.
- * A checkpoint may sit far outside the endpoint-node box; querying obstacles only
- * in that box makes every blocker on the distant legs invisible to the router. */
-const includePointsInBounds = (
-  bounds: Rect,
-  points: readonly IPoint[]
-): Rect => {
-  let minX = bounds.x
-  let minY = bounds.y
-  let maxX = bounds.x + bounds.width
-  let maxY = bounds.y + bounds.height
-  for (const point of points) {
-    minX = Math.min(minX, point.x)
-    minY = Math.min(minY, point.y)
-    maxX = Math.max(maxX, point.x)
-    maxY = Math.max(maxY, point.y)
-  }
-  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
-}
-
 /**
  * Resolve one edge's endpoints, or `null` when the base position is unknowable
  * (a node not yet measured) so the caller can hold the previous route.
@@ -346,6 +326,14 @@ function outwardNormal(side: Position | undefined): IPoint | undefined {
       return undefined
   }
 }
+
+/**
+ * A 5% deadband around the aspect-scaled diagonal. This is deliberately
+ * deterministic rather than history-based: peers and cold re-solves still choose
+ * byte-identical sides, while an ordinary one-grid-cell drag no longer makes an
+ * endpoint jump across a node corner.
+ */
+const STRAIGHT_SIDE_DEADBAND_PERMILLE = 50
 
 function indexRoutePolyline(
   grid: NeighborGrid,
@@ -1356,12 +1344,20 @@ function computeAllEdgeGeometryPass(
     if (!fixedPorts.has(sourceKey) && !sideOverrideByEnd?.has(sourceKey))
       straightSideByEnd.set(
         sourceKey,
-        facingSide(sourceRect, centerOf(targetRect))
+        facingSide(
+          sourceRect,
+          centerOf(targetRect),
+          STRAIGHT_SIDE_DEADBAND_PERMILLE
+        )
       )
     if (!fixedPorts.has(targetKey) && !sideOverrideByEnd?.has(targetKey))
       straightSideByEnd.set(
         targetKey,
-        facingSide(targetRect, centerOf(sourceRect))
+        facingSide(
+          targetRect,
+          centerOf(sourceRect),
+          STRAIGHT_SIDE_DEADBAND_PERMILLE
+        )
       )
   }
   const originalPortEnds = collectPortEnds(
@@ -1526,19 +1522,23 @@ function computeAllEdgeGeometryPass(
     // lines, but they get the SAME sophistication as step edges up to the routing
     // primitive: an unbent, unpinned edge picks its facing sides and a balanced
     // centred port (via `selectEdgeAnchors` + the shared `assignPorts` band), while
-    // a bent edge keeps its authored waypoints. The chosen endpoints are then joined
-    // by a straight, obstacle-avoiding polyline (Track D) instead of an orthogonal
-    // route — waypoints ride along as mandatory checkpoints. The result enters the
-    // neighbour map so step edges route around it.
+    // a bent edge keeps its authored route exactly. Automatic edges are joined by a
+    // straight, obstacle-avoiding polyline (Track D) instead of an orthogonal route.
+    // Every result enters the neighbour map so later step edges route around it.
     if (straightHookTypes.has(edge.type ?? "")) {
       const interior = getStraightHookInterior(edge)
-      const straightCandidateBounds = includePointsInBounds(
-        candidateBounds,
-        interior
-      )
+      if (interior.length > 0) {
+        const authored = [
+          endpoints.adjustedSource,
+          ...interior,
+          endpoints.adjustedTarget,
+        ]
+        routeById[edge.id] = authored
+        indexRoutePolyline(neighborGrid, edge.id, authored)
+        continue
+      }
       // Every straight edge avoids intervening node bodies; the routing cost keeps
       // the detour readable (see `straightPolylineRouter`).
-      const avoidsObstacles = true
       const straightObstacles = getEdgeObstacles(
         nodes,
         edge.source,
@@ -1546,120 +1546,114 @@ function computeAllEdgeGeometryPass(
         endpoints.adjustedSource,
         endpoints.adjustedTarget,
         nodeIndex,
-        straightCandidateBounds
+        candidateBounds
       )
       let straightSource = endpoints.adjustedSource
       let straightTarget = endpoints.adjustedTarget
       let straightSourceSide = endpoints.sourcePosition
       let straightTargetSide = endpoints.targetPosition
-      let straightNeighbors: IPoint[][] = []
-      let straightSiblings: IPoint[][] = []
-      if (interior.length === 0) {
-        const sourceType = nodeById.get(edge.source)?.type
-        const targetType = nodeById.get(edge.target)?.type
-        const { edgeRoutes: neighborEdges } = collectNeighbors(
-          edge,
-          endpoints,
-          nodes,
-          nodeIndex,
-          straightObstacles,
-          routeById,
-          neighborGrid,
-          edgeById
-        )
-        const selected = selectEdgeAnchors({
-          sourceRect: rectFromEndpoint(
-            endpoints.sourceAbsolutePosition,
-            endpoints.sourceSize
+      const sourceType = nodeById.get(edge.source)?.type
+      const targetType = nodeById.get(edge.target)?.type
+      const { edgeRoutes: neighborEdges } = collectNeighbors(
+        edge,
+        endpoints,
+        nodes,
+        nodeIndex,
+        straightObstacles,
+        routeById,
+        neighborGrid,
+        edgeById
+      )
+      const selected = selectEdgeAnchors({
+        sourceRect: rectFromEndpoint(
+          endpoints.sourceAbsolutePosition,
+          endpoints.sourceSize
+        ),
+        targetRect: rectFromEndpoint(
+          endpoints.targetAbsolutePosition,
+          endpoints.targetSize
+        ),
+        sourceType,
+        targetType,
+        // On a node side shared with other connectors the coordinated seat is
+        // AUTHORITATIVE, not a suggestion. A straight edge can always shorten
+        // itself by aiming its port straight at the partner, so a soft
+        // preference loses every time — and the whole fan collapses onto one or
+        // two points, which is how two edges end up leaving from the SAME pixel.
+        // Pinning the seat is what keeps the fan evenly spread and symmetric.
+        // Lone ends are absent from the band and stay free to optimise.
+        sourceCustom:
+          asFreeformAnchor(edge.data?.sourceAnchor) ??
+          coordinatedStraightPort(edge.id, "source"),
+        targetCustom:
+          asFreeformAnchor(edge.data?.targetAnchor) ??
+          coordinatedStraightPort(edge.id, "target"),
+        resolve: (overrides) =>
+          resolveEdgeEndpoints(
+            edge,
+            nodes,
+            nodeById,
+            nodeLookup,
+            connectionMode,
+            overrides,
+            true,
+            nodeIndex
           ),
-          targetRect: rectFromEndpoint(
-            endpoints.targetAbsolutePosition,
-            endpoints.targetSize
-          ),
-          sourceType,
-          targetType,
-          // On a node side shared with other connectors the coordinated seat is
-          // AUTHORITATIVE, not a suggestion. A straight edge can always shorten
-          // itself by aiming its port straight at the partner, so a soft
-          // preference loses every time — and the whole fan collapses onto one or
-          // two points, which is how two edges end up leaving from the SAME pixel.
-          // Pinning the seat is what keeps the fan evenly spread and symmetric.
-          // Lone ends are absent from the band and stay free to optimise.
-          sourceCustom:
-            asFreeformAnchor(edge.data?.sourceAnchor) ??
-            coordinatedStraightPort(edge.id, "source"),
-          targetCustom:
-            asFreeformAnchor(edge.data?.targetAnchor) ??
-            coordinatedStraightPort(edge.id, "target"),
-          resolve: (overrides) =>
-            resolveEdgeEndpoints(
-              edge,
-              nodes,
-              nodeById,
-              nodeLookup,
-              connectionMode,
-              overrides,
-              true,
-              nodeIndex
-            ),
-          // Side selection stays obstacle-aware for EVERY straight edge, so a
-          // stacked node makes the edge pick a side that clears it (a straight line
-          // that avoids the overlap) rather than one that runs through it. Only the
-          // bend-generating router below is gated per type.
-          obstacles: straightObstacles,
-          thirdPartyObstacles: straightObstacles.filter(
-            (o) => !o.soft && o.id !== edge.source && o.id !== edge.target
-          ),
-          neighborEdges,
-          enableStraightPath: true,
-        })
-        // Sibling carve-out (the same one the orthogonal neighbour scan makes):
-        // connectors that share a node with this edge are MEANT to fan out from it
-        // side by side. Pricing that as crowding makes the search shove the
-        // departure sideways into exactly the grazing exit we are trying to remove.
-        // Unrelated edges still contribute crossing/overlap/crowding cost.
-        const shares = (other: Edge): boolean =>
-          other.source === edge.source ||
-          other.source === edge.target ||
-          other.target === edge.source ||
-          other.target === edge.target
-        straightNeighbors = []
-        straightSiblings = []
-        for (const [otherId, route] of Object.entries(routeById)) {
-          if (otherId === edge.id || route.length < 2) continue
-          const other = edgeById.get(otherId)
-          if (other && shares(other)) straightSiblings.push(route)
-          else straightNeighbors.push(route)
-        }
-        if (selected) {
-          straightSource = selected.endpoints.adjustedSource
-          straightTarget = selected.endpoints.adjustedTarget
-          straightSourceSide = selected.endpoints.sourcePosition
-          straightTargetSide = selected.endpoints.targetPosition
-        }
+        // Side selection stays obstacle-aware for EVERY straight edge, so a
+        // stacked node makes the edge pick a side that clears it (a straight line
+        // that avoids the overlap) rather than one that runs through it. Only the
+        // bend-generating router below is gated per type.
+        obstacles: straightObstacles,
+        thirdPartyObstacles: straightObstacles.filter(
+          (o) => !o.soft && o.id !== edge.source && o.id !== edge.target
+        ),
+        neighborEdges,
+        enableStraightPath: true,
+      })
+      // Sibling carve-out (the same one the orthogonal neighbour scan makes):
+      // connectors that share a node with this edge are MEANT to fan out from it
+      // side by side. Pricing that as crowding makes the search shove the
+      // departure sideways into exactly the grazing exit we are trying to remove.
+      // Unrelated edges still contribute crossing/overlap/crowding cost.
+      const shares = (other: Edge): boolean =>
+        other.source === edge.source ||
+        other.source === edge.target ||
+        other.target === edge.source ||
+        other.target === edge.target
+      const straightNeighbors: IPoint[][] = []
+      const straightSiblings: IPoint[][] = []
+      for (const [otherId, route] of Object.entries(routeById)) {
+        if (otherId === edge.id || route.length < 2) continue
+        const other = edgeById.get(otherId)
+        if (other && shares(other)) straightSiblings.push(route)
+        else straightNeighbors.push(route)
       }
-      const line = avoidsObstacles
-        ? routeStraightPolyline({
-            source: straightSource,
-            target: straightTarget,
-            checkpoints: interior,
-            // Never treat the edge's OWN endpoint nodes as obstacles — they are
-            // where it attaches, and routing around them produces a backwards jog.
-            obstacles: straightObstacles.filter(
-              (o) => o.id !== edge.source && o.id !== edge.target
-            ),
-            neighborRoutes: straightNeighbors,
-            siblingRoutes: straightSiblings,
-            // Outer members of a fan turn on the outer corner ring, so siblings
-            // clearing one obstacle nest instead of stacking on a single elbow.
-            // `|ratio - 1/2|` is mirror-invariant, so the two halves of a
-            // symmetric diagram still make the same choice.
-            preferredCornerRing: straightCornerRing(edge),
-            clearancePx: EDGES.NODE_CLEARANCE_PX,
-            sourceNormal: outwardNormal(straightSourceSide),
-            targetNormal: outwardNormal(straightTargetSide),
-          })
-        : [straightSource, ...interior, straightTarget]
+      if (selected) {
+        straightSource = selected.endpoints.adjustedSource
+        straightTarget = selected.endpoints.adjustedTarget
+        straightSourceSide = selected.endpoints.sourcePosition
+        straightTargetSide = selected.endpoints.targetPosition
+      }
+      const line = routeStraightPolyline({
+        source: straightSource,
+        target: straightTarget,
+        checkpoints: [],
+        // Never treat the edge's OWN endpoint nodes as obstacles — they are where
+        // it attaches, and routing around them produces a backwards jog.
+        obstacles: straightObstacles.filter(
+          (o) => o.id !== edge.source && o.id !== edge.target
+        ),
+        neighborRoutes: straightNeighbors,
+        siblingRoutes: straightSiblings,
+        // Outer members of a fan turn on the outer corner ring, so siblings
+        // clearing one obstacle nest instead of stacking on a single elbow.
+        // `|ratio - 1/2|` is mirror-invariant, so the two halves of a symmetric
+        // diagram still make the same choice.
+        preferredCornerRing: straightCornerRing(edge),
+        clearancePx: EDGES.NODE_CLEARANCE_PX,
+        sourceNormal: outwardNormal(straightSourceSide),
+        targetNormal: outwardNormal(straightTargetSide),
+      })
       routeById[edge.id] = line
       indexRoutePolyline(neighborGrid, edge.id, line)
       continue

--- a/library/lib/utils/geometry/edgeGeometrySolver.ts
+++ b/library/lib/utils/geometry/edgeGeometrySolver.ts
@@ -34,6 +34,7 @@ import {
   type ObstacleRect,
 } from "@/utils/geometry/obstacles"
 import { routeStepEdge } from "@/utils/geometry/edgeRoute"
+import { routeStraightPolyline } from "@/utils/geometry/straightPolylineRouter"
 import {
   routeChosenAnchors,
   selectEdgeAnchors,
@@ -42,6 +43,7 @@ import {
   assignPorts,
   assignSides,
   endKey,
+  redistributeCrowdedStraightEnds,
   type EndRef,
   type ReservedSideEnd,
   type SideEdge,
@@ -49,6 +51,7 @@ import {
 import {
   canRunStraight,
   centerOf,
+  facingSide,
   sideAxisLength,
 } from "@/utils/geometry/rectSides"
 import {
@@ -92,6 +95,26 @@ const nodeWidth = (node: Node): number | undefined =>
   node.width ?? node.measured?.width
 const nodeHeight = (node: Node): number | undefined =>
   node.height ?? node.measured?.height
+
+/** Expand a source/target corridor to include authored straight-edge checkpoints.
+ * A checkpoint may sit far outside the endpoint-node box; querying obstacles only
+ * in that box makes every blocker on the distant legs invisible to the router. */
+const includePointsInBounds = (
+  bounds: Rect,
+  points: readonly IPoint[]
+): Rect => {
+  let minX = bounds.x
+  let minY = bounds.y
+  let maxX = bounds.x + bounds.width
+  let maxY = bounds.y + bounds.height
+  for (const point of points) {
+    minX = Math.min(minX, point.x)
+    minY = Math.min(minY, point.y)
+    maxX = Math.max(maxX, point.x)
+    maxY = Math.max(maxY, point.y)
+  }
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
+}
 
 /**
  * Resolve one edge's endpoints, or `null` when the base position is unknowable
@@ -276,21 +299,6 @@ function mergeManualPoints(
   return points
 }
 
-/** Straight-hook edges persist interior vertices only, unlike orthogonal edges
- * whose manual points contain the full route. Keep that data contract visible to
- * shared geometry so crossings and neighbouring routes see the authored bend. */
-function getStraightHookRoute(
-  edge: Edge,
-  endpoints: ResolvedEdgeEndpoints
-): IPoint[] {
-  const interior = edge.data?.points
-  return [
-    endpoints.adjustedSource,
-    ...(Array.isArray(interior) ? (interior as IPoint[]) : []),
-    endpoints.adjustedTarget,
-  ]
-}
-
 /**
  * A grid bucketing each already-routed edge's polyline by cell, so an edge finds
  * its nearby neighbours without scanning every routed edge (the walk is
@@ -308,6 +316,37 @@ const NEIGHBOR_CELL_PX = 256
 const cellKey = (cx: number, cy: number): string => `${cx},${cy}`
 
 /** Bucket `edgeId` under every cell its polyline's segments pass through. */
+/**
+ * Interior waypoints authored on a straight-hook edge. Following the JointJS
+ * "vertices" model, a straight-hook edge's `data.points` holds ONLY the interior
+ * bends; its route is `[adjustedSource, ...interior, adjustedTarget]` connected by
+ * plain diagonal segments — never re-projected onto an orthogonal staircase (that
+ * would silently diverge preview from commit). Returns `[]` for an unbent edge.
+ */
+function getStraightHookInterior(edge: {
+  data?: { points?: unknown }
+}): IPoint[] {
+  const points = edge.data?.points
+  return Array.isArray(points) ? (points as IPoint[]) : []
+}
+
+/** Outward unit normal of a node side, so the straight router can price a route
+ * that leaves (or meets) a node at a grazing angle instead of squarely. */
+function outwardNormal(side: Position | undefined): IPoint | undefined {
+  switch (side) {
+    case Position.Top:
+      return { x: 0, y: -1 }
+    case Position.Right:
+      return { x: 1, y: 0 }
+    case Position.Bottom:
+      return { x: 0, y: 1 }
+    case Position.Left:
+      return { x: -1, y: 0 }
+    default:
+      return undefined
+  }
+}
+
 function indexRoutePolyline(
   grid: NeighborGrid,
   edgeId: string,
@@ -838,7 +877,6 @@ function collectFixedPorts(
   nodeById: Map<string, Node>,
   nodeLookup: Map<string, InternalNode>,
   connectionMode: ConnectionMode,
-  straightHookTypes: ReadonlySet<string>,
   liveOverride: LiveEdgeOverride | null | undefined,
   fixedRoutes: Readonly<Record<string, IPoint[]>>,
   nodeIndex: NodeIndex
@@ -850,9 +888,13 @@ function collectFixedPorts(
     if (sourcePinned) result.set(endKey(edge.id, "source"), sourcePinned)
     if (targetPinned) result.set(endKey(edge.id, "target"), targetPinned)
 
+    // A straight-hook edge is NO LONGER pinned to its drawn handle. Unbent,
+    // unpinned ones become free ends so they get the same facing-side selection
+    // and balanced port band as step edges (their route is drawn straight, not
+    // orthogonal). Only an authored bend (points) or an explicit pin fixes a
+    // straight-hook endpoint — handled by the clauses below.
     const topologyFixed =
       edge.id === liveOverride?.edgeId ||
-      straightHookTypes.has(edge.type ?? "") ||
       edge.source === edge.target ||
       (Array.isArray(edge.data?.points) && edge.data.points.length > 0) ||
       fixedRoutes[edge.id] !== undefined
@@ -907,6 +949,7 @@ function collectFixedPorts(
  * capacity model as immutable reservations. Ends of single-edge nodes are omitted:
  * there is no sibling capacity to coordinate there. */
 function collectPortEnds(
+  straightHookTypes: ReadonlySet<string>,
   ordered: readonly Edge[],
   nodes: readonly Node[],
   nodeById: Map<string, Node>,
@@ -1036,6 +1079,7 @@ function collectPortEnds(
         nodeId: edge.source,
         rect: sourceRect,
         side: sourceSide,
+        straight: straightHookTypes.has(edge.type ?? ""),
         partnerCenter: centerOf(targetRect),
         partnerNodeId: edge.target,
         partnerRect: targetRect,
@@ -1050,6 +1094,7 @@ function collectPortEnds(
         nodeId: edge.target,
         rect: targetRect,
         side: targetSide,
+        straight: straightHookTypes.has(edge.type ?? ""),
         partnerCenter: centerOf(sourceRect),
         partnerNodeId: edge.source,
         partnerRect: sourceRect,
@@ -1220,7 +1265,6 @@ function computeAllEdgeGeometryPass(
     nodeById,
     nodeLookup,
     connectionMode,
-    straightHookTypes,
     liveOverride,
     fixedRoutes,
     nodeIndex
@@ -1233,19 +1277,32 @@ function computeAllEdgeGeometryPass(
       reservedRouteById.set(edge.id, liveOverride.points)
       continue
     }
+    // Straight-hook edges are checked FIRST. A BENT one (authored interior
+    // waypoints) reserves a diagonal passthrough and must never fall into the
+    // orthogonal reprojection below (its `data.points` are interior-only). An
+    // UNBENT one is a free end — its facing side and balanced port are assigned
+    // like a step edge and its straight route is computed in the main pass, so it
+    // reserves nothing here.
     if (straightHookTypes.has(edge.type ?? "")) {
-      const endpoints = resolveEdgeEndpoints(
-        edge,
-        nodes,
-        nodeById,
-        nodeLookup,
-        connectionMode,
-        undefined,
-        undefined,
-        nodeIndex
-      )
-      if (endpoints)
-        reservedRouteById.set(edge.id, getStraightHookRoute(edge, endpoints))
+      const interior = getStraightHookInterior(edge)
+      if (interior.length > 0) {
+        const endpoints = resolveEdgeEndpoints(
+          edge,
+          nodes,
+          nodeById,
+          nodeLookup,
+          connectionMode,
+          undefined,
+          undefined,
+          nodeIndex
+        )
+        if (endpoints)
+          reservedRouteById.set(edge.id, [
+            endpoints.adjustedSource,
+            ...interior,
+            endpoints.adjustedTarget,
+          ])
+      }
       continue
     }
     const manual = edge.data?.points
@@ -1275,16 +1332,140 @@ function computeAllEdgeGeometryPass(
       continue
     }
   }
-  const bandPorts = assignPorts(
-    collectPortEnds(
-      coordinationEdges,
-      nodes,
-      nodeById,
-      fixedPorts,
-      [...reservedRouteById.values()],
-      sideOverrideByEnd
-    )
+  // `assignSides` chooses the side PAIR that minimises ORTHOGONAL corners — the
+  // right objective for a step edge, and the wrong one for a straight line, which
+  // pays no corner to reach any side. A straight edge's side is instead decided by
+  // where its partner lies: the "partner direction decides side" rule this pipeline
+  // already follows for ordering (Hegemann & Wolff, GD 2023 — see
+  // geometry/README.md). `facingSide` weighs that direction against the node's own
+  // half-extents, so a row of children below a parent all attach on their TOP edge
+  // rather than some of them catching a corner and coming in sideways — which is
+  // what makes a fan of siblings read as parallel. Being a pure function of the two
+  // rectangles, it also yields mirror-symmetric sides for a mirror-symmetric
+  // diagram, which corner-minimisation does not guarantee.
+  const straightSideByEnd = new Map<string, Position>(sideOverrideByEnd ?? [])
+  for (const edge of coordinationEdges) {
+    if (!straightHookTypes.has(edge.type ?? "")) continue
+    if (edge.source === edge.target) continue
+    if (getStraightHookInterior(edge).length > 0) continue
+    const sourceRect = nodeRect(edge.source, nodes, nodeById)
+    const targetRect = nodeRect(edge.target, nodes, nodeById)
+    if (!sourceRect || !targetRect) continue
+    const sourceKey = endKey(edge.id, "source")
+    const targetKey = endKey(edge.id, "target")
+    if (!fixedPorts.has(sourceKey) && !sideOverrideByEnd?.has(sourceKey))
+      straightSideByEnd.set(
+        sourceKey,
+        facingSide(sourceRect, centerOf(targetRect))
+      )
+    if (!fixedPorts.has(targetKey) && !sideOverrideByEnd?.has(targetKey))
+      straightSideByEnd.set(
+        targetKey,
+        facingSide(targetRect, centerOf(sourceRect))
+      )
+  }
+  const originalPortEnds = collectPortEnds(
+    straightHookTypes,
+    coordinationEdges,
+    nodes,
+    nodeById,
+    fixedPorts,
+    [...reservedRouteById.values()],
+    straightSideByEnd
   )
+  const portEnds = redistributeCrowdedStraightEnds(originalPortEnds)
+  const overflowedStraightEnds = new Set<string>()
+  const overflowedStraightNodes = new Set<string>()
+  for (const end of portEnds) {
+    const key = endKey(end.edgeId, end.end)
+    if (end.straight && end.side !== straightSideByEnd.get(key)) {
+      overflowedStraightEnds.add(key)
+      overflowedStraightNodes.add(end.nodeId)
+    }
+  }
+  for (const end of portEnds)
+    if (end.straight)
+      straightSideByEnd.set(endKey(end.edgeId, end.end), end.side)
+  const bandPorts = assignPorts(portEnds)
+
+  // How far off its side's centre each seat sits, and the largest such offset on
+  // every occupied (node, side). Used to nest a fan — see `straightCornerRing`.
+  // QUANTISED, and that is the whole point. A seat and its mirror image are the same
+  // distance from their side's centre in exact arithmetic, but not in binary
+  // floating point: for a seven-way band, 0.5 - 1/7 and 6/7 - 0.5 differ in the last
+  // bit. Comparing raw distances therefore made one flank of a symmetric diagram
+  // take the roomy corner ring and the other the tight one — a visible asymmetry
+  // from a rounding artefact. Rounding to whole permille is far finer than any seat
+  // spacing yet coarse enough that reflection is exact.
+  const seatOffset = (anchor: FreeformEdgeAnchor): number =>
+    Math.round(Math.abs(anchor.ratio - 0.5) * 1000)
+  const outermostSeatOffset = new Map<string, number>()
+  for (const edge of coordinationEdges) {
+    for (const [end, nodeId] of [
+      ["source", edge.source],
+      ["target", edge.target],
+    ] as const) {
+      const seat = bandPorts.get(endKey(edge.id, end))
+      if (!seat) continue
+      const key = `${nodeId}|${seat.side}`
+      outermostSeatOffset.set(
+        key,
+        Math.max(outermostSeatOffset.get(key) ?? 0, seatOffset(seat))
+      )
+    }
+  }
+
+  /**
+   * Which corner ring this edge should turn on. The OUTERMOST members of a fan —
+   * those seated furthest from their side's centre — stand off obstacles further,
+   * so siblings clearing one obstacle nest instead of meeting at a single elbow.
+   *
+   * Keyed on the seat's distance from the centre rather than its rank along the
+   * side, because reflecting the diagram preserves that distance but reverses the
+   * rank: a rank-keyed rule would nest a symmetric diagram's two halves differently.
+   * Comparing against the side's own maximum keeps it free of a magic threshold,
+   * which the raw ratios (they depend on side length and seat count) would trip over.
+   */
+  const straightCornerRing = (edge: Edge): number => {
+    if (
+      overflowedStraightEnds.has(endKey(edge.id, "source")) ||
+      overflowedStraightEnds.has(endKey(edge.id, "target"))
+    )
+      return 1
+    for (const [end, nodeId] of [
+      ["source", edge.source],
+      ["target", edge.target],
+    ] as const) {
+      const seat = bandPorts.get(endKey(edge.id, end))
+      if (!seat) continue
+      // Once a crowded fan overflows, the adjacent-side members ARE its outer
+      // ring. Re-ranking the remaining three-seat middle band would incorrectly
+      // promote its flanks too and collapse them back onto the same elbow.
+      if (overflowedStraightNodes.has(nodeId)) continue
+      const outermost = outermostSeatOffset.get(`${nodeId}|${seat.side}`) ?? 0
+      if (outermost > 0 && seatOffset(seat) >= outermost) return 1
+    }
+    return 0
+  }
+
+  /**
+   * Where a straight edge attaches. On a shared node side the coordinated band seat
+   * applies; a LONE end has no seat, so it takes the CENTRE of its normal-aligned
+   * side — the same "centre it when nothing competes" rule `endpointPlacementCost`
+   * rewards for step edges. Leaving a lone end free instead lets the anchor search
+   * wrap it onto a side the edge does not approach from, and breaks the mirror
+   * symmetry of an otherwise symmetric diagram.
+   */
+  const coordinatedStraightPort = (
+    edgeId: string,
+    end: "source" | "target"
+  ): FreeformEdgeAnchor | undefined => {
+    const key = endKey(edgeId, end)
+    const banded = bandPorts.get(key)
+    if (banded) return banded
+    const side = straightSideByEnd.get(key)
+    return side ? { side, ratio: 0.5 } : undefined
+  }
 
   for (const edge of ordered) {
     if (liveOverride && liveOverride.edgeId === edge.id) {
@@ -1309,16 +1490,6 @@ function computeAllEdgeGeometryPass(
         routeById[edge.id] = previous[edge.id]
         indexRoutePolyline(neighborGrid, edge.id, previous[edge.id])
       }
-      continue
-    }
-
-    // Straight-hook edges connect authored interior waypoints directly — no
-    // obstacle or neighbour routing — but their polyline still enters the map so
-    // crossings and neighbouring step edges see the same geometry users see.
-    if (straightHookTypes.has(edge.type ?? "")) {
-      const route = getStraightHookRoute(edge, endpoints)
-      routeById[edge.id] = route
-      indexRoutePolyline(neighborGrid, edge.id, route)
       continue
     }
 
@@ -1349,6 +1520,149 @@ function computeAllEdgeGeometryPass(
           endpoints.sourceAbsolutePosition.y,
           endpoints.targetAbsolutePosition.y
         ),
+    }
+
+    // Straight-hook edges (use-case, syntax-tree, petri-net) render as diagonal
+    // lines, but they get the SAME sophistication as step edges up to the routing
+    // primitive: an unbent, unpinned edge picks its facing sides and a balanced
+    // centred port (via `selectEdgeAnchors` + the shared `assignPorts` band), while
+    // a bent edge keeps its authored waypoints. The chosen endpoints are then joined
+    // by a straight, obstacle-avoiding polyline (Track D) instead of an orthogonal
+    // route — waypoints ride along as mandatory checkpoints. The result enters the
+    // neighbour map so step edges route around it.
+    if (straightHookTypes.has(edge.type ?? "")) {
+      const interior = getStraightHookInterior(edge)
+      const straightCandidateBounds = includePointsInBounds(
+        candidateBounds,
+        interior
+      )
+      // Every straight edge avoids intervening node bodies; the routing cost keeps
+      // the detour readable (see `straightPolylineRouter`).
+      const avoidsObstacles = true
+      const straightObstacles = getEdgeObstacles(
+        nodes,
+        edge.source,
+        edge.target,
+        endpoints.adjustedSource,
+        endpoints.adjustedTarget,
+        nodeIndex,
+        straightCandidateBounds
+      )
+      let straightSource = endpoints.adjustedSource
+      let straightTarget = endpoints.adjustedTarget
+      let straightSourceSide = endpoints.sourcePosition
+      let straightTargetSide = endpoints.targetPosition
+      let straightNeighbors: IPoint[][] = []
+      let straightSiblings: IPoint[][] = []
+      if (interior.length === 0) {
+        const sourceType = nodeById.get(edge.source)?.type
+        const targetType = nodeById.get(edge.target)?.type
+        const { edgeRoutes: neighborEdges } = collectNeighbors(
+          edge,
+          endpoints,
+          nodes,
+          nodeIndex,
+          straightObstacles,
+          routeById,
+          neighborGrid,
+          edgeById
+        )
+        const selected = selectEdgeAnchors({
+          sourceRect: rectFromEndpoint(
+            endpoints.sourceAbsolutePosition,
+            endpoints.sourceSize
+          ),
+          targetRect: rectFromEndpoint(
+            endpoints.targetAbsolutePosition,
+            endpoints.targetSize
+          ),
+          sourceType,
+          targetType,
+          // On a node side shared with other connectors the coordinated seat is
+          // AUTHORITATIVE, not a suggestion. A straight edge can always shorten
+          // itself by aiming its port straight at the partner, so a soft
+          // preference loses every time — and the whole fan collapses onto one or
+          // two points, which is how two edges end up leaving from the SAME pixel.
+          // Pinning the seat is what keeps the fan evenly spread and symmetric.
+          // Lone ends are absent from the band and stay free to optimise.
+          sourceCustom:
+            asFreeformAnchor(edge.data?.sourceAnchor) ??
+            coordinatedStraightPort(edge.id, "source"),
+          targetCustom:
+            asFreeformAnchor(edge.data?.targetAnchor) ??
+            coordinatedStraightPort(edge.id, "target"),
+          resolve: (overrides) =>
+            resolveEdgeEndpoints(
+              edge,
+              nodes,
+              nodeById,
+              nodeLookup,
+              connectionMode,
+              overrides,
+              true,
+              nodeIndex
+            ),
+          // Side selection stays obstacle-aware for EVERY straight edge, so a
+          // stacked node makes the edge pick a side that clears it (a straight line
+          // that avoids the overlap) rather than one that runs through it. Only the
+          // bend-generating router below is gated per type.
+          obstacles: straightObstacles,
+          thirdPartyObstacles: straightObstacles.filter(
+            (o) => !o.soft && o.id !== edge.source && o.id !== edge.target
+          ),
+          neighborEdges,
+          enableStraightPath: true,
+        })
+        // Sibling carve-out (the same one the orthogonal neighbour scan makes):
+        // connectors that share a node with this edge are MEANT to fan out from it
+        // side by side. Pricing that as crowding makes the search shove the
+        // departure sideways into exactly the grazing exit we are trying to remove.
+        // Unrelated edges still contribute crossing/overlap/crowding cost.
+        const shares = (other: Edge): boolean =>
+          other.source === edge.source ||
+          other.source === edge.target ||
+          other.target === edge.source ||
+          other.target === edge.target
+        straightNeighbors = []
+        straightSiblings = []
+        for (const [otherId, route] of Object.entries(routeById)) {
+          if (otherId === edge.id || route.length < 2) continue
+          const other = edgeById.get(otherId)
+          if (other && shares(other)) straightSiblings.push(route)
+          else straightNeighbors.push(route)
+        }
+        if (selected) {
+          straightSource = selected.endpoints.adjustedSource
+          straightTarget = selected.endpoints.adjustedTarget
+          straightSourceSide = selected.endpoints.sourcePosition
+          straightTargetSide = selected.endpoints.targetPosition
+        }
+      }
+      const line = avoidsObstacles
+        ? routeStraightPolyline({
+            source: straightSource,
+            target: straightTarget,
+            checkpoints: interior,
+            // Never treat the edge's OWN endpoint nodes as obstacles — they are
+            // where it attaches, and routing around them produces a backwards jog.
+            obstacles: straightObstacles.filter(
+              (o) => o.id !== edge.source && o.id !== edge.target
+            ),
+            neighborRoutes: straightNeighbors,
+            siblingRoutes: straightSiblings,
+            // Outer members of a fan turn on the outer corner ring, so siblings
+            // clearing one obstacle nest instead of stacking on a single elbow.
+            // `|ratio - 1/2|` is mirror-invariant, so the two halves of a
+            // symmetric diagram still make the same choice.
+            preferredCornerRing: straightCornerRing(edge),
+            clearancePx: EDGES.NODE_CLEARANCE_PX,
+            sourceNormal: outwardNormal(straightSourceSide),
+            targetNormal: outwardNormal(straightTargetSide),
+          })
+        : [straightSource, ...interior, straightTarget]
+      routeById[edge.id] = line
+      indexRoutePolyline(neighborGrid, edge.id, line)
+      continue
     }
     const obstacles: ObstacleRect[] = getEdgeObstacles(
       nodes,

--- a/library/lib/utils/geometry/edgeGeometryWorkerController.ts
+++ b/library/lib/utils/geometry/edgeGeometryWorkerController.ts
@@ -39,12 +39,17 @@ export const shouldUseEdgeGeometryWorker = ({
   edgeCount,
   threshold,
   disabled,
+  force = false,
 }: {
   hasRunInitialSolve: boolean
   edgeCount: number
   threshold: number
   disabled: boolean
-}): boolean => hasRunInitialSolve && edgeCount >= threshold && !disabled
+  /** Use the Worker below the size crossover for an interaction whose main-thread
+   * solver would otherwise compete with pointer rendering. */
+  force?: boolean
+}): boolean =>
+  hasRunInitialSolve && (force || edgeCount >= threshold) && !disabled
 
 export const EDGE_GEOMETRY_WORKER_EDGE_THRESHOLD = 32
 export const EDGE_GEOMETRY_WORKER_DEFAULT_CADENCE_MS = 80
@@ -97,10 +102,13 @@ export const updateEdgeGeometryWorkerRoundTrip = (
 export const shouldSampleEdgeGeometryWorker = ({
   edgeCount,
   interacting,
+  force = false,
 }: {
   edgeCount: number
   interacting: boolean
-}): boolean => interacting && edgeCount >= EDGE_GEOMETRY_WORKER_EDGE_THRESHOLD
+  force?: boolean
+}): boolean =>
+  interacting && (force || edgeCount >= EDGE_GEOMETRY_WORKER_EDGE_THRESHOLD)
 
 /**
  * A Worker cannot interrupt a CPU-bound solve already running. The controller

--- a/library/lib/utils/geometry/integerGeometry.ts
+++ b/library/lib/utils/geometry/integerGeometry.ts
@@ -1,0 +1,95 @@
+/**
+ * Determinism leaf for straight-polyline routing.
+ *
+ * Every function here is a pure integer computation. No `Math.sqrt`, `Math.hypot`
+ * or `Math.atan2` appears on any decision path — those are permitted engine-defined
+ * rounding, and the auto-router's output must be reproduced byte-identically by Yjs
+ * peers and after a reload on a different JS engine (V8/JSC). The only square root is
+ * an exact integer floor (`isqrt`); angle classification uses `BigInt` dot/cross
+ * comparisons so it stays exact for any coordinate magnitude.
+ */
+import type { IPoint } from "@/edges/Connection"
+
+/**
+ * Exact integer floor square root for a non-negative integer up to 2^53.
+ *
+ * Computed by the bit-by-bit method rather than `Math.floor(Math.sqrt(n))`: the
+ * float path can be off by one near perfect squares once `n` approaches 2^53, and a
+ * single off-by-one in a segment length would desynchronise peers. Every
+ * intermediate value here stays `<= n` (so `<= 2^53`, exactly representable) or is a
+ * power of two, so the arithmetic is exact.
+ */
+export function isqrt(n: number): number {
+  if (!Number.isInteger(n) || n < 0)
+    throw new RangeError("isqrt requires a non-negative integer")
+  if (n < 2) return n
+
+  // Highest power of four not exceeding n. `bit * 4` is a power of two and thus
+  // exactly representable even when it briefly exceeds 2^53.
+  let bit = 1
+  while (bit * 4 <= n) bit *= 4
+
+  let result = 0
+  let remaining = n
+  while (bit !== 0) {
+    if (remaining >= result + bit) {
+      remaining -= result + bit
+      // result stays below 2^27 for n <= 2^53, so the halving is exact.
+      result = Math.floor(result / 2) + bit
+    } else {
+      result = Math.floor(result / 2)
+    }
+    bit = Math.floor(bit / 4)
+  }
+  return result
+}
+
+/** Squared distance between two integer points. Exact for realistic coordinates
+ * (each squared delta is well under 2^53). */
+export function distSqInt(a: IPoint, b: IPoint): number {
+  const dx = a.x - b.x
+  const dy = a.y - b.y
+  return dx * dx + dy * dy
+}
+
+/** Integer (floored) Euclidean length of the segment a→b. */
+export function segLenInt(a: IPoint, b: IPoint): number {
+  return isqrt(distSqInt(a, b))
+}
+
+/**
+ * Classify the turn between an incoming travel vector `(ux,uy)` and an outgoing
+ * travel vector `(vx,vy)` into a coarse integer bucket, using ONLY integer dot and
+ * cross products — never `atan2`.
+ *
+ * Buckets (θ is the turn angle between the two travel directions; 0 = dead straight):
+ *   0 — near-straight, θ ≤ 45°  (interior corner angle ≥ 135°)
+ *   1 — moderate,      45° < θ ≤ 90°
+ *   2 — acute/hairpin, θ > 90°
+ *
+ * The thresholds come from comparing cos²θ against sin²θ without a square root:
+ * with `dot = |u||v|cosθ` and `cross = |u||v|sinθ`, `dot² ≥ cross²` iff θ ≤ 45°, and
+ * `sign(dot)` alone splits θ ≤ 90° from θ > 90°. `BigInt` keeps `dot²`/`cross²`
+ * exact for any coordinate magnitude (plain numbers would overflow 2^53 when
+ * squaring large products).
+ */
+export function turnBucket(
+  ux: number,
+  uy: number,
+  vx: number,
+  vy: number
+): number {
+  // A degenerate (zero-length) incoming or outgoing vector implies no genuine
+  // corner; treat it as straight so it never adds a spurious penalty.
+  if ((ux === 0 && uy === 0) || (vx === 0 && vy === 0)) return 0
+
+  const bux = BigInt(ux)
+  const buy = BigInt(uy)
+  const bvx = BigInt(vx)
+  const bvy = BigInt(vy)
+  const dot = bux * bvx + buy * bvy
+  const cross = bux * bvy - buy * bvx
+  if (dot > 0n && dot * dot >= cross * cross) return 0
+  if (dot >= 0n) return 1
+  return 2
+}

--- a/library/lib/utils/geometry/portAssignment.ts
+++ b/library/lib/utils/geometry/portAssignment.ts
@@ -748,6 +748,9 @@ export type EndRef = {
   nodeId: string
   rect: Rect
   side: Position
+  /** This end belongs to a STRAIGHT edge, which reaches its partner directly rather
+   * than along axes — see `rotOf` for why that changes the non-crossing order. */
+  straight?: boolean
   partnerCenter: IPoint
   /** The partner node's id and rect — used to detect and align PARALLEL SIBLINGS
    * (several edges between the same node pair), which must share one straight lane
@@ -799,6 +802,102 @@ export type AssignedPort = {
 /** Key for one end in the returned map: `${edgeId}|${end}`. */
 export const endKey = (edgeId: string, end: "source" | "target"): string =>
   `${edgeId}|${end}`
+
+const adjacentSides = (side: Position): { low: Position; high: Position } => {
+  switch (side) {
+    case Position.Top:
+    case Position.Bottom:
+      return { low: Position.Left, high: Position.Right }
+    case Position.Left:
+    case Position.Right:
+      return { low: Position.Top, high: Position.Bottom }
+  }
+}
+
+/**
+ * Overflow a crowded straight-edge fan onto the two adjacent sides before seat
+ * assignment. Compressing five ports onto a 70px side makes their first segments
+ * indistinguishable and turns tiny geometry changes into order flips. The angular
+ * outer pair instead leaves through the corresponding adjacent sides, preserving
+ * the middle fan and mirror symmetry.
+ *
+ * Authored reservations and non-straight ends never move. The returned objects are
+ * clones and both ends' `partnerSide` references are refreshed after redistribution.
+ */
+export const redistributeCrowdedStraightEnds = (
+  ends: readonly EndRef[],
+  pitchPx: number = PORT_PITCH_PX
+): EndRef[] => {
+  const redistributed = ends.map((end) => ({ ...end }))
+  const groups = new Map<string, EndRef[]>()
+  for (const end of redistributed) {
+    const key = `${end.nodeId}|${end.side}`
+    const group = groups.get(key)
+    if (group) group.push(end)
+    else groups.set(key, [end])
+  }
+
+  for (const group of groups.values()) {
+    const { side, rect } = group[0]
+    const axis = sideAxisLength(side, rect)
+    if (axis <= 0) continue
+    const margin = Math.min(CORNER_CLEARANCE_PX, axis * 0.3)
+    const capacity = group[0].fourCenter
+      ? 1
+      : Math.max(1, Math.floor((axis - 2 * margin) / pitchPx) + 1)
+    if (group.length <= capacity) continue
+
+    const movable = group.filter(
+      (end) => end.straight && end.immutableRatio === undefined
+    )
+    let moveCount = Math.min(movable.length, group.length - capacity)
+    // When possible overflow a pair, not one arbitrary flank. For an odd fan this
+    // intentionally leaves one fewer seat on the original side than its numeric
+    // maximum; exact reflection is more stable and legible than one extra port.
+    if (moveCount % 2 === 1 && moveCount < movable.length) moveCount++
+    if (moveCount === 0) continue
+
+    const nodeCenter = centerOf(rect)
+    movable.sort((a, b) => {
+      const ak = alongSideKey(
+        side,
+        a.partnerCenter.x - nodeCenter.x,
+        a.partnerCenter.y - nodeCenter.y
+      )
+      const bk = alongSideKey(
+        side,
+        b.partnerCenter.x - nodeCenter.x,
+        b.partnerCenter.y - nodeCenter.y
+      )
+      return (
+        ak - bk ||
+        cmpStr(a.partnerNodeId, b.partnerNodeId) ||
+        cmpStr(a.edgeId, b.edgeId) ||
+        cmpStr(a.end, b.end)
+      )
+    })
+    const lowCount = Math.floor(moveCount / 2)
+    const highCount = moveCount - lowCount
+    const adjacent = adjacentSides(side)
+    for (const end of movable.slice(0, lowCount)) end.side = adjacent.low
+    for (const end of movable.slice(movable.length - highCount))
+      end.side = adjacent.high
+  }
+
+  const byEdge = new Map<string, Partial<Record<"source" | "target", EndRef>>>()
+  for (const end of redistributed) {
+    const pair = byEdge.get(end.edgeId) ?? {}
+    pair[end.end] = end
+    byEdge.set(end.edgeId, pair)
+  }
+  for (const end of redistributed) {
+    const other = byEdge.get(end.edgeId)?.[
+      end.end === "source" ? "target" : "source"
+    ]
+    if (other) end.partnerSide = other.side
+  }
+  return redistributed
+}
 
 /**
  * The shared straight band for K parallel siblings between `rect`'s `side` and the
@@ -1009,12 +1108,19 @@ export const assignPorts = (
     const tangentialHalfExtent = sideAxisLength(side, rect) / 2
     const rotOf = (e: EndRef): number => {
       const c = centerOf(e.rect)
-      return crossingOrderKey(
-        side,
-        e.partnerCenter.x - c.x,
-        e.partnerCenter.y - c.y,
-        tangentialHalfExtent
-      )
+      const dx = e.partnerCenter.x - c.x
+      const dy = e.partnerCenter.y - c.y
+      // A STRAIGHT edge runs directly at its partner, so the order that avoids a
+      // fan crossing itself is simply the angular one. `crossingOrderKey` exists
+      // for orthogonal routes, which leave along an axis and turn far away: for a
+      // partner beyond the node's own band it deliberately INVERTS the angular
+      // order so the farther-reaching route nests outside the nearer one. Applied
+      // to a straight line that inversion manufactures exactly the crossing it is
+      // meant to prevent — a near partner gets seated past a far one, and the two
+      // rays must cross.
+      return e.straight
+        ? alongSideKey(side, dx, dy)
+        : crossingOrderKey(side, dx, dy, tangentialHalfExtent)
     }
     const byPartner = new Map<string, EndRef[]>()
     for (const e of group) {

--- a/library/lib/utils/geometry/rectSides.ts
+++ b/library/lib/utils/geometry/rectSides.ts
@@ -64,15 +64,27 @@ export const sideAxisLength = (side: Position, rect: Rect): number =>
  *
  * Cross-multiplied rather than divided: on integer-ish coordinates the products are
  * exact where the quotients are not, so the comparison cannot land differently on
- * different engines.
+ * different engines. `deadbandPermille` optionally treats a near-tie as the
+ * existing horizontal tie-break; automatic straight edges use this to avoid
+ * switching sides for a tiny movement around the diagonal boundary.
  */
-export const facingSide = (rect: Rect, toward: IPoint): Position => {
+export const facingSide = (
+  rect: Rect,
+  toward: IPoint,
+  deadbandPermille = 0
+): Position => {
   const c = centerOf(rect)
   const dx = toward.x - c.x
   const dy = toward.y - c.y
   const halfW = rect.width / 2 || 1
   const halfH = rect.height / 2 || 1
-  return Math.abs(dx) * halfH >= Math.abs(dy) * halfW
+  const horizontal = Math.abs(dx) * halfH
+  const vertical = Math.abs(dy) * halfW
+  const nearBoundary =
+    deadbandPermille > 0 &&
+    Math.abs(horizontal - vertical) * 1000 <=
+      Math.max(horizontal, vertical) * deadbandPermille
+  return horizontal >= vertical || nearBoundary
     ? dx >= 0
       ? Position.Right
       : Position.Left

--- a/library/lib/utils/geometry/straightPolylineRouter.ts
+++ b/library/lib/utils/geometry/straightPolylineRouter.ts
@@ -16,9 +16,9 @@
  *    the input order of obstacles/neighbours.
  *
  * Design:
- *  1. Gate: if every checkpoint sub-chord already clears all hard obstacles by
- *     ≥ MIN clearance AND has no crossing/overlap with another edge, return the
- *     straight polyline unchanged (the common case).
+ *  1. Gate: if every checkpoint sub-chord avoids hard obstacles by the direct-route
+ *     guard AND has no crossing/overlap with another edge, return the straight
+ *     polyline unchanged (the common case).
  *  2. Otherwise build a reduced/tangent visibility graph over the endpoints, the
  *     checkpoints, two rings of inflated corners per HARD obstacle, and clearance
  *     corners around neighbouring segments that conflict with the direct route.
@@ -134,18 +134,15 @@ const turnCostPx = (from: IPoint, via: IPoint, to: IPoint): number => {
   )
 }
 
-/** A diagonal crossing needs a stronger deterrent than the orthogonal baseline.
- * Orthogonal lines cross at 90° and remain easy to trace; arbitrary-angle straight
- * lines can merge visually. Keep this surcharge crossing-only so parallel crowding
- * cannot force gratuitous bends in an otherwise clean fan. */
-const STRAIGHT_CROSSING_SURCHARGE_PX = ROUTING_COST.edgeCrossing
-
 /**
  * Cost of one candidate segment against every neighbouring edge, delegated to the
  * SHARED `polylineConflictCost` so a crossing, a collinear overlap and a too-close
  * parallel run keep the orthogonal engine's shared scale (`edgeCrossing` 400,
- * `overlapPerPx` 25, `crowdingPerPx` 3), then adding the diagonal-only crossing
- * surcharge above. Summed over neighbours, so input order cannot change the cost.
+ * `overlapPerPx` 25, `crowdingPerPx` 3). A crossing is intentionally charged once:
+ * axis-aligned crossings can use line-jump bridges, and even an unavoidable
+ * diagonal crossing is easier to trace than a disproportionate excursion around a
+ * long neighbouring line. Summed over neighbours, so input order cannot change
+ * the cost.
  */
 const neighborCostPx = (
   a: IPoint,
@@ -153,18 +150,19 @@ const neighborCostPx = (
   neighborRoutes: readonly (readonly IPoint[])[],
   crowdingClearancePx: number
 ): number => {
-  const conflict = polylineConflictCost(
-    [a, b],
-    neighborRoutes,
-    crowdingClearancePx
-  )
-  return conflict.cost + conflict.crossings * STRAIGHT_CROSSING_SURCHARGE_PX
+  return polylineConflictCost([a, b], neighborRoutes, crowdingClearancePx).cost
 }
 
-/** The MINIMUM clearance the returned route guarantees from every hard obstacle.
- * It is also the obstacle half of the direct-route gate; a chord must additionally
- * have no crossing or overlap to be returned as-is. */
+/** The MINIMUM clearance a generated detour guarantees from every hard obstacle. */
 const MIN_CLEARANCE_PX = EDGES.MIN_NODE_CLEARANCE_PX
+
+/**
+ * A straight line should reroute when it hits a node, not merely because it comes
+ * within the preferred detour clearance. Keep a 1 px collision guard so a line on
+ * the node outline does not disappear beneath its border. Once routing intervenes,
+ * the generated detour still receives the full `MIN_CLEARANCE_PX` breathing room.
+ */
+const DIRECT_ROUTE_CLEARANCE_PX = 1
 
 /**
  * The routing objective, expressed entirely in pixels of travel so it composes with
@@ -339,10 +337,34 @@ const segmentIntersectsRectInterior = (
 }
 
 /**
+ * Test a visibility segment against a MIN-clearance rectangle. A route endpoint
+ * already inside the clearance halo may leave it, but the exemption stops at the
+ * obstacle's actual body. The solver removes the real source/target bodies before
+ * calling the router, so entering this deflated body is always invalid.
+ */
+const segmentBlockedByClearanceRect = (
+  a: IPoint,
+  b: IPoint,
+  clearanceRect: IntRect,
+  relaxAtA: boolean,
+  relaxAtB: boolean
+): boolean => {
+  const startsInHalo = relaxAtA && inclusiveContains(clearanceRect, a)
+  const endsInHalo = relaxAtB && inclusiveContains(clearanceRect, b)
+  if (startsInHalo || endsInHalo)
+    return segmentIntersectsRectInterior(
+      a,
+      b,
+      inflate(clearanceRect, -MIN_CLEARANCE_PX)
+    )
+  return segmentIntersectsRectInterior(a, b, clearanceRect)
+}
+
+/**
  * Does the straight chord a→b clear every HARD obstacle by at least
- * `minClearancePx`? An obstacle whose `minClearancePx`-inflated body already
- * contains an endpoint is that endpoint's OWN node and is exempt (you cannot clear
- * the node your endpoint sits on). Soft obstacles are ignored.
+ * `minClearancePx`? An endpoint already inside a third-party clearance halo may
+ * leave that halo, but its chord must still avoid the obstacle's actual body.
+ * Soft obstacles are ignored.
  */
 export function chordClearsObstacles(
   a: IPoint,
@@ -352,9 +374,12 @@ export function chordClearsObstacles(
 ): boolean {
   for (const o of hardObstacles) {
     if (o.soft) continue
-    const inflated = inflate(rectOf(o), minClearancePx)
-    if (inclusiveContains(inflated, a) || inclusiveContains(inflated, b))
+    const body = rectOf(o)
+    const inflated = inflate(body, minClearancePx)
+    if (inclusiveContains(inflated, a) || inclusiveContains(inflated, b)) {
+      if (segmentIntersectsRectInterior(a, b, body)) return false
       continue
+    }
     if (segmentIntersectsRectInterior(a, b, inflated)) return false
   }
   return true
@@ -568,8 +593,8 @@ const buildVertices = (
 /**
  * Mutual visibility of two vertices: the segment between them must not enter the
  * MIN-clearance-inflated interior of any hard obstacle. A segment incident to the
- * sub-chord's own endpoint is exempt from obstacles whose inflated body contains
- * that endpoint (the node it departs from / arrives at). Corner touches are allowed.
+ * sub-chord endpoint may leave a clearance halo it already occupies, but never
+ * enter the obstacle's actual body. Corner touches are allowed.
  */
 const visible = (
   vertices: readonly Vertex[],
@@ -584,9 +609,7 @@ const visible = (
   const exemptI = i === endA || i === endB
   const exemptJ = j === endA || j === endB
   for (const r of blockRects) {
-    if (exemptI && inclusiveContains(r, p)) continue
-    if (exemptJ && inclusiveContains(r, q)) continue
-    if (segmentIntersectsRectInterior(p, q, r)) return false
+    if (segmentBlockedByClearanceRect(p, q, r, exemptI, exemptJ)) return false
   }
   return true
 }
@@ -951,11 +974,9 @@ const simplifyRoute = (
       const b = candidate[i]
       const isEndA = i - 1 === 0
       const isEndB = i === candidate.length - 1
-      const blocked = blockRects.some((r) => {
-        if (isEndA && inclusiveContains(r, a)) return false
-        if (isEndB && inclusiveContains(r, b)) return false
-        return segmentIntersectsRectInterior(a, b, r)
-      })
+      const blocked = blockRects.some((r) =>
+        segmentBlockedByClearanceRect(a, b, r, isEndA, isEndB)
+      )
       if (blocked) continue
       const cost = totalRouteCostPx(
         candidate,
@@ -1008,7 +1029,7 @@ export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
       anchors[i - 1],
       a,
       hardObstacles,
-      MIN_CLEARANCE_PX
+      DIRECT_ROUTE_CLEARANCE_PX
     )
   })
   const direct = collapseCollinear(anchors)
@@ -1019,14 +1040,20 @@ export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
     return conflict.crossings > 0 || conflict.overlapPx > 0
   }
   const allSiblingRoutes = siblingRoutes ?? []
-  // Only unrelated neighbors contribute detour vertices. Siblings arrive through
-  // the greedy route walk one at a time; materialising vertices from only the
-  // already-routed half makes a symmetric fan resolve asymmetrically. Their
-  // crossings/overlaps are still priced by the search, while coordinated ports
-  // and obstacle rings provide the order-independent sibling separation.
-  const conflictingRoutes = neighborRoutes.filter((route) =>
+  // Sibling crowding remains exempt, but a sibling crossing/overlap is structural:
+  // it must open the graph and contribute the same candidate detour vertices as an
+  // unrelated edge. Coordinated ports and obstacle rings still handle ordinary
+  // side-by-side fan separation without route-order-dependent crowding.
+  const conflictingNeighborRoutes = neighborRoutes.filter((route) =>
     conflictsStructurally([route])
   )
+  const conflictingSiblingRoutes = allSiblingRoutes.filter((route) =>
+    conflictsStructurally([route])
+  )
+  const conflictingRoutes = [
+    ...conflictingNeighborRoutes,
+    ...conflictingSiblingRoutes,
+  ]
   if (straightClears && conflictingRoutes.length === 0) return direct
 
   // 2. Visibility graph over endpoints, checkpoints and inflated hard corners.

--- a/library/lib/utils/geometry/straightPolylineRouter.ts
+++ b/library/lib/utils/geometry/straightPolylineRouter.ts
@@ -13,22 +13,22 @@
  *  - The A* frontier is a 4-ary min-heap keyed on `(gPlusH, vertexIndex, seq)`,
  *    whose final tie-break — the monotonic insertion counter `seq` — is a unique
  *    discriminator, so the search result cannot depend on engine scheduling or on
- *    the input order of obstacles/neighbours.
+ *    the input order of obstacles.
  *
  * Design:
  *  1. Gate: if every checkpoint sub-chord avoids hard obstacles by the direct-route
- *     guard AND has no crossing/overlap with another edge, return the straight
- *     polyline unchanged (the common case).
+ *     guard, return the straight polyline unchanged (the common case). Crossings
+ *     and overlaps do not manufacture bends: Apollon renders crossings explicitly,
+ *     and direct-line editors conventionally reserve auto-detours for node bodies.
  *  2. Otherwise build a reduced/tangent visibility graph over the endpoints, the
- *     checkpoints, two rings of inflated corners per HARD obstacle, and clearance
- *     corners around neighbouring segments that conflict with the direct route.
+ *     checkpoints, and two rings of inflated corners per HARD obstacle.
  *     Soft obstacles never block visibility.
  *  3. Route each checkpoint sub-chord with A* over DIRECTED EDGES, so the objective
  *     can price the things that decide whether a detour looks deliberate or
  *     accidental: travel, a flat per-bend charge plus a sharpness-graduated turn
- *     cost, the departure/arrival angle against each node side, and the shared
- *     crossing / overlap / crowding cost against neighbouring edges. Checkpoints
- *     are mandatory via-points (the libavoid model).
+ *     cost and the departure/arrival angle against each node side. Checkpoints are
+ *     mandatory via-points (the libavoid model). Other connectors do not reshape
+ *     the path; crossings stay predictable and use Apollon's line jumps.
  *  4. Collapse collinear points, then string-pull away any bend the route does not
  *     need — accepted only when it strictly improves that same objective.
  *
@@ -38,10 +38,7 @@
  */
 import type { IPoint } from "@/edges/Connection"
 import { CANVAS, EDGES } from "@/utils/geometry/routingConstants"
-import {
-  polylineConflictCost,
-  ROUTING_COST,
-} from "@/utils/geometry/routingCost"
+import { ROUTING_COST } from "@/utils/geometry/routingCost"
 import { distSqInt, isqrt, segLenInt } from "@/utils/geometry/integerGeometry"
 
 export interface StraightRouteObstacle {
@@ -62,11 +59,8 @@ export interface StraightRouteRequest {
   checkpoints: IPoint[]
   /** Corridor obstacle rects (bboxes). */
   obstacles: StraightRouteObstacle[]
-  /** Other edges' polylines, for crossing/overlap/crowding pricing. */
-  neighborRoutes: IPoint[][]
   /** Preferred breathing room around a node (EDGES.NODE_CLEARANCE_PX). It sets the
-   * roomier of the two corner rings; the guaranteed margin is MIN_NODE_CLEARANCE_PX.
-   * Edge-to-edge crowding is measured separately (EDGE_CROWDING_CLEARANCE_PX). */
+   * roomier of the two corner rings; the guaranteed margin is MIN_NODE_CLEARANCE_PX. */
   clearancePx: number
   /**
    * Which ring of obstacle corners this route should prefer to turn on: 0 hugs the
@@ -77,11 +71,6 @@ export interface StraightRouteRequest {
    * mirror-symmetric diagram still resolves symmetrically.
    */
   preferredCornerRing?: number
-  /** Routes of edges that SHARE a node with this one. They are meant to fan out
-   * side by side, so they are exempt from the crowding term — but never from
-   * crossing or from lying exactly on top of one another, which is always a defect.
-   * Pricing them at zero crowding clearance expresses precisely that. */
-  siblingRoutes?: IPoint[][]
   /** Outward unit normal of the node side the route leaves from, when known. The
    * search then prices a grazing departure (see `ENDPOINT_ANGLE_PENALTY_PX`). */
   sourceNormal?: IPoint
@@ -132,25 +121,6 @@ const turnCostPx = (from: IPoint, via: IPoint, to: IPoint): number => {
     BEND_PENALTY_PX +
     Math.trunc((TURN_PENALTY_PX * (SCALE - cosScaled)) / SCALE)
   )
-}
-
-/**
- * Cost of one candidate segment against every neighbouring edge, delegated to the
- * SHARED `polylineConflictCost` so a crossing, a collinear overlap and a too-close
- * parallel run keep the orthogonal engine's shared scale (`edgeCrossing` 400,
- * `overlapPerPx` 25, `crowdingPerPx` 3). A crossing is intentionally charged once:
- * axis-aligned crossings can use line-jump bridges, and even an unavoidable
- * diagonal crossing is easier to trace than a disproportionate excursion around a
- * long neighbouring line. Summed over neighbours, so input order cannot change
- * the cost.
- */
-const neighborCostPx = (
-  a: IPoint,
-  b: IPoint,
-  neighborRoutes: readonly (readonly IPoint[])[],
-  crowdingClearancePx: number
-): number => {
-  return polylineConflictCost([a, b], neighborRoutes, crowdingClearancePx).cost
 }
 
 /** The MINIMUM clearance a generated detour guarantees from every hard obstacle. */
@@ -205,35 +175,9 @@ const TURN_PENALTY_PX = 90
  */
 const ENDPOINT_ANGLE_PENALTY_PX = 150
 
-/**
- * The separation at which two edges stop reading as one thick line. Below it the
- * crowding term charges, in proportion to how far short the run falls; at or above
- * it the charge is exactly zero. That is what makes a pair of neatly parallel
- * connectors the CHEAPEST arrangement available rather than merely a tolerated one —
- * expressed as a penalty that vanishes, because a literal bonus would be a negative
- * edge weight and A* may not have those.
- *
- * Deliberately the node clearance rather than the engine's tighter edge-to-edge
- * band: a straight route is free to sit anywhere, so it can afford real daylight,
- * and the reported drawings read as cramped at the tighter value.
- */
-const EDGE_CROWDING_CLEARANCE_PX = EDGES.NODE_CLEARANCE_PX
-
-/**
- * Charged for turning at a point another route already turns at, so connectors that
- * must clear the same obstacle do not all pile onto one shared elbow.
- *
- * Deliberately SMALL. A larger value unties the knot but is order-dependent — the
- * first route to claim a corner keeps it and the next is pushed out — which makes a
- * mirror-symmetric diagram resolve differently on its two halves. Symmetry is worth
- * more than an untied elbow, so this only breaks ties between otherwise equal
- * corners; genuinely separating a fan needs deterministic port-rank nudging.
- */
-const SHARED_BEND_PENALTY_PX = 12
-
 /** Charged for turning on a corner ring other than the edge's preferred one. Enough
- * to outweigh the extra travel of standing further off an obstacle, far below a
- * crossing, so it nests a fan without ever buying a conflict. */
+ * to outweigh the extra travel of standing further off an obstacle, while still
+ * far below another bend, so it nests a fan without creating an excursion. */
 const RING_MISMATCH_PENALTY_PX = 70
 
 /** Beyond this many graph vertices the directed-edge search is skipped in favour of
@@ -241,12 +185,11 @@ const RING_MISMATCH_PENALTY_PX = 70
  * still uses the same visibility graph and therefore never gives up obstacle safety. */
 const MAX_DIRECTED_SEARCH_VERTICES = 176
 
-type Kind = 0 | 1 | 2 | 3 | 4
+type Kind = 0 | 1 | 2 | 3
 const KIND_SOURCE: Kind = 0
 const KIND_TARGET: Kind = 1
 const KIND_CHECKPOINT: Kind = 2
 const KIND_CORNER: Kind = 3
-const KIND_NEIGHBOR_CORNER: Kind = 4
 
 type Vertex = {
   x: number
@@ -474,8 +417,7 @@ const buildVertices = (
   target: IPoint,
   checkpoints: readonly IPoint[],
   hardObstacles: readonly StraightRouteObstacle[],
-  cornerPads: readonly number[],
-  conflictingRoutes: readonly (readonly IPoint[])[]
+  cornerPads: readonly number[]
 ): { vertices: Vertex[]; indexAt: (p: IPoint) => number } => {
   const raw: Vertex[] = [
     {
@@ -505,9 +447,8 @@ const buildVertices = (
   // Two rings of corner vertices per obstacle. The TIGHT ring (the blocking margin)
   // keeps a narrow gap between two nodes usable — a single wide ring welds their
   // padded corners together and closes it. The ROOMY ring gives a second, more
-  // generous turning point where there is space, so two sibling routes bending past
-  // the same node are not forced through one shared pinch point: the crowding term
-  // then separates them instead of stacking them.
+  // generous turning point where there is space. A geometry-derived fan rank picks
+  // the ring, so sibling detours nest without depending on route order.
   const blocked = hardObstacles.map((o) => inflate(rectOf(o), MIN_CLEARANCE_PX))
   for (const o of hardObstacles) {
     if (o.soft) continue
@@ -530,47 +471,6 @@ const buildVertices = (
           kind: KIND_CORNER,
           ownerId: o.id,
           cornerIndex: ring * 4 + ci,
-        })
-      })
-    }
-  }
-
-  // An edge is a priced constraint, not a hard obstacle: these are candidate
-  // detour points, while visibility may still cross it when every detour is worse.
-  // Axis-aligned bounding corners give the search points beyond BOTH endpoints of
-  // a crossing segment; a single normal offset would cross it again on the way out.
-  //
-  // Owner ids derive only from canonical geometry. Neighbor arrays have no stable
-  // ids here and may arrive in any order, so their indices cannot enter a tie-break.
-  for (const route of conflictingRoutes) {
-    for (let i = 1; i < route.length; i++) {
-      const first = route[i - 1]
-      const second = route[i]
-      if (samePoint(first, second)) continue
-      const a =
-        first.x < second.x || (first.x === second.x && first.y <= second.y)
-          ? first
-          : second
-      const b = a === first ? second : first
-      const ownerId = `${a.x},${a.y}:${b.x},${b.y}`
-      const loX = Math.min(a.x, b.x) - EDGE_CROWDING_CLEARANCE_PX
-      const hiX = Math.max(a.x, b.x) + EDGE_CROWDING_CLEARANCE_PX
-      const loY = Math.min(a.y, b.y) - EDGE_CROWDING_CLEARANCE_PX
-      const hiY = Math.max(a.y, b.y) + EDGE_CROWDING_CLEARANCE_PX
-      const corners: IPoint[] = [
-        { x: loX, y: loY },
-        { x: hiX, y: loY },
-        { x: hiX, y: hiY },
-        { x: loX, y: hiY },
-      ]
-      corners.forEach((p, cornerIndex) => {
-        if (blocked.some((rect) => strictlyInside(rect, p))) return
-        raw.push({
-          x: p.x,
-          y: p.y,
-          kind: KIND_NEIGHBOR_CORNER,
-          ownerId,
-          cornerIndex,
         })
       })
     }
@@ -639,18 +539,13 @@ const buildAdjacency = (
 /**
  * Linear-state fallback for an unusually large visibility graph. Exact turn
  * sharpness needs a directed-edge state, but hard-obstacle safety does not. This
- * search still prices a flat bend, edge conflicts, endpoint angles, occupied
- * elbows, and the preferred obstacle ring.
+ * search still prices a flat bend, endpoint angles, and the preferred obstacle ring.
  */
 const routeSubPathByVertex = (
   vertices: readonly Vertex[],
   startIndex: number,
   goalIndex: number,
   blockRects: readonly IntRect[],
-  neighborRoutes: readonly (readonly IPoint[])[],
-  crowdingClearancePx: number,
-  siblingRoutes: readonly (readonly IPoint[])[],
-  occupiedBends: ReadonlySet<string>,
   preferredCornerRing: number,
   sourceNormal: IPoint | undefined,
   targetNormal: IPoint | undefined
@@ -679,10 +574,7 @@ const routeSubPathByVertex = (
       const from = vertices[current]
       const to = vertices[next]
       const dir = { x: to.x - from.x, y: to.y - from.y }
-      let step =
-        segLenInt(from, to) +
-        neighborCostPx(from, to, neighborRoutes, crowdingClearancePx) +
-        neighborCostPx(from, to, siblingRoutes, 0)
+      let step = segLenInt(from, to)
       if (current === startIndex && sourceNormal)
         step += angleCostPx(dir, sourceNormal, ENDPOINT_ANGLE_PENALTY_PX)
       if (next === goalIndex && targetNormal)
@@ -693,8 +585,6 @@ const routeSubPathByVertex = (
         )
       if (current !== startIndex) {
         step += BEND_PENALTY_PX
-        if (occupiedBends.has(`${from.x},${from.y}`))
-          step += SHARED_BEND_PENALTY_PX
         if (
           from.kind === KIND_CORNER &&
           Math.floor(from.cornerIndex / 4) !== preferredCornerRing
@@ -735,10 +625,6 @@ const routeSubPath = (
   startIndex: number,
   goalIndex: number,
   blockRects: readonly IntRect[],
-  neighborRoutes: readonly (readonly IPoint[])[],
-  crowdingClearancePx: number,
-  siblingRoutes: readonly (readonly IPoint[])[],
-  occupiedBends: ReadonlySet<string>,
   preferredCornerRing: number,
   sourceNormal: IPoint | undefined,
   targetNormal: IPoint | undefined
@@ -769,9 +655,7 @@ const routeSubPath = (
 
   const bendCostAt = (i: number): number => {
     if (i === goalIndex) return 0
-    let cost = occupiedBends.has(`${vertices[i].x},${vertices[i].y}`)
-      ? SHARED_BEND_PENALTY_PX
-      : 0
+    let cost = 0
     if (
       vertices[i].kind === KIND_CORNER &&
       Math.floor(vertices[i].cornerIndex / 4) !== preferredCornerRing
@@ -781,15 +665,7 @@ const routeSubPath = (
   }
 
   const segmentCost = (i: number, j: number): number =>
-    segLenInt(vertices[i], vertices[j]) +
-    neighborCostPx(
-      vertices[i],
-      vertices[j],
-      neighborRoutes,
-      crowdingClearancePx
-    ) +
-    // Zero clearance: a sibling only costs when it is crossed or lain upon.
-    neighborCostPx(vertices[i], vertices[j], siblingRoutes, 0)
+    segLenInt(vertices[i], vertices[j])
 
   for (const v of adjacency[startIndex]) {
     const dir = {
@@ -855,10 +731,6 @@ const routeSubPath = (
       startIndex,
       goalIndex,
       blockRects,
-      neighborRoutes,
-      crowdingClearancePx,
-      siblingRoutes,
-      occupiedBends,
       preferredCornerRing,
       sourceNormal,
       targetNormal
@@ -895,27 +767,16 @@ const collapseCollinear = (points: readonly IPoint[]): IPoint[] => {
 }
 
 /** The complete objective for a finished route, in integer px: travel, every bend,
- * both endpoint departure angles, and the shared neighbour-conflict cost. This is
- * the same sum the search minimises, so simplification can be accepted only when it
- * genuinely improves the drawing. */
+ * and both endpoint departure angles. This is the same sum the search minimises,
+ * so simplification can be accepted only when it genuinely improves the drawing. */
 const totalRouteCostPx = (
   route: readonly IPoint[],
-  neighborRoutes: readonly (readonly IPoint[])[],
-  crowdingClearancePx: number,
-  siblingRoutes: readonly (readonly IPoint[])[],
   sourceNormal: IPoint | undefined,
   targetNormal: IPoint | undefined
 ): number => {
   let cost = 0
   for (let i = 1; i < route.length; i++) {
     cost += segLenInt(route[i - 1], route[i])
-    cost += neighborCostPx(
-      route[i - 1],
-      route[i],
-      neighborRoutes,
-      crowdingClearancePx
-    )
-    cost += neighborCostPx(route[i - 1], route[i], siblingRoutes, 0)
     if (i >= 2) cost += turnCostPx(route[i - 2], route[i - 1], route[i])
   }
   if (sourceNormal && route.length >= 2)
@@ -949,22 +810,12 @@ const totalRouteCostPx = (
 const simplifyRoute = (
   route: readonly IPoint[],
   blockRects: readonly IntRect[],
-  neighborRoutes: readonly (readonly IPoint[])[],
-  crowdingClearancePx: number,
-  siblingRoutes: readonly (readonly IPoint[])[],
   sourceNormal: IPoint | undefined,
   targetNormal: IPoint | undefined,
   protectedPoints: ReadonlySet<string> = new Set()
 ): IPoint[] => {
   let best = [...route]
-  let bestCost = totalRouteCostPx(
-    best,
-    neighborRoutes,
-    crowdingClearancePx,
-    siblingRoutes,
-    sourceNormal,
-    targetNormal
-  )
+  let bestCost = totalRouteCostPx(best, sourceNormal, targetNormal)
   for (let pass = 0; pass < 4; pass++) {
     let improved = false
     for (let i = 1; i < best.length - 1; i++) {
@@ -978,14 +829,7 @@ const simplifyRoute = (
         segmentBlockedByClearanceRect(a, b, r, isEndA, isEndB)
       )
       if (blocked) continue
-      const cost = totalRouteCostPx(
-        candidate,
-        neighborRoutes,
-        crowdingClearancePx,
-        siblingRoutes,
-        sourceNormal,
-        targetNormal
-      )
+      const cost = totalRouteCostPx(candidate, sourceNormal, targetNormal)
       if (cost < bestCost) {
         best = candidate
         bestCost = cost
@@ -1001,8 +845,8 @@ const simplifyRoute = (
 /**
  * Route a deterministic straight (obstacle-avoiding) polyline from source to target
  * through every checkpoint in order. Returns the full route INCLUDING the endpoints:
- * `[source, …bends, target]`. A direct polyline is returned unchanged only when it
- * clears hard obstacles and has no structural edge conflict.
+ * `[source, …bends, target]`. A direct polyline is returned unchanged whenever it
+ * clears hard obstacles; only node bodies can create an automatic detour.
  */
 export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
   const {
@@ -1010,9 +854,7 @@ export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
     target,
     checkpoints,
     obstacles,
-    neighborRoutes,
     clearancePx,
-    siblingRoutes,
     preferredCornerRing,
     sourceNormal,
     targetNormal,
@@ -1020,9 +862,11 @@ export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
   const hardObstacles = obstacles.filter((o) => !o.soft)
   const anchors: IPoint[] = [source, ...checkpoints, target]
 
-  // 1. Gate: every sub-chord clears hard obstacles and has no structural edge
-  //    conflict. Mere crowding does not manufacture a bend in an otherwise clean
-  //    chord; crossings and overlaps open the graph so it can avoid them.
+  // 1. Gate: every sub-chord clears hard obstacles. Edge crossings and overlaps
+  //    are not routing obstacles: trying to dodge them makes a direct edge change
+  //    topology as soon as another connector passes across it, and makes a dense
+  //    but unobstructed diagram pay for a quadratic visibility search. Apollon's
+  //    line jumps make an ordinary crossing readable without that excursion.
   const straightClears = anchors.every((a, i) => {
     if (i === 0) return true
     return chordClearsObstacles(
@@ -1033,104 +877,105 @@ export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
     )
   })
   const direct = collapseCollinear(anchors)
-  const conflictsStructurally = (
-    routes: readonly (readonly IPoint[])[]
-  ): boolean => {
-    const conflict = polylineConflictCost(direct, routes, 0)
-    return conflict.crossings > 0 || conflict.overlapPx > 0
-  }
-  const allSiblingRoutes = siblingRoutes ?? []
-  // Sibling crowding remains exempt, but a sibling crossing/overlap is structural:
-  // it must open the graph and contribute the same candidate detour vertices as an
-  // unrelated edge. Coordinated ports and obstacle rings still handle ordinary
-  // side-by-side fan separation without route-order-dependent crowding.
-  const conflictingNeighborRoutes = neighborRoutes.filter((route) =>
-    conflictsStructurally([route])
-  )
-  const conflictingSiblingRoutes = allSiblingRoutes.filter((route) =>
-    conflictsStructurally([route])
-  )
-  const conflictingRoutes = [
-    ...conflictingNeighborRoutes,
-    ...conflictingSiblingRoutes,
-  ]
-  if (straightClears && conflictingRoutes.length === 0) return direct
+  if (straightClears) return direct
 
-  // 2. Visibility graph over endpoints, checkpoints and inflated hard corners.
-  //    Corners are inflated by the SAME margin the visibility test blocks at. A
-  //    wider corner pad silently welds neighbouring obstacles together — their
-  //    padded corners land inside each other — which closes legitimate gaps between
-  //    two nodes and forces a long detour around the whole group.
-  const { vertices, indexAt } = buildVertices(
-    source,
-    target,
-    checkpoints,
-    hardObstacles,
-    [MIN_CLEARANCE_PX, clearancePx],
-    conflictingRoutes
-  )
-  const blockRects = hardObstacles.map((o) =>
-    inflate(rectOf(o), MIN_CLEARANCE_PX)
-  )
-  // Elbows other routes already turn at — see SHARED_BEND_PENALTY_PX.
-  const occupiedBends = new Set<string>()
-  for (const route of [...neighborRoutes, ...(siblingRoutes ?? [])])
-    for (const point of route.slice(1, -1))
-      occupiedBends.add(`${point.x},${point.y}`)
-
-  // 3. Route each checkpoint sub-chord independently and concatenate. Only the
-  //    first sub-chord departs the source node and only the last meets the target,
-  //    so the endpoint-angle terms apply to those alone.
-  const combined: IPoint[] = []
-  for (let k = 1; k < anchors.length; k++) {
-    const startIndex = indexAt(anchors[k - 1])
-    const goalIndex = indexAt(anchors[k])
-    const sub =
-      startIndex < 0 || goalIndex < 0
-        ? [anchors[k - 1], anchors[k]]
-        : vertices.length > MAX_DIRECTED_SEARCH_VERTICES
-          ? routeSubPathByVertex(
-              vertices,
-              startIndex,
-              goalIndex,
-              blockRects,
-              neighborRoutes,
-              EDGE_CROWDING_CLEARANCE_PX,
-              allSiblingRoutes,
-              occupiedBends,
-              preferredCornerRing ?? 0,
-              k === 1 ? sourceNormal : undefined,
-              k === anchors.length - 1 ? targetNormal : undefined
-            )
-          : routeSubPath(
-              vertices,
-              startIndex,
-              goalIndex,
-              blockRects,
-              neighborRoutes,
-              EDGE_CROWDING_CLEARANCE_PX,
-              allSiblingRoutes,
-              occupiedBends,
-              preferredCornerRing ?? 0,
-              k === 1 ? sourceNormal : undefined,
-              k === anchors.length - 1 ? targetNormal : undefined
-            )
-    if (combined.length === 0) combined.push(...sub)
-    else combined.push(...sub.slice(1))
-  }
-
-  // 4. Collapse collinear points, then string-pull away any bend the route does not
-  //    need using the complete search objective.
-  return collapseCollinear(
-    simplifyRoute(
-      collapseCollinear(combined),
-      blockRects,
-      neighborRoutes,
-      EDGE_CROWDING_CLEARANCE_PX,
-      allSiblingRoutes,
-      sourceNormal,
-      targetNormal,
-      new Set(checkpoints.map((point) => `${point.x},${point.y}`))
+  const routeWithObstacles = (
+    activeObstacles: StraightRouteObstacle[]
+  ): IPoint[] => {
+    // 2. Visibility graph over the endpoints, checkpoints and the obstacles that
+    //    can actually constrain this route. Corners use the same inflation as
+    //    visibility; a wider pad would weld neighbouring nodes together.
+    const { vertices, indexAt } = buildVertices(
+      source,
+      target,
+      checkpoints,
+      activeObstacles,
+      [MIN_CLEARANCE_PX, clearancePx]
     )
+    const blockRects = activeObstacles.map((obstacle) =>
+      inflate(rectOf(obstacle), MIN_CLEARANCE_PX)
+    )
+
+    // 3. Route each checkpoint sub-chord independently and concatenate. Only the
+    //    first sub-chord departs the source node and only the last meets the target.
+    const combined: IPoint[] = []
+    for (let k = 1; k < anchors.length; k++) {
+      const startIndex = indexAt(anchors[k - 1])
+      const goalIndex = indexAt(anchors[k])
+      const sub =
+        startIndex < 0 || goalIndex < 0
+          ? [anchors[k - 1], anchors[k]]
+          : vertices.length > MAX_DIRECTED_SEARCH_VERTICES
+            ? routeSubPathByVertex(
+                vertices,
+                startIndex,
+                goalIndex,
+                blockRects,
+                preferredCornerRing ?? 0,
+                k === 1 ? sourceNormal : undefined,
+                k === anchors.length - 1 ? targetNormal : undefined
+              )
+            : routeSubPath(
+                vertices,
+                startIndex,
+                goalIndex,
+                blockRects,
+                preferredCornerRing ?? 0,
+                k === 1 ? sourceNormal : undefined,
+                k === anchors.length - 1 ? targetNormal : undefined
+              )
+      if (combined.length === 0) combined.push(...sub)
+      else combined.push(...sub.slice(1))
+    }
+
+    // 4. Collapse collinear points, then string-pull away any unnecessary bend.
+    return collapseCollinear(
+      simplifyRoute(
+        collapseCollinear(combined),
+        blockRects,
+        sourceNormal,
+        targetNormal,
+        new Set(checkpoints.map((point) => `${point.x},${point.y}`))
+      )
+    )
+  }
+
+  const blocksRoute = (
+    obstacle: StraightRouteObstacle,
+    route: readonly IPoint[],
+    clearancePx: number
+  ): boolean =>
+    route.some(
+      (point, index) =>
+        index > 0 &&
+        !chordClearsObstacles(route[index - 1], point, [obstacle], clearancePx)
+    )
+
+  // The direct route's blockers are the only obstacles that belong in the first
+  // graph. A diagonal's axis-aligned bounds can contain an entire diagram even
+  // though it touches one node; putting all of those corners in the graph makes
+  // visibility work cubic in unrelated geometry. If the chosen detour approaches
+  // another node, add every newly relevant obstacle and solve again. This monotonic
+  // repair keeps the same safety guarantee without paying for distant nodes.
+  let activeObstacles = hardObstacles.filter((obstacle) =>
+    blocksRoute(obstacle, anchors, DIRECT_ROUTE_CLEARANCE_PX)
   )
+  let route = routeWithObstacles(activeObstacles)
+  const activeIds = new Set(activeObstacles.map((obstacle) => obstacle.id))
+  const MAX_LOCAL_REPAIRS = 2
+  for (let repair = 0; repair < MAX_LOCAL_REPAIRS; repair++) {
+    const newlyRelevant = hardObstacles.filter(
+      (obstacle) =>
+        !activeIds.has(obstacle.id) &&
+        blocksRoute(obstacle, route, MIN_CLEARANCE_PX)
+    )
+    if (newlyRelevant.length === 0) return route
+    for (const obstacle of newlyRelevant) activeIds.add(obstacle.id)
+    activeObstacles = [...activeObstacles, ...newlyRelevant]
+    route = routeWithObstacles(activeObstacles)
+  }
+
+  // A contrived chain can reveal one new obstacle per detour. Fall back once to
+  // the complete field after the bounded local repairs; safety is never degraded.
+  return routeWithObstacles(hardObstacles)
 }

--- a/library/lib/utils/geometry/straightPolylineRouter.ts
+++ b/library/lib/utils/geometry/straightPolylineRouter.ts
@@ -1,0 +1,1109 @@
+/**
+ * Deterministic obstacle-avoiding STRAIGHT polyline router.
+ *
+ * Given resolved integer endpoints, ordered mandatory checkpoints, and hard/soft
+ * obstacle rectangles, this produces the shortest straight-segment polyline that
+ * keeps clearance from the hard obstacles. It feeds memoryless auto-routing, so the
+ * output MUST be reproduced byte-identically by Yjs peers and after a reload:
+ *
+ *  - Every decision is integer. The only square root is `isqrt` (exact floor); no
+ *    `hypot`/`atan2`/float comparison ever chooses a vertex or breaks a tie.
+ *  - Vertices carry a canonical key `(x, y, kind, ownerId, cornerIndex)` and the
+ *    graph, adjacency lists and A* frontier are all built in that fixed order.
+ *  - The A* frontier is a 4-ary min-heap keyed on `(gPlusH, vertexIndex, seq)`,
+ *    whose final tie-break — the monotonic insertion counter `seq` — is a unique
+ *    discriminator, so the search result cannot depend on engine scheduling or on
+ *    the input order of obstacles/neighbours.
+ *
+ * Design:
+ *  1. Gate: if every checkpoint sub-chord already clears all hard obstacles by
+ *     ≥ MIN clearance AND has no crossing/overlap with another edge, return the
+ *     straight polyline unchanged (the common case).
+ *  2. Otherwise build a reduced/tangent visibility graph over the endpoints, the
+ *     checkpoints, two rings of inflated corners per HARD obstacle, and clearance
+ *     corners around neighbouring segments that conflict with the direct route.
+ *     Soft obstacles never block visibility.
+ *  3. Route each checkpoint sub-chord with A* over DIRECTED EDGES, so the objective
+ *     can price the things that decide whether a detour looks deliberate or
+ *     accidental: travel, a flat per-bend charge plus a sharpness-graduated turn
+ *     cost, the departure/arrival angle against each node side, and the shared
+ *     crossing / overlap / crowding cost against neighbouring edges. Checkpoints
+ *     are mandatory via-points (the libavoid model).
+ *  4. Collapse collinear points, then string-pull away any bend the route does not
+ *     need — accepted only when it strictly improves that same objective.
+ *
+ * This module is deliberately self-contained: `segmentsCrossOpen` and the 4-ary heap
+ * live privately in `routingCost.ts` / `orthogonalRouter.ts` and are not exported, so
+ * the equivalent logic is re-implemented here rather than editing those files.
+ */
+import type { IPoint } from "@/edges/Connection"
+import { CANVAS, EDGES } from "@/utils/geometry/routingConstants"
+import {
+  polylineConflictCost,
+  ROUTING_COST,
+} from "@/utils/geometry/routingCost"
+import { distSqInt, isqrt, segLenInt } from "@/utils/geometry/integerGeometry"
+
+export interface StraightRouteObstacle {
+  id: string
+  x: number
+  y: number
+  width: number
+  height: number
+  soft: boolean
+}
+
+export interface StraightRouteRequest {
+  /** Resolved, integer, adjusted source endpoint. */
+  source: IPoint
+  /** Resolved, integer, adjusted target endpoint. */
+  target: IPoint
+  /** Ordered mandatory via-points (user waypoints); may be empty. */
+  checkpoints: IPoint[]
+  /** Corridor obstacle rects (bboxes). */
+  obstacles: StraightRouteObstacle[]
+  /** Other edges' polylines, for crossing/overlap/crowding pricing. */
+  neighborRoutes: IPoint[][]
+  /** Preferred breathing room around a node (EDGES.NODE_CLEARANCE_PX). It sets the
+   * roomier of the two corner rings; the guaranteed margin is MIN_NODE_CLEARANCE_PX.
+   * Edge-to-edge crowding is measured separately (EDGE_CROWDING_CLEARANCE_PX). */
+  clearancePx: number
+  /**
+   * Which ring of obstacle corners this route should prefer to turn on: 0 hugs the
+   * guaranteed margin, 1 stands further off. Sibling connectors that must clear the
+   * same obstacle otherwise converge on one shared elbow; giving the outer members
+   * of a fan the outer ring nests them instead, so they stay separated and parallel.
+   * Derived from the edge's own coordinated seat, never from routing order, so a
+   * mirror-symmetric diagram still resolves symmetrically.
+   */
+  preferredCornerRing?: number
+  /** Routes of edges that SHARE a node with this one. They are meant to fan out
+   * side by side, so they are exempt from the crowding term — but never from
+   * crossing or from lying exactly on top of one another, which is always a defect.
+   * Pricing them at zero crowding clearance expresses precisely that. */
+  siblingRoutes?: IPoint[][]
+  /** Outward unit normal of the node side the route leaves from, when known. The
+   * search then prices a grazing departure (see `ENDPOINT_ANGLE_PENALTY_PX`). */
+  sourceNormal?: IPoint
+  /** Outward unit normal of the node side the route arrives at, when known. */
+  targetNormal?: IPoint
+}
+
+/** `weight · (1 − cos θ)` between `dir` and a unit `reference`, in integer px. */
+const angleCostPx = (
+  dir: IPoint,
+  reference: IPoint,
+  weightPx: number
+): number => {
+  const length = isqrt(dir.x * dir.x + dir.y * dir.y)
+  if (length === 0) return 0
+  const dot = dir.x * reference.x + dir.y * reference.y
+  const cosScaled = Math.trunc((dot * SCALE) / length)
+  return Math.trunc((weightPx * (SCALE - cosScaled)) / SCALE)
+}
+
+/** Cost of the bend at `via` between the incoming and outgoing segments. */
+const turnCostPx = (from: IPoint, via: IPoint, to: IPoint): number => {
+  const incoming = { x: via.x - from.x, y: via.y - from.y }
+  const outgoing = { x: to.x - via.x, y: to.y - via.y }
+  const incomingLength = isqrt(
+    incoming.x * incoming.x + incoming.y * incoming.y
+  )
+  if (incomingLength === 0) return 0
+  // Normalising the incoming direction to the fixed-point scale keeps the whole
+  // computation integer while measuring the true deviation from "straight on".
+  const reference = {
+    x: Math.trunc((incoming.x * SCALE) / incomingLength),
+    y: Math.trunc((incoming.y * SCALE) / incomingLength),
+  }
+  const outgoingLength = isqrt(
+    outgoing.x * outgoing.x + outgoing.y * outgoing.y
+  )
+  if (outgoingLength === 0) return 0
+  const dot = outgoing.x * reference.x + outgoing.y * reference.y
+  // `isqrt` floors both normalisation lengths. Without this clamp two equal
+  // diagonal directions can produce SCALE + 1, making a bend cheaper than its
+  // documented flat floor and destabilising near-tied routes.
+  const cosScaled = Math.max(
+    -SCALE,
+    Math.min(SCALE, Math.trunc(dot / outgoingLength))
+  )
+  return (
+    BEND_PENALTY_PX +
+    Math.trunc((TURN_PENALTY_PX * (SCALE - cosScaled)) / SCALE)
+  )
+}
+
+/** A diagonal crossing needs a stronger deterrent than the orthogonal baseline.
+ * Orthogonal lines cross at 90° and remain easy to trace; arbitrary-angle straight
+ * lines can merge visually. Keep this surcharge crossing-only so parallel crowding
+ * cannot force gratuitous bends in an otherwise clean fan. */
+const STRAIGHT_CROSSING_SURCHARGE_PX = ROUTING_COST.edgeCrossing
+
+/**
+ * Cost of one candidate segment against every neighbouring edge, delegated to the
+ * SHARED `polylineConflictCost` so a crossing, a collinear overlap and a too-close
+ * parallel run keep the orthogonal engine's shared scale (`edgeCrossing` 400,
+ * `overlapPerPx` 25, `crowdingPerPx` 3), then adding the diagonal-only crossing
+ * surcharge above. Summed over neighbours, so input order cannot change the cost.
+ */
+const neighborCostPx = (
+  a: IPoint,
+  b: IPoint,
+  neighborRoutes: readonly (readonly IPoint[])[],
+  crowdingClearancePx: number
+): number => {
+  const conflict = polylineConflictCost(
+    [a, b],
+    neighborRoutes,
+    crowdingClearancePx
+  )
+  return conflict.cost + conflict.crossings * STRAIGHT_CROSSING_SURCHARGE_PX
+}
+
+/** The MINIMUM clearance the returned route guarantees from every hard obstacle.
+ * It is also the obstacle half of the direct-route gate; a chord must additionally
+ * have no crossing or overlap to be returned as-is. */
+const MIN_CLEARANCE_PX = EDGES.MIN_NODE_CLEARANCE_PX
+
+/**
+ * The routing objective, expressed entirely in pixels of travel so it composes with
+ * segment length and with the shared `ROUTING_COST` scale the orthogonal engine uses.
+ *
+ * `SCALE` is the fixed-point denominator for the cosine terms: every angular cost is
+ * `weight · (1 − cos θ) / SCALE`, computed from integer dot products and `isqrt`
+ * lengths, so no float/`atan2` ever reaches a decision.
+ */
+const SCALE = 1024
+
+/**
+ * Flat cost of HAVING a bend at all, independent of how gentle it is — the straight
+ * regime's counterpart to the engine's per-corner `bendInGridCells` charge.
+ *
+ * Two jobs. Without a floor, a graduated angle cost makes a staircase of tiny
+ * near-free bends cheaper than one honest corner and the route acquires a shimmer of
+ * pointless kinks. And the floor has to be GENEROUS — four orthogonal corners' worth
+ * — because a diagonal bend may fall anywhere, so a small floor lets the search buy
+ * an extra corner for a few pixels of length. That is exactly what makes a drawing
+ * unstable: nudge a node and a route that was saving 5px suddenly gains a bend.
+ * Pricing a corner well above such savings measurably steadies the picture (bend
+ * flips under a one-grid-cell node move fell by ~70% in the routing fixtures)
+ * without lengthening a single route in them.
+ */
+const BEND_PENALTY_PX =
+  4 * ROUTING_COST.bendInGridCells * CANVAS.SNAP_TO_GRID_PX
+
+/** Additional cost scaled by how sharply the route turns. `(1 − cos)` keeps a gentle
+ * course correction cheap while a right-angle turn costs ~2 further bends and a
+ * hairpin twice that, so an obstacle detour reads as one smooth deviation. */
+const TURN_PENALTY_PX = 90
+
+/**
+ * Cost of leaving (or meeting) a node at anything other than a right angle to its
+ * side. A grazing departure that skims along the node's own edge is the single
+ * ugliest artefact a shortest-path router produces, so it is priced above a bend:
+ * the search would rather spend a corner, or attach on a different side, than slide
+ * out sideways. Running back INTO the node costs twice this.
+ */
+const ENDPOINT_ANGLE_PENALTY_PX = 150
+
+/**
+ * The separation at which two edges stop reading as one thick line. Below it the
+ * crowding term charges, in proportion to how far short the run falls; at or above
+ * it the charge is exactly zero. That is what makes a pair of neatly parallel
+ * connectors the CHEAPEST arrangement available rather than merely a tolerated one —
+ * expressed as a penalty that vanishes, because a literal bonus would be a negative
+ * edge weight and A* may not have those.
+ *
+ * Deliberately the node clearance rather than the engine's tighter edge-to-edge
+ * band: a straight route is free to sit anywhere, so it can afford real daylight,
+ * and the reported drawings read as cramped at the tighter value.
+ */
+const EDGE_CROWDING_CLEARANCE_PX = EDGES.NODE_CLEARANCE_PX
+
+/**
+ * Charged for turning at a point another route already turns at, so connectors that
+ * must clear the same obstacle do not all pile onto one shared elbow.
+ *
+ * Deliberately SMALL. A larger value unties the knot but is order-dependent — the
+ * first route to claim a corner keeps it and the next is pushed out — which makes a
+ * mirror-symmetric diagram resolve differently on its two halves. Symmetry is worth
+ * more than an untied elbow, so this only breaks ties between otherwise equal
+ * corners; genuinely separating a fan needs deterministic port-rank nudging.
+ */
+const SHARED_BEND_PENALTY_PX = 12
+
+/** Charged for turning on a corner ring other than the edge's preferred one. Enough
+ * to outweigh the extra travel of standing further off an obstacle, far below a
+ * crossing, so it nests a fan without ever buying a conflict. */
+const RING_MISMATCH_PENALTY_PX = 70
+
+/** Beyond this many graph vertices the directed-edge search is skipped in favour of
+ * the bounded vertex-keyed search below. It has a less exact turn objective, but
+ * still uses the same visibility graph and therefore never gives up obstacle safety. */
+const MAX_DIRECTED_SEARCH_VERTICES = 176
+
+type Kind = 0 | 1 | 2 | 3 | 4
+const KIND_SOURCE: Kind = 0
+const KIND_TARGET: Kind = 1
+const KIND_CHECKPOINT: Kind = 2
+const KIND_CORNER: Kind = 3
+const KIND_NEIGHBOR_CORNER: Kind = 4
+
+type Vertex = {
+  x: number
+  y: number
+  kind: Kind
+  ownerId: string
+  cornerIndex: number
+}
+
+type IntRect = { x: number; y: number; w: number; h: number }
+
+const rectOf = (o: StraightRouteObstacle): IntRect => ({
+  x: o.x,
+  y: o.y,
+  w: o.width,
+  h: o.height,
+})
+
+const inflate = (r: IntRect, d: number): IntRect => ({
+  x: r.x - d,
+  y: r.y - d,
+  w: r.w + 2 * d,
+  h: r.h + 2 * d,
+})
+
+const strictlyInside = (r: IntRect, p: IPoint): boolean =>
+  p.x > r.x && p.x < r.x + r.w && p.y > r.y && p.y < r.y + r.h
+
+const inclusiveContains = (r: IntRect, p: IPoint): boolean =>
+  p.x >= r.x && p.x <= r.x + r.w && p.y >= r.y && p.y <= r.y + r.h
+
+/** Orientation sign of point c relative to the directed line a→b (integer). */
+const orient = (a: IPoint, b: IPoint, c: IPoint): number =>
+  (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+
+/**
+ * Strict interior crossing of two segments. Endpoint touches are attachment
+ * geometry, not crossings — this mirrors the private `segmentsCrossOpen` in
+ * `routingCost.ts`, re-implemented here so the module stays self-contained.
+ */
+const segmentsCrossOpen = (
+  a1: IPoint,
+  a2: IPoint,
+  b1: IPoint,
+  b2: IPoint
+): boolean => {
+  const l1 = orient(a1, a2, b1)
+  const l2 = orient(a1, a2, b2)
+  const r1 = orient(b1, b2, a1)
+  const r2 = orient(b1, b2, a2)
+  return l1 * l2 < 0 && r1 * r2 < 0
+}
+
+/**
+ * Does the open segment a→b pass through the OPEN interior of the axis-aligned
+ * rectangle? Three exact integer tests: either endpoint strictly inside, the
+ * midpoint strictly inside (doubled coordinates keep it integer — this catches a
+ * corner-to-corner diagonal that grazes only the rectangle's own corners), or a
+ * strict crossing of any of the four sides. Corner touches are allowed.
+ */
+const segmentIntersectsRectInterior = (
+  a: IPoint,
+  b: IPoint,
+  r: IntRect
+): boolean => {
+  if (strictlyInside(r, a) || strictlyInside(r, b)) return true
+
+  const sx = a.x + b.x
+  const sy = a.y + b.y
+  if (
+    sx > 2 * r.x &&
+    sx < 2 * (r.x + r.w) &&
+    sy > 2 * r.y &&
+    sy < 2 * (r.y + r.h)
+  )
+    return true
+
+  const c0 = { x: r.x, y: r.y }
+  const c1 = { x: r.x + r.w, y: r.y }
+  const c2 = { x: r.x + r.w, y: r.y + r.h }
+  const c3 = { x: r.x, y: r.y + r.h }
+  return (
+    segmentsCrossOpen(a, b, c0, c1) ||
+    segmentsCrossOpen(a, b, c1, c2) ||
+    segmentsCrossOpen(a, b, c2, c3) ||
+    segmentsCrossOpen(a, b, c3, c0)
+  )
+}
+
+/**
+ * Does the straight chord a→b clear every HARD obstacle by at least
+ * `minClearancePx`? An obstacle whose `minClearancePx`-inflated body already
+ * contains an endpoint is that endpoint's OWN node and is exempt (you cannot clear
+ * the node your endpoint sits on). Soft obstacles are ignored.
+ */
+export function chordClearsObstacles(
+  a: IPoint,
+  b: IPoint,
+  hardObstacles: StraightRouteObstacle[],
+  minClearancePx: number
+): boolean {
+  for (const o of hardObstacles) {
+    if (o.soft) continue
+    const inflated = inflate(rectOf(o), minClearancePx)
+    if (inclusiveContains(inflated, a) || inclusiveContains(inflated, b))
+      continue
+    if (segmentIntersectsRectInterior(a, b, inflated)) return false
+  }
+  return true
+}
+
+const samePoint = (a: IPoint, b: IPoint): boolean => a.x === b.x && a.y === b.y
+
+const compareStrings = (a: string, b: string): number =>
+  a < b ? -1 : a > b ? 1 : 0
+
+/** Canonical total order on vertices. Deterministic across engines: numeric fields
+ * compare exactly and string ids compare by UTF-16 code unit. */
+const compareVertices = (a: Vertex, b: Vertex): number =>
+  a.x - b.x ||
+  a.y - b.y ||
+  a.kind - b.kind ||
+  compareStrings(a.ownerId, b.ownerId) ||
+  a.cornerIndex - b.cornerIndex
+
+/**
+ * A minimal deterministic 4-ary min-heap keyed on `(priority, vertexIndex, seq)`.
+ * Adapted from the private heap in `orthogonalRouter.ts`; `vertexIndex` is both the
+ * stored payload and the secondary key, and the monotonic `seq` is a unique final
+ * discriminator, so pops are engine-independent.
+ */
+class MinHeap {
+  private readonly pr: number[] = []
+  private readonly idx: number[] = []
+  private readonly sq: number[] = []
+
+  get size(): number {
+    return this.pr.length
+  }
+
+  private less(i: number, j: number): boolean {
+    if (this.pr[i] !== this.pr[j]) return this.pr[i] < this.pr[j]
+    if (this.idx[i] !== this.idx[j]) return this.idx[i] < this.idx[j]
+    return this.sq[i] < this.sq[j]
+  }
+
+  private swap(i: number, j: number): void {
+    ;[this.pr[i], this.pr[j]] = [this.pr[j], this.pr[i]]
+    ;[this.idx[i], this.idx[j]] = [this.idx[j], this.idx[i]]
+    ;[this.sq[i], this.sq[j]] = [this.sq[j], this.sq[i]]
+  }
+
+  push(priority: number, vertexIndex: number, seq: number): void {
+    this.pr.push(priority)
+    this.idx.push(vertexIndex)
+    this.sq.push(seq)
+    let i = this.pr.length - 1
+    while (i > 0) {
+      const parent = (i - 1) >> 2
+      if (!this.less(i, parent)) break
+      this.swap(i, parent)
+      i = parent
+    }
+  }
+
+  /** The lowest-priority payload, or -1 when empty. */
+  pop(): number {
+    if (this.pr.length === 0) return -1
+    const top = this.idx[0]
+    const lastPr = this.pr.pop() as number
+    const lastIdx = this.idx.pop() as number
+    const lastSq = this.sq.pop() as number
+    if (this.pr.length === 0) return top
+    this.pr[0] = lastPr
+    this.idx[0] = lastIdx
+    this.sq[0] = lastSq
+    let i = 0
+    const n = this.pr.length
+    for (;;) {
+      const first = 4 * i + 1
+      if (first >= n) break
+      let best = first
+      const end = Math.min(first + 4, n)
+      for (let c = first + 1; c < end; c++) if (this.less(c, best)) best = c
+      if (!this.less(best, i)) break
+      this.swap(i, best)
+      i = best
+    }
+    return top
+  }
+}
+
+/** Build the canonical, deduplicated vertex list and a coordinate → index lookup.
+ * On a shared coordinate the canonically-smallest vertex wins, so an endpoint (low
+ * kind) is never shadowed by a coincident obstacle corner. */
+const buildVertices = (
+  source: IPoint,
+  target: IPoint,
+  checkpoints: readonly IPoint[],
+  hardObstacles: readonly StraightRouteObstacle[],
+  cornerPads: readonly number[],
+  conflictingRoutes: readonly (readonly IPoint[])[]
+): { vertices: Vertex[]; indexAt: (p: IPoint) => number } => {
+  const raw: Vertex[] = [
+    {
+      x: source.x,
+      y: source.y,
+      kind: KIND_SOURCE,
+      ownerId: "",
+      cornerIndex: 0,
+    },
+    {
+      x: target.x,
+      y: target.y,
+      kind: KIND_TARGET,
+      ownerId: "",
+      cornerIndex: 0,
+    },
+  ]
+  checkpoints.forEach((c, i) =>
+    raw.push({
+      x: c.x,
+      y: c.y,
+      kind: KIND_CHECKPOINT,
+      ownerId: "",
+      cornerIndex: i,
+    })
+  )
+  // Two rings of corner vertices per obstacle. The TIGHT ring (the blocking margin)
+  // keeps a narrow gap between two nodes usable — a single wide ring welds their
+  // padded corners together and closes it. The ROOMY ring gives a second, more
+  // generous turning point where there is space, so two sibling routes bending past
+  // the same node are not forced through one shared pinch point: the crowding term
+  // then separates them instead of stacking them.
+  const blocked = hardObstacles.map((o) => inflate(rectOf(o), MIN_CLEARANCE_PX))
+  for (const o of hardObstacles) {
+    if (o.soft) continue
+    for (const [ring, pad] of cornerPads.entries()) {
+      const r = inflate(rectOf(o), pad)
+      const corners: IPoint[] = [
+        { x: r.x, y: r.y },
+        { x: r.x + r.w, y: r.y },
+        { x: r.x + r.w, y: r.y + r.h },
+        { x: r.x, y: r.y + r.h },
+      ]
+      corners.forEach((p, ci) => {
+        // A roomier corner is only worth having where it is actually reachable.
+        // Keeping one that has drifted inside a NEIGHBOURING node is what welds two
+        // obstacles into one blob and closes the gap between them.
+        if (ring > 0 && blocked.some((b) => strictlyInside(b, p))) return
+        raw.push({
+          x: p.x,
+          y: p.y,
+          kind: KIND_CORNER,
+          ownerId: o.id,
+          cornerIndex: ring * 4 + ci,
+        })
+      })
+    }
+  }
+
+  // An edge is a priced constraint, not a hard obstacle: these are candidate
+  // detour points, while visibility may still cross it when every detour is worse.
+  // Axis-aligned bounding corners give the search points beyond BOTH endpoints of
+  // a crossing segment; a single normal offset would cross it again on the way out.
+  //
+  // Owner ids derive only from canonical geometry. Neighbor arrays have no stable
+  // ids here and may arrive in any order, so their indices cannot enter a tie-break.
+  for (const route of conflictingRoutes) {
+    for (let i = 1; i < route.length; i++) {
+      const first = route[i - 1]
+      const second = route[i]
+      if (samePoint(first, second)) continue
+      const a =
+        first.x < second.x || (first.x === second.x && first.y <= second.y)
+          ? first
+          : second
+      const b = a === first ? second : first
+      const ownerId = `${a.x},${a.y}:${b.x},${b.y}`
+      const loX = Math.min(a.x, b.x) - EDGE_CROWDING_CLEARANCE_PX
+      const hiX = Math.max(a.x, b.x) + EDGE_CROWDING_CLEARANCE_PX
+      const loY = Math.min(a.y, b.y) - EDGE_CROWDING_CLEARANCE_PX
+      const hiY = Math.max(a.y, b.y) + EDGE_CROWDING_CLEARANCE_PX
+      const corners: IPoint[] = [
+        { x: loX, y: loY },
+        { x: hiX, y: loY },
+        { x: hiX, y: hiY },
+        { x: loX, y: hiY },
+      ]
+      corners.forEach((p, cornerIndex) => {
+        if (blocked.some((rect) => strictlyInside(rect, p))) return
+        raw.push({
+          x: p.x,
+          y: p.y,
+          kind: KIND_NEIGHBOR_CORNER,
+          ownerId,
+          cornerIndex,
+        })
+      })
+    }
+  }
+
+  raw.sort(compareVertices)
+
+  const vertices: Vertex[] = []
+  const byCoord = new Map<string, number>()
+  for (const v of raw) {
+    const key = `${v.x},${v.y}`
+    if (byCoord.has(key)) continue
+    byCoord.set(key, vertices.length)
+    vertices.push(v)
+  }
+  const indexAt = (p: IPoint): number => byCoord.get(`${p.x},${p.y}`) ?? -1
+  return { vertices, indexAt }
+}
+
+/**
+ * Mutual visibility of two vertices: the segment between them must not enter the
+ * MIN-clearance-inflated interior of any hard obstacle. A segment incident to the
+ * sub-chord's own endpoint is exempt from obstacles whose inflated body contains
+ * that endpoint (the node it departs from / arrives at). Corner touches are allowed.
+ */
+const visible = (
+  vertices: readonly Vertex[],
+  i: number,
+  j: number,
+  endA: number,
+  endB: number,
+  blockRects: readonly IntRect[]
+): boolean => {
+  const p = vertices[i]
+  const q = vertices[j]
+  const exemptI = i === endA || i === endB
+  const exemptJ = j === endA || j === endB
+  for (const r of blockRects) {
+    if (exemptI && inclusiveContains(r, p)) continue
+    if (exemptJ && inclusiveContains(r, q)) continue
+    if (segmentIntersectsRectInterior(p, q, r)) return false
+  }
+  return true
+}
+
+/** Canonical visibility adjacency, shared by the full directed-edge search and its
+ * large-graph fallback. Complexity pressure may simplify the objective, never
+ * remove obstacle avoidance. */
+const buildAdjacency = (
+  vertices: readonly Vertex[],
+  startIndex: number,
+  goalIndex: number,
+  blockRects: readonly IntRect[]
+): number[][] => {
+  const adjacency: number[][] = []
+  for (let i = 0; i < vertices.length; i++) {
+    const list: number[] = []
+    for (let j = 0; j < vertices.length; j++) {
+      if (j === i) continue
+      if (visible(vertices, i, j, startIndex, goalIndex, blockRects))
+        list.push(j)
+    }
+    adjacency.push(list)
+  }
+  return adjacency
+}
+
+/**
+ * Linear-state fallback for an unusually large visibility graph. Exact turn
+ * sharpness needs a directed-edge state, but hard-obstacle safety does not. This
+ * search still prices a flat bend, edge conflicts, endpoint angles, occupied
+ * elbows, and the preferred obstacle ring.
+ */
+const routeSubPathByVertex = (
+  vertices: readonly Vertex[],
+  startIndex: number,
+  goalIndex: number,
+  blockRects: readonly IntRect[],
+  neighborRoutes: readonly (readonly IPoint[])[],
+  crowdingClearancePx: number,
+  siblingRoutes: readonly (readonly IPoint[])[],
+  occupiedBends: ReadonlySet<string>,
+  preferredCornerRing: number,
+  sourceNormal: IPoint | undefined,
+  targetNormal: IPoint | undefined
+): IPoint[] => {
+  const start = vertices[startIndex]
+  const goal = vertices[goalIndex]
+  if (startIndex === goalIndex) return [{ x: start.x, y: start.y }]
+  const adjacency = buildAdjacency(vertices, startIndex, goalIndex, blockRects)
+  const distance = new Float64Array(vertices.length).fill(
+    Number.POSITIVE_INFINITY
+  )
+  const previous = new Int32Array(vertices.length).fill(-1)
+  const closed = new Uint8Array(vertices.length)
+  const heap = new MinHeap()
+  let seq = 0
+  distance[startIndex] = 0
+  heap.push(isqrt(distSqInt(start, goal)), startIndex, seq++)
+
+  while (heap.size > 0) {
+    const current = heap.pop()
+    if (closed[current]) continue
+    closed[current] = 1
+    if (current === goalIndex) break
+    for (const next of adjacency[current]) {
+      if (closed[next]) continue
+      const from = vertices[current]
+      const to = vertices[next]
+      const dir = { x: to.x - from.x, y: to.y - from.y }
+      let step =
+        segLenInt(from, to) +
+        neighborCostPx(from, to, neighborRoutes, crowdingClearancePx) +
+        neighborCostPx(from, to, siblingRoutes, 0)
+      if (current === startIndex && sourceNormal)
+        step += angleCostPx(dir, sourceNormal, ENDPOINT_ANGLE_PENALTY_PX)
+      if (next === goalIndex && targetNormal)
+        step += angleCostPx(
+          { x: -dir.x, y: -dir.y },
+          targetNormal,
+          ENDPOINT_ANGLE_PENALTY_PX
+        )
+      if (current !== startIndex) {
+        step += BEND_PENALTY_PX
+        if (occupiedBends.has(`${from.x},${from.y}`))
+          step += SHARED_BEND_PENALTY_PX
+        if (
+          from.kind === KIND_CORNER &&
+          Math.floor(from.cornerIndex / 4) !== preferredCornerRing
+        )
+          step += RING_MISMATCH_PENALTY_PX
+      }
+      const candidate = distance[current] + step
+      if (candidate < distance[next]) {
+        distance[next] = candidate
+        previous[next] = current
+        heap.push(candidate + isqrt(distSqInt(to, goal)), next, seq++)
+      }
+    }
+  }
+
+  if (!Number.isFinite(distance[goalIndex])) {
+    // This indicates malformed geometry (for example, an endpoint inside a
+    // non-endpoint obstacle). Preserve the endpoint contract as a last resort.
+    return [
+      { x: start.x, y: start.y },
+      { x: goal.x, y: goal.y },
+    ]
+  }
+  const reversed: IPoint[] = []
+  for (let at = goalIndex; at >= 0; at = previous[at]) {
+    reversed.push({ x: vertices[at].x, y: vertices[at].y })
+    if (at === startIndex) break
+  }
+  reversed.reverse()
+  return reversed
+}
+
+/** Shortest obstacle-avoiding sub-path from vertex `startIndex` to `goalIndex` via
+ * A* on the visibility graph. Returns the ordered point list `[A, …, B]`; an
+ * unreachable directed state retries with the safety-preserving vertex search. */
+const routeSubPath = (
+  vertices: readonly Vertex[],
+  startIndex: number,
+  goalIndex: number,
+  blockRects: readonly IntRect[],
+  neighborRoutes: readonly (readonly IPoint[])[],
+  crowdingClearancePx: number,
+  siblingRoutes: readonly (readonly IPoint[])[],
+  occupiedBends: ReadonlySet<string>,
+  preferredCornerRing: number,
+  sourceNormal: IPoint | undefined,
+  targetNormal: IPoint | undefined
+): IPoint[] => {
+  const a: IPoint = { x: vertices[startIndex].x, y: vertices[startIndex].y }
+  if (startIndex === goalIndex) return [a]
+
+  const n = vertices.length
+  const goal = vertices[goalIndex]
+
+  // Adjacency built in ascending index order for a deterministic frontier.
+  const adjacency = buildAdjacency(vertices, startIndex, goalIndex, blockRects)
+
+  const heuristic = (i: number): number => isqrt(distSqInt(vertices[i], goal))
+
+  // The search runs over DIRECTED EDGES, not vertices: the cost of arriving at a
+  // vertex depends on the direction you arrived from (that is what a turn penalty
+  // means), and the departure/arrival angles are properties of the first and last
+  // segment. A state is `from * n + to`, so the bend at `to` is exactly priced when
+  // the state is expanded. Vertex-keyed Dijkstra cannot express this without
+  // under-counting turns.
+  const stateCount = n * n
+  const stateG = new Float64Array(stateCount).fill(Number.POSITIVE_INFINITY)
+  const statePrev = new Int32Array(stateCount).fill(-1)
+  const stateClosed = new Uint8Array(stateCount)
+  const heap = new MinHeap()
+  let seq = 0
+
+  const bendCostAt = (i: number): number => {
+    if (i === goalIndex) return 0
+    let cost = occupiedBends.has(`${vertices[i].x},${vertices[i].y}`)
+      ? SHARED_BEND_PENALTY_PX
+      : 0
+    if (
+      vertices[i].kind === KIND_CORNER &&
+      Math.floor(vertices[i].cornerIndex / 4) !== preferredCornerRing
+    )
+      cost += RING_MISMATCH_PENALTY_PX
+    return cost
+  }
+
+  const segmentCost = (i: number, j: number): number =>
+    segLenInt(vertices[i], vertices[j]) +
+    neighborCostPx(
+      vertices[i],
+      vertices[j],
+      neighborRoutes,
+      crowdingClearancePx
+    ) +
+    // Zero clearance: a sibling only costs when it is crossed or lain upon.
+    neighborCostPx(vertices[i], vertices[j], siblingRoutes, 0)
+
+  for (const v of adjacency[startIndex]) {
+    const dir = {
+      x: vertices[v].x - vertices[startIndex].x,
+      y: vertices[v].y - vertices[startIndex].y,
+    }
+    let cost = segmentCost(startIndex, v)
+    if (sourceNormal)
+      cost += angleCostPx(dir, sourceNormal, ENDPOINT_ANGLE_PENALTY_PX)
+    if (v === goalIndex && targetNormal)
+      cost += angleCostPx(
+        { x: -dir.x, y: -dir.y },
+        targetNormal,
+        ENDPOINT_ANGLE_PENALTY_PX
+      )
+    const state = startIndex * n + v
+    if (cost < stateG[state]) {
+      stateG[state] = cost
+      heap.push(cost + heuristic(v), state, seq++)
+    }
+  }
+
+  let goalState = -1
+  while (heap.size > 0) {
+    const state = heap.pop()
+    if (stateClosed[state]) continue
+    stateClosed[state] = 1
+    const u = (state / n) | 0
+    const v = state % n
+    if (v === goalIndex) {
+      goalState = state
+      break
+    }
+    for (const w of adjacency[v]) {
+      if (w === u) continue
+      const next = v * n + w
+      if (stateClosed[next]) continue
+      let cost =
+        stateG[state] +
+        segmentCost(v, w) +
+        turnCostPx(vertices[u], vertices[v], vertices[w]) +
+        bendCostAt(v)
+      if (w === goalIndex && targetNormal)
+        cost += angleCostPx(
+          {
+            x: vertices[v].x - vertices[w].x,
+            y: vertices[v].y - vertices[w].y,
+          },
+          targetNormal,
+          ENDPOINT_ANGLE_PENALTY_PX
+        )
+      if (cost < stateG[next]) {
+        stateG[next] = cost
+        statePrev[next] = state
+        heap.push(cost + heuristic(w), next, seq++)
+      }
+    }
+  }
+
+  if (goalState < 0)
+    return routeSubPathByVertex(
+      vertices,
+      startIndex,
+      goalIndex,
+      blockRects,
+      neighborRoutes,
+      crowdingClearancePx,
+      siblingRoutes,
+      occupiedBends,
+      preferredCornerRing,
+      sourceNormal,
+      targetNormal
+    )
+
+  const reversed: IPoint[] = []
+  for (let at = goalState; at !== -1; at = statePrev[at])
+    reversed.push({ x: vertices[at % n].x, y: vertices[at % n].y })
+  reversed.push(a)
+  reversed.reverse()
+  return reversed
+}
+
+/** Drop exact duplicates and interior points that are collinear with their
+ * neighbours (integer cross product). Endpoints are always kept. */
+const collapseCollinear = (points: readonly IPoint[]): IPoint[] => {
+  const dedup: IPoint[] = []
+  for (const p of points) {
+    const last = dedup[dedup.length - 1]
+    if (last && samePoint(last, p)) continue
+    dedup.push(p)
+  }
+  if (dedup.length <= 2) return dedup
+  const out: IPoint[] = [dedup[0]]
+  for (let i = 1; i < dedup.length - 1; i++) {
+    const a = dedup[i - 1]
+    const p = dedup[i]
+    const c = dedup[i + 1]
+    if (orient(a, c, p) === 0) continue
+    out.push(p)
+  }
+  out.push(dedup[dedup.length - 1])
+  return out
+}
+
+/** The complete objective for a finished route, in integer px: travel, every bend,
+ * both endpoint departure angles, and the shared neighbour-conflict cost. This is
+ * the same sum the search minimises, so simplification can be accepted only when it
+ * genuinely improves the drawing. */
+const totalRouteCostPx = (
+  route: readonly IPoint[],
+  neighborRoutes: readonly (readonly IPoint[])[],
+  crowdingClearancePx: number,
+  siblingRoutes: readonly (readonly IPoint[])[],
+  sourceNormal: IPoint | undefined,
+  targetNormal: IPoint | undefined
+): number => {
+  let cost = 0
+  for (let i = 1; i < route.length; i++) {
+    cost += segLenInt(route[i - 1], route[i])
+    cost += neighborCostPx(
+      route[i - 1],
+      route[i],
+      neighborRoutes,
+      crowdingClearancePx
+    )
+    cost += neighborCostPx(route[i - 1], route[i], siblingRoutes, 0)
+    if (i >= 2) cost += turnCostPx(route[i - 2], route[i - 1], route[i])
+  }
+  if (sourceNormal && route.length >= 2)
+    cost += angleCostPx(
+      { x: route[1].x - route[0].x, y: route[1].y - route[0].y },
+      sourceNormal,
+      ENDPOINT_ANGLE_PENALTY_PX
+    )
+  if (targetNormal && route.length >= 2) {
+    const last = route.length - 1
+    cost += angleCostPx(
+      {
+        x: route[last - 1].x - route[last].x,
+        y: route[last - 1].y - route[last].y,
+      },
+      targetNormal,
+      ENDPOINT_ANGLE_PENALTY_PX
+    )
+  }
+  return cost
+}
+
+/**
+ * String-pulling: drop any bend the route does not actually need. A visibility graph
+ * can only turn at obstacle corners, so it often rounds a corner it could have cut —
+ * leaving a small kink that reads as a mistake. Each interior point is removed only
+ * when the shortcut still clears every obstacle AND strictly lowers the complete
+ * objective, so this can never trade clearance or a good exit angle for fewer bends.
+ * Deterministic: a single left-to-right sweep, repeated until nothing changes.
+ */
+const simplifyRoute = (
+  route: readonly IPoint[],
+  blockRects: readonly IntRect[],
+  neighborRoutes: readonly (readonly IPoint[])[],
+  crowdingClearancePx: number,
+  siblingRoutes: readonly (readonly IPoint[])[],
+  sourceNormal: IPoint | undefined,
+  targetNormal: IPoint | undefined,
+  protectedPoints: ReadonlySet<string> = new Set()
+): IPoint[] => {
+  let best = [...route]
+  let bestCost = totalRouteCostPx(
+    best,
+    neighborRoutes,
+    crowdingClearancePx,
+    siblingRoutes,
+    sourceNormal,
+    targetNormal
+  )
+  for (let pass = 0; pass < 4; pass++) {
+    let improved = false
+    for (let i = 1; i < best.length - 1; i++) {
+      if (protectedPoints.has(`${best[i].x},${best[i].y}`)) continue
+      const candidate = [...best.slice(0, i), ...best.slice(i + 1)]
+      const a = candidate[i - 1]
+      const b = candidate[i]
+      const isEndA = i - 1 === 0
+      const isEndB = i === candidate.length - 1
+      const blocked = blockRects.some((r) => {
+        if (isEndA && inclusiveContains(r, a)) return false
+        if (isEndB && inclusiveContains(r, b)) return false
+        return segmentIntersectsRectInterior(a, b, r)
+      })
+      if (blocked) continue
+      const cost = totalRouteCostPx(
+        candidate,
+        neighborRoutes,
+        crowdingClearancePx,
+        siblingRoutes,
+        sourceNormal,
+        targetNormal
+      )
+      if (cost < bestCost) {
+        best = candidate
+        bestCost = cost
+        improved = true
+        i--
+      }
+    }
+    if (!improved) break
+  }
+  return best
+}
+
+/**
+ * Route a deterministic straight (obstacle-avoiding) polyline from source to target
+ * through every checkpoint in order. Returns the full route INCLUDING the endpoints:
+ * `[source, …bends, target]`. A direct polyline is returned unchanged only when it
+ * clears hard obstacles and has no structural edge conflict.
+ */
+export function routeStraightPolyline(req: StraightRouteRequest): IPoint[] {
+  const {
+    source,
+    target,
+    checkpoints,
+    obstacles,
+    neighborRoutes,
+    clearancePx,
+    siblingRoutes,
+    preferredCornerRing,
+    sourceNormal,
+    targetNormal,
+  } = req
+  const hardObstacles = obstacles.filter((o) => !o.soft)
+  const anchors: IPoint[] = [source, ...checkpoints, target]
+
+  // 1. Gate: every sub-chord clears hard obstacles and has no structural edge
+  //    conflict. Mere crowding does not manufacture a bend in an otherwise clean
+  //    chord; crossings and overlaps open the graph so it can avoid them.
+  const straightClears = anchors.every((a, i) => {
+    if (i === 0) return true
+    return chordClearsObstacles(
+      anchors[i - 1],
+      a,
+      hardObstacles,
+      MIN_CLEARANCE_PX
+    )
+  })
+  const direct = collapseCollinear(anchors)
+  const conflictsStructurally = (
+    routes: readonly (readonly IPoint[])[]
+  ): boolean => {
+    const conflict = polylineConflictCost(direct, routes, 0)
+    return conflict.crossings > 0 || conflict.overlapPx > 0
+  }
+  const allSiblingRoutes = siblingRoutes ?? []
+  // Only unrelated neighbors contribute detour vertices. Siblings arrive through
+  // the greedy route walk one at a time; materialising vertices from only the
+  // already-routed half makes a symmetric fan resolve asymmetrically. Their
+  // crossings/overlaps are still priced by the search, while coordinated ports
+  // and obstacle rings provide the order-independent sibling separation.
+  const conflictingRoutes = neighborRoutes.filter((route) =>
+    conflictsStructurally([route])
+  )
+  if (straightClears && conflictingRoutes.length === 0) return direct
+
+  // 2. Visibility graph over endpoints, checkpoints and inflated hard corners.
+  //    Corners are inflated by the SAME margin the visibility test blocks at. A
+  //    wider corner pad silently welds neighbouring obstacles together — their
+  //    padded corners land inside each other — which closes legitimate gaps between
+  //    two nodes and forces a long detour around the whole group.
+  const { vertices, indexAt } = buildVertices(
+    source,
+    target,
+    checkpoints,
+    hardObstacles,
+    [MIN_CLEARANCE_PX, clearancePx],
+    conflictingRoutes
+  )
+  const blockRects = hardObstacles.map((o) =>
+    inflate(rectOf(o), MIN_CLEARANCE_PX)
+  )
+  // Elbows other routes already turn at — see SHARED_BEND_PENALTY_PX.
+  const occupiedBends = new Set<string>()
+  for (const route of [...neighborRoutes, ...(siblingRoutes ?? [])])
+    for (const point of route.slice(1, -1))
+      occupiedBends.add(`${point.x},${point.y}`)
+
+  // 3. Route each checkpoint sub-chord independently and concatenate. Only the
+  //    first sub-chord departs the source node and only the last meets the target,
+  //    so the endpoint-angle terms apply to those alone.
+  const combined: IPoint[] = []
+  for (let k = 1; k < anchors.length; k++) {
+    const startIndex = indexAt(anchors[k - 1])
+    const goalIndex = indexAt(anchors[k])
+    const sub =
+      startIndex < 0 || goalIndex < 0
+        ? [anchors[k - 1], anchors[k]]
+        : vertices.length > MAX_DIRECTED_SEARCH_VERTICES
+          ? routeSubPathByVertex(
+              vertices,
+              startIndex,
+              goalIndex,
+              blockRects,
+              neighborRoutes,
+              EDGE_CROWDING_CLEARANCE_PX,
+              allSiblingRoutes,
+              occupiedBends,
+              preferredCornerRing ?? 0,
+              k === 1 ? sourceNormal : undefined,
+              k === anchors.length - 1 ? targetNormal : undefined
+            )
+          : routeSubPath(
+              vertices,
+              startIndex,
+              goalIndex,
+              blockRects,
+              neighborRoutes,
+              EDGE_CROWDING_CLEARANCE_PX,
+              allSiblingRoutes,
+              occupiedBends,
+              preferredCornerRing ?? 0,
+              k === 1 ? sourceNormal : undefined,
+              k === anchors.length - 1 ? targetNormal : undefined
+            )
+    if (combined.length === 0) combined.push(...sub)
+    else combined.push(...sub.slice(1))
+  }
+
+  // 4. Collapse collinear points, then string-pull away any bend the route does not
+  //    need using the complete search objective.
+  return collapseCollinear(
+    simplifyRoute(
+      collapseCollinear(combined),
+      blockRects,
+      neighborRoutes,
+      EDGE_CROWDING_CLEARANCE_PX,
+      allSiblingRoutes,
+      sourceNormal,
+      targetNormal,
+      new Set(checkpoints.map((point) => `${point.x},${point.y}`))
+    )
+  )
+}

--- a/library/lib/utils/tidyTree/applyTidyLayout.ts
+++ b/library/lib/utils/tidyTree/applyTidyLayout.ts
@@ -1,0 +1,123 @@
+import type { Node, Edge, XYPosition } from "@xyflow/react"
+import { getPositionOnCanvas } from "@/utils/nodeUtils"
+import { buildSyntaxTreeForest, type Forest } from "./buildForest"
+import {
+  layoutTidyTree,
+  type TidyNodeInput,
+  type TidyOptions,
+} from "./tidyTree"
+
+export type { TidyOptions } from "./tidyTree"
+export type { Forest } from "./buildForest"
+
+/** Fallback footprint for a syntax-tree node with no measured or declared size. */
+const FALLBACK_WIDTH = 90
+const FALLBACK_HEIGHT = 40
+
+/** Sensible defaults; `gridSnap` mirrors `CANVAS.SNAP_TO_GRID_PX`. */
+export const DEFAULT_TIDY_OPTIONS: TidyOptions = {
+  siblingGap: 30,
+  subtreeGap: 20,
+  levelGap: 60,
+  gridSnap: 5,
+}
+
+const measuredWidth = (node: Node): number =>
+  node.measured?.width ?? node.width ?? FALLBACK_WIDTH
+
+const measuredHeight = (node: Node): number =>
+  node.measured?.height ?? node.height ?? FALLBACK_HEIGHT
+
+/**
+ * Tidy the syntax-tree forest inside `nodes`, leaving every other node untouched.
+ *
+ * Returns a NEW nodes array of the same length and id set. Only nodes the layout
+ * actually moves are replaced with a fresh object (new `position`); every other
+ * node — non-syntax nodes, skipped malformed nodes, and already-tidy nodes — is
+ * returned BY REFERENCE. Each clean component is translated so its root keeps its
+ * current on-canvas position, so a tidy pass never makes the tree jump on screen
+ * and re-running it on an already-tidy tree is idempotent.
+ */
+export function computeTidyLayout(
+  nodes: Node[],
+  edges: Edge[],
+  opts: Partial<TidyOptions> = {}
+): Node[] {
+  const options: TidyOptions = { ...DEFAULT_TIDY_OPTIONS, ...opts }
+  const forest: Forest = buildSyntaxTreeForest(nodes, edges)
+  if (forest.laidOut.size === 0) return nodes
+
+  const nodeById = new Map<string, Node>()
+  for (const node of nodes) nodeById.set(node.id, node)
+
+  // Feed real per-node footprints into the layout so long labels push siblings
+  // apart. Child order comes straight from the forest (already deterministic).
+  const inputById = new Map<string, TidyNodeInput>()
+  for (const id of forest.laidOut) {
+    const node = nodeById.get(id)
+    if (!node) continue
+    inputById.set(id, {
+      id,
+      width: measuredWidth(node),
+      height: measuredHeight(node),
+      childIds: forest.childIds.get(id) ?? [],
+    })
+  }
+
+  const layout = layoutTidyTree(forest.roots, inputById, options)
+
+  // Absolute on-canvas position each laid-out node should end up at: translate
+  // every component so its root stays exactly where it is now.
+  const targetCanvas = new Map<string, XYPosition>()
+  for (const rootId of forest.roots) {
+    const rootNode = nodeById.get(rootId)
+    const rootLayout = layout.get(rootId)
+    if (!rootNode || !rootLayout) continue
+    const rootCanvas = getPositionOnCanvas(rootNode, nodes)
+    const deltaX = rootCanvas.x - rootLayout.x
+    const deltaY = rootCanvas.y - rootLayout.y
+
+    // Walk the component from its root so each node inherits the same delta.
+    const stack = [rootId]
+    const visited = new Set<string>()
+    while (stack.length) {
+      const id = stack.pop()!
+      if (visited.has(id)) continue
+      visited.add(id)
+      const nodeLayout = layout.get(id)
+      if (nodeLayout) {
+        targetCanvas.set(id, {
+          x: nodeLayout.x + deltaX,
+          y: nodeLayout.y + deltaY,
+        })
+      }
+      for (const child of forest.childIds.get(id) ?? []) stack.push(child)
+    }
+  }
+
+  return nodes.map((node) => {
+    const canvasTarget = targetCanvas.get(node.id)
+    if (!canvasTarget) return node
+
+    // Convert the absolute canvas target back into a position relative to the
+    // node's container (parentId), mirroring usePalettePlacement's nesting math.
+    // The container is never a laid-out syntax node, so its canvas position is
+    // read from the untouched input graph.
+    let position: XYPosition = canvasTarget
+    if (node.parentId) {
+      const parent = nodeById.get(node.parentId)
+      if (parent) {
+        const parentCanvas = getPositionOnCanvas(parent, nodes)
+        position = {
+          x: canvasTarget.x - parentCanvas.x,
+          y: canvasTarget.y - parentCanvas.y,
+        }
+      }
+    }
+
+    if (position.x === node.position.x && position.y === node.position.y) {
+      return node
+    }
+    return { ...node, position }
+  })
+}

--- a/library/lib/utils/tidyTree/buildForest.ts
+++ b/library/lib/utils/tidyTree/buildForest.ts
@@ -1,0 +1,244 @@
+import type { Node, Edge } from "@xyflow/react"
+import { getPositionOnCanvas } from "@/utils/nodeUtils"
+
+/**
+ * Reconstruct the clean syntax-tree forest from a freeform React Flow graph.
+ *
+ * The editor lets users draw whatever they like, so the input can be malformed:
+ * a node may have several parents, edges may form cycles, and links may cross
+ * container boundaries. This module contains that mess — it never corrupts the
+ * graph. Anything it cannot lay out as a clean rooted tree is reported in
+ * `skipped` and MUST keep its exact current position; everything else lands in
+ * `laidOut` with an ordered child list ready for `layoutTidyTree`.
+ */
+
+/** Node types that participate in a syntax tree (see `library/lib/constants.ts`). */
+const SYNTAX_TREE_NODE_TYPES: ReadonlySet<string> = new Set([
+  "syntaxTreeNonterminal",
+  "syntaxTreeTerminal",
+])
+
+/** Edge type connecting syntax-tree nodes (see `library/lib/edges/types.tsx`). */
+const SYNTAX_TREE_EDGE_TYPE = "SyntaxTreeLink"
+
+export interface Forest {
+  /** Root ids (indegree-0, clean) of each independently laid-out component. */
+  roots: string[]
+  /** Ordered clean children per laid-out node (parent → child ids). */
+  childIds: Map<string, string[]>
+  /** Nodes the tidy layout will place. */
+  laidOut: Set<string>
+  /** Malformed nodes that must keep their exact current position. */
+  skipped: Set<string>
+}
+
+const isSyntaxTreeNode = (node: Node): boolean =>
+  !!node.type && SYNTAX_TREE_NODE_TYPES.has(node.type)
+
+/** Container-nesting depth: how many `parentId` hops reach a top-level node. */
+const containerDepth = (node: Node, nodeById: Map<string, Node>): number => {
+  let depth = 0
+  let current: Node | undefined = node
+  const guard = new Set<string>()
+  while (current?.parentId && !guard.has(current.id)) {
+    guard.add(current.id)
+    depth++
+    current = nodeById.get(current.parentId)
+  }
+  return depth
+}
+
+export function buildSyntaxTreeForest(nodes: Node[], edges: Edge[]): Forest {
+  const nodeById = new Map<string, Node>()
+  for (const node of nodes) nodeById.set(node.id, node)
+
+  const syntaxNodes = nodes.filter(isSyntaxTreeNode)
+  const syntaxIds = new Set(syntaxNodes.map((node) => node.id))
+
+  // Absolute canvas x per syntax node — the child ordering key, and the
+  // tie-break within cross-container links.
+  const canvasX = new Map<string, number>()
+  for (const node of syntaxNodes) {
+    canvasX.set(node.id, getPositionOnCanvas(node, nodes).x)
+  }
+
+  const skipped = new Set<string>()
+  const childIds = new Map<string, string[]>()
+  const indegree = new Map<string, number>()
+  for (const id of syntaxIds) {
+    childIds.set(id, [])
+    indegree.set(id, 0)
+  }
+
+  // Pass 1: keep only syntax-tree links between two syntax-tree nodes. A link
+  // that crosses a container boundary is dropped and its deeper endpoint marked
+  // skipped, so container scopes never merge into one tree.
+  for (const edge of edges) {
+    if (edge.type !== SYNTAX_TREE_EDGE_TYPE) continue
+    const parentId = edge.source
+    const childId = edge.target
+    if (!syntaxIds.has(parentId) || !syntaxIds.has(childId)) continue
+    if (parentId === childId) {
+      // A self-link is a degenerate cycle — the node cannot be a clean tree.
+      skipped.add(parentId)
+      continue
+    }
+
+    const parentNode = nodeById.get(parentId)!
+    const childNode = nodeById.get(childId)!
+    if (
+      (parentNode.parentId ?? undefined) !== (childNode.parentId ?? undefined)
+    ) {
+      const deeperIsChild =
+        containerDepth(childNode, nodeById) >=
+        containerDepth(parentNode, nodeById)
+      skipped.add(deeperIsChild ? childId : parentId)
+      continue
+    }
+
+    childIds.get(parentId)!.push(childId)
+    indegree.set(childId, (indegree.get(childId) ?? 0) + 1)
+  }
+
+  // Order every parent's children by current absolute x, then id — the fixed,
+  // deterministic order the tidy layout consumes.
+  for (const [parentId, children] of childIds) {
+    children.sort((a, b) => {
+      const dx = (canvasX.get(a) ?? 0) - (canvasX.get(b) ?? 0)
+      return dx !== 0 ? dx : a < b ? -1 : a > b ? 1 : 0
+    })
+    childIds.set(parentId, children)
+  }
+
+  // Pass 2: any node with two or more parents cannot sit in a single tree.
+  // Mark it and its whole descendant subtree skipped.
+  const skipSubtree = (rootId: string): void => {
+    const stack = [rootId]
+    while (stack.length) {
+      const id = stack.pop()!
+      if (skipped.has(id)) continue
+      skipped.add(id)
+      for (const child of childIds.get(id) ?? []) stack.push(child)
+    }
+  }
+  for (const id of syntaxIds) {
+    if ((indegree.get(id) ?? 0) >= 2) skipSubtree(id)
+  }
+
+  // Pass 3: skip every node on a directed cycle (Tarjan strongly-connected
+  // components of size > 1). Self-links were already handled above.
+  for (const id of tarjanCyclicNodes(syntaxIds, childIds)) skipped.add(id)
+
+  // Roots are the clean indegree-0 nodes. Build each component top-down, never
+  // descending into a skipped node and never visiting a node twice.
+  const laidOut = new Set<string>()
+  const roots: string[] = []
+  const cleanChildIds = new Map<string, string[]>()
+
+  const collect = (rootId: string): void => {
+    const stack = [rootId]
+    while (stack.length) {
+      const id = stack.pop()!
+      if (laidOut.has(id) || skipped.has(id)) continue
+      laidOut.add(id)
+      const children = (childIds.get(id) ?? []).filter(
+        (child) => !skipped.has(child)
+      )
+      cleanChildIds.set(id, children)
+      for (const child of children) stack.push(child)
+    }
+  }
+
+  const rootCandidates = [...syntaxIds]
+    .filter((id) => !skipped.has(id) && (indegree.get(id) ?? 0) === 0)
+    .sort((a, b) => {
+      const dx = (canvasX.get(a) ?? 0) - (canvasX.get(b) ?? 0)
+      return dx !== 0 ? dx : a < b ? -1 : a > b ? 1 : 0
+    })
+  for (const id of rootCandidates) {
+    if (laidOut.has(id) || skipped.has(id)) continue
+    roots.push(id)
+    collect(id)
+  }
+
+  // Any clean child list must be pruned to the nodes that survived collection.
+  for (const [id, children] of cleanChildIds) {
+    cleanChildIds.set(
+      id,
+      children.filter((child) => laidOut.has(child))
+    )
+  }
+
+  return { roots, childIds: cleanChildIds, laidOut, skipped }
+}
+
+/**
+ * Ids that belong to a strongly-connected component of size > 1 in the
+ * `parent → child` graph — i.e. every node caught on a directed cycle.
+ * Iterative Tarjan so deep chains cannot overflow the stack.
+ */
+function tarjanCyclicNodes(
+  ids: ReadonlySet<string>,
+  childIds: ReadonlyMap<string, string[]>
+): Set<string> {
+  const index = new Map<string, number>()
+  const lowlink = new Map<string, number>()
+  const onStack = new Set<string>()
+  const stack: string[] = []
+  const cyclic = new Set<string>()
+  let counter = 0
+
+  type Frame = { id: string; childIndex: number }
+
+  for (const start of ids) {
+    if (index.has(start)) continue
+    const frames: Frame[] = [{ id: start, childIndex: 0 }]
+    index.set(start, counter)
+    lowlink.set(start, counter)
+    counter++
+    stack.push(start)
+    onStack.add(start)
+
+    while (frames.length) {
+      const frame = frames[frames.length - 1]
+      const children = childIds.get(frame.id) ?? []
+      if (frame.childIndex < children.length) {
+        const child = children[frame.childIndex]
+        frame.childIndex++
+        if (!index.has(child)) {
+          index.set(child, counter)
+          lowlink.set(child, counter)
+          counter++
+          stack.push(child)
+          onStack.add(child)
+          frames.push({ id: child, childIndex: 0 })
+        } else if (onStack.has(child)) {
+          lowlink.set(
+            frame.id,
+            Math.min(lowlink.get(frame.id)!, index.get(child)!)
+          )
+        }
+      } else {
+        if (lowlink.get(frame.id) === index.get(frame.id)) {
+          const component: string[] = []
+          let popped: string
+          do {
+            popped = stack.pop()!
+            onStack.delete(popped)
+            component.push(popped)
+          } while (popped !== frame.id)
+          if (component.length > 1) for (const id of component) cyclic.add(id)
+        }
+        frames.pop()
+        if (frames.length) {
+          const parent = frames[frames.length - 1]
+          lowlink.set(
+            parent.id,
+            Math.min(lowlink.get(parent.id)!, lowlink.get(frame.id)!)
+          )
+        }
+      }
+    }
+  }
+  return cyclic
+}

--- a/library/lib/utils/tidyTree/index.ts
+++ b/library/lib/utils/tidyTree/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Self-contained syntax-tree tidy-layout module.
+ *
+ * Public entry point is `computeTidyLayout`; the tidy-tree core and the forest
+ * reconstruction are exported for direct testing and advanced callers.
+ */
+export {
+  computeTidyLayout,
+  DEFAULT_TIDY_OPTIONS,
+  type TidyOptions,
+  type Forest,
+} from "./applyTidyLayout"
+export {
+  layoutTidyTree,
+  type TidyNodeInput,
+  type TidyPosition,
+} from "./tidyTree"
+export { buildSyntaxTreeForest } from "./buildForest"

--- a/library/lib/utils/tidyTree/tidyTree.ts
+++ b/library/lib/utils/tidyTree/tidyTree.ts
@@ -1,0 +1,315 @@
+/**
+ * Buchheim–Jünger–Leipert linear-time tidy tree.
+ *
+ * A hand-written implementation of the layout described in:
+ *
+ *   Christoph Buchheim, Michael Jünger, Sebastian Leipert,
+ *   "Improving Walker's Algorithm to Run in Linear Time" (Graph Drawing 2002),
+ *
+ * which itself improves
+ *
+ *   John Q. Walker II, "A Node-Positioning Algorithm for General Trees" (1990),
+ *
+ * the n-ary generalisation of
+ *
+ *   Edward M. Reingold, John S. Tilford,
+ *   "Tidier Drawings of Trees" (IEEE TSE 1981).
+ *
+ * The two-pass structure (`firstWalk` computing preliminary x offsets and per-node
+ * modifiers, `secondWalk` summing modifiers into absolute centres) with contour
+ * threading (`thread`, `leftMost`/`rightMost` via `nextLeft`/`nextRight`), the
+ * `ancestor` shortcut and the `shift`/`change` amortisation is exactly the BJL
+ * scheme; `apportion` runs each contour pair once, giving overall linear time.
+ *
+ * This variant is n-ary and supports **variable node widths**: the minimum
+ * horizontal separation between two adjacent subtrees at the same level is
+ *
+ *     half(width[left]) + siblingGap + half(width[right])   (+ subtreeGap
+ *                                                            for distinct subtrees)
+ *
+ * fed straight into the apportion distance, so a long label pushes its siblings
+ * apart instead of overlapping them. Vertical placement gives each depth a single
+ * y equal to the cumulative maximum row height of the shallower levels plus
+ * `levelGap`. The final absolute top-left coordinates are grid-snapped and the
+ * whole layout is normalised so its minimum x and y are 0. The result is fully
+ * deterministic: child order is fixed by the caller.
+ */
+
+export interface TidyOptions {
+  /** Min horizontal clearance between adjacent sibling subtrees (px). */
+  siblingGap: number
+  /** Extra gap inserted between distinct sibling subtrees (px). */
+  subtreeGap: number
+  /** Vertical gap between depth levels (px). */
+  levelGap: number
+  /** Grid the final absolute coordinates snap to (px). */
+  gridSnap: number
+}
+
+export interface TidyNodeInput {
+  id: string
+  width: number
+  height: number
+  childIds: string[]
+}
+
+export interface TidyPosition {
+  x: number
+  y: number
+}
+
+/**
+ * A mutable working node for the two-pass walk. All coordinate fields live in a
+ * centre-x space until `secondWalk`; `x` then holds the absolute centre.
+ */
+interface WorkNode {
+  id: string
+  width: number
+  height: number
+  depth: number
+  parent: WorkNode | null
+  children: WorkNode[]
+  /** 1-based index among siblings — divisor in the shift smoothing. */
+  number: number
+  ancestor: WorkNode
+  thread: WorkNode | null
+  prelim: number
+  mod: number
+  change: number
+  shift: number
+  /** Absolute centre-x, filled by `secondWalk`. */
+  x: number
+}
+
+const half = (value: number): number => value / 2
+
+const snapToGrid = (value: number, grid: number): number =>
+  grid > 0 ? Math.round(value / grid) * grid : Math.round(value)
+
+/**
+ * Layout a forest of tidy trees. `roots` gives the root id of each independent
+ * component; `nodesById` supplies width/height and the (already ordered) child
+ * ids for every node reachable from those roots. Returns absolute top-left
+ * positions normalised so the whole forest's minimum x and y are 0.
+ *
+ * Anchoring a component to its current on-canvas position is the caller's job —
+ * here every component is laid out in one shared, normalised coordinate space.
+ */
+export function layoutTidyTree(
+  roots: string[],
+  nodesById: Map<string, TidyNodeInput>,
+  opts: TidyOptions
+): Map<string, TidyPosition> {
+  const built: WorkNode[] = []
+  const seen = new Set<string>()
+
+  const build = (
+    id: string,
+    parent: WorkNode | null,
+    depth: number,
+    number: number
+  ): WorkNode | null => {
+    const input = nodesById.get(id)
+    if (!input) return null
+    // A node can be reached only once in a clean forest; the guard keeps a
+    // malformed input from looping and keeps the walk deterministic.
+    if (seen.has(id)) return null
+    seen.add(id)
+
+    const node: WorkNode = {
+      id,
+      width: input.width,
+      height: input.height,
+      depth,
+      parent,
+      children: [],
+      number,
+      ancestor: null as unknown as WorkNode,
+      thread: null,
+      prelim: 0,
+      mod: 0,
+      change: 0,
+      shift: 0,
+      x: 0,
+    }
+    node.ancestor = node
+    built.push(node)
+
+    let childNumber = 1
+    for (const childId of input.childIds) {
+      const child = build(childId, node, depth + 1, childNumber)
+      if (child) {
+        node.children.push(child)
+        childNumber++
+      }
+    }
+    return node
+  }
+
+  const rootNodes: WorkNode[] = []
+  for (const rootId of roots) {
+    const root = build(rootId, null, 0, 1)
+    if (root) rootNodes.push(root)
+  }
+
+  // Vertical: one y per depth, from the cumulative max row height of shallower
+  // levels. Computed across the whole forest so equal depths stay aligned.
+  const rowHeight: number[] = []
+  for (const node of built) {
+    rowHeight[node.depth] = Math.max(rowHeight[node.depth] ?? 0, node.height)
+  }
+  const depthTop: number[] = []
+  let cumulative = 0
+  for (let depth = 0; depth < rowHeight.length; depth++) {
+    depthTop[depth] = cumulative
+    cumulative += (rowHeight[depth] ?? 0) + opts.levelGap
+  }
+
+  const separation = (left: WorkNode, right: WorkNode): number => {
+    const base = half(left.width) + half(right.width) + opts.siblingGap
+    return left.parent === right.parent ? base : base + opts.subtreeGap
+  }
+
+  const nextLeft = (node: WorkNode): WorkNode | null =>
+    node.children.length ? node.children[0] : node.thread
+
+  const nextRight = (node: WorkNode): WorkNode | null =>
+    node.children.length ? node.children[node.children.length - 1] : node.thread
+
+  const nextAncestor = (
+    vim: WorkNode,
+    v: WorkNode,
+    defaultAncestor: WorkNode
+  ): WorkNode =>
+    vim.ancestor.parent === v.parent ? vim.ancestor : defaultAncestor
+
+  const moveSubtree = (wm: WorkNode, wp: WorkNode, shift: number): void => {
+    const subtrees = wp.number - wm.number
+    const change = shift / subtrees
+    wp.change -= change
+    wp.shift += shift
+    wm.change += change
+    wp.prelim += shift
+    wp.mod += shift
+  }
+
+  const executeShifts = (v: WorkNode): void => {
+    let shift = 0
+    let change = 0
+    for (let i = v.children.length - 1; i >= 0; i--) {
+      const w = v.children[i]
+      w.prelim += shift
+      w.mod += shift
+      change += w.change
+      shift += w.shift + change
+    }
+  }
+
+  const previousSibling = (v: WorkNode): WorkNode | null => {
+    if (!v.parent) return null
+    const index = v.number - 2 // number is 1-based; left sibling is number-1
+    return index >= 0 ? v.parent.children[index] : null
+  }
+
+  const apportion = (v: WorkNode, defaultAncestor: WorkNode): WorkNode => {
+    const w = previousSibling(v)
+    if (!w) return defaultAncestor
+
+    let vip: WorkNode | null = v
+    let vop: WorkNode | null = v
+    let vim: WorkNode | null = w
+    let vom: WorkNode | null = v.parent!.children[0]
+    let sip = vip.mod
+    let sop = vop.mod
+    let sim = vim.mod
+    let som = vom.mod
+
+    vim = nextRight(vim)
+    vip = nextLeft(vip)
+    while (vim && vip) {
+      vom = nextLeft(vom!)
+      vop = nextRight(vop!)
+      vop!.ancestor = v
+      const shift = vim.prelim + sim - (vip.prelim + sip) + separation(vim, vip)
+      if (shift > 0) {
+        moveSubtree(nextAncestor(vim, v, defaultAncestor), v, shift)
+        sip += shift
+        sop += shift
+      }
+      sim += vim.mod
+      sip += vip.mod
+      som += vom!.mod
+      sop += vop!.mod
+
+      vim = nextRight(vim)
+      vip = nextLeft(vip)
+    }
+
+    if (vim && !nextRight(vop!)) {
+      vop!.thread = vim
+      vop!.mod += sim - sop
+    }
+    if (vip && !nextLeft(vom!)) {
+      vom!.thread = vip
+      vom!.mod += sip - som
+      defaultAncestor = v
+    }
+    return defaultAncestor
+  }
+
+  const firstWalk = (v: WorkNode): void => {
+    const w = previousSibling(v)
+    if (v.children.length === 0) {
+      v.prelim = w ? w.prelim + separation(v, w) : 0
+      return
+    }
+    let defaultAncestor = v.children[0]
+    for (const child of v.children) {
+      firstWalk(child)
+      defaultAncestor = apportion(child, defaultAncestor)
+    }
+    executeShifts(v)
+    const midpoint = half(
+      v.children[0].prelim + v.children[v.children.length - 1].prelim
+    )
+    if (w) {
+      v.prelim = w.prelim + separation(v, w)
+      v.mod = v.prelim - midpoint
+    } else {
+      v.prelim = midpoint
+    }
+  }
+
+  const secondWalk = (v: WorkNode, modSum: number): void => {
+    v.x = v.prelim + modSum
+    for (const child of v.children) secondWalk(child, modSum + v.mod)
+  }
+
+  for (const root of rootNodes) {
+    firstWalk(root)
+    secondWalk(root, 0)
+  }
+
+  // Convert centre-x + depth into top-left coordinates, then normalise the whole
+  // forest so its minimum x and y are 0 before grid-snapping. Snapping a common
+  // translation of every node preserves the separation invariant exactly when
+  // widths and gaps are grid multiples.
+  let minX = Number.POSITIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  for (const node of built) {
+    const left = node.x - half(node.width)
+    if (left < minX) minX = left
+    if (depthTop[node.depth] < minY) minY = depthTop[node.depth]
+  }
+  if (!Number.isFinite(minX)) minX = 0
+  if (!Number.isFinite(minY)) minY = 0
+
+  const positions = new Map<string, TidyPosition>()
+  for (const node of built) {
+    positions.set(node.id, {
+      x: snapToGrid(node.x - half(node.width) - minX, opts.gridSnap),
+      y: snapToGrid(depthTop[node.depth] - minY, opts.gridSnap),
+    })
+  }
+  return positions
+}

--- a/library/package.json
+++ b/library/package.json
@@ -80,7 +80,7 @@
     {
       "name": "main entry (published JS, deps externalized)",
       "path": "dist/index.js",
-      "limit": "121 kB",
+      "limit": "126 kB",
       "disablePlugins": [
         "@size-limit/webpack",
         "@size-limit/time"
@@ -89,7 +89,7 @@
     {
       "name": "edge-routing Worker (loaded for large diagrams)",
       "path": "dist/assets/edgeGeometry.worker-*.js",
-      "limit": "40 kB",
+      "limit": "44 kB",
       "disablePlugins": [
         "@size-limit/webpack",
         "@size-limit/time"

--- a/library/tests/unit/ZoomControls.test.ts
+++ b/library/tests/unit/ZoomControls.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest"
+import { runTidyLayoutAndFit } from "@/chrome/builtins/ZoomControls"
+
+describe("tidy-layout toolbar action", () => {
+  it("fits only after the controlled layout has crossed two paint boundaries", () => {
+    const callbacks: FrameRequestCallback[] = []
+    const schedule = vi.fn((callback: FrameRequestCallback) => {
+      callbacks.push(callback)
+      return callbacks.length
+    })
+    const layout = vi.fn()
+    const fit = vi.fn()
+
+    runTidyLayoutAndFit(layout, fit, schedule)
+    expect(layout).toHaveBeenCalledOnce()
+    expect(fit).not.toHaveBeenCalled()
+    expect(callbacks).toHaveLength(1)
+
+    callbacks.shift()!(0)
+    expect(fit).not.toHaveBeenCalled()
+    expect(callbacks).toHaveLength(1)
+
+    callbacks.shift()!(16)
+    expect(fit).toHaveBeenCalledOnce()
+  })
+})

--- a/library/tests/unit/connectionModes.test.ts
+++ b/library/tests/unit/connectionModes.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect } from "vitest"
-import { Position, type Rect, type XYPosition } from "@xyflow/react"
+import {
+  Position,
+  type InternalNode,
+  type Rect,
+  type XYPosition,
+} from "@xyflow/react"
 import {
   getConnectionMode,
   getEdgeAnchorFromPoint,
   getEdgeAnchorPoint,
+  getNativeConnectionAnchor,
 } from "@/utils/connectionModes"
 
 // center (180, 150), rx 80, ry 50
@@ -13,6 +19,62 @@ const cy = rect.y + rect.height / 2
 
 const onEllipse = (p: XYPosition) =>
   ((p.x - cx) / (rect.width / 2)) ** 2 + ((p.y - cy) / (rect.height / 2)) ** 2
+
+const internalNode = (
+  id: string,
+  x: number,
+  y: number,
+  type = "class"
+): InternalNode =>
+  ({
+    id,
+    type,
+    position: { x, y },
+    width: 160,
+    height: 100,
+    measured: { width: 160, height: 100 },
+    data: {},
+    internals: {
+      positionAbsolute: { x, y },
+      userNode: {},
+      z: 0,
+    },
+  }) as unknown as InternalNode
+
+describe("native connection targets", () => {
+  it("uses the validated handle point and node even when the pointer and scene disagree", () => {
+    const target = internalNode("target", 100, 100)
+    const overlappingNode = internalNode("overlap", 240, 100)
+    const exactHandle = { x: 260, y: 125 }
+    const releasePointer = { x: 180, y: 200 }
+
+    const committed = getNativeConnectionAnchor({
+      to: exactHandle,
+      toNode: target,
+    })
+    expect(committed).toEqual({ side: Position.Right, ratio: 0.25 })
+
+    // Recomputing from the event pointer would choose another side, while
+    // resolving the overlapping node would choose its left border. Neither may
+    // influence a native target React Flow already validated.
+    expect(
+      getEdgeAnchorFromPoint(target.type, releasePointer, {
+        x: 100,
+        y: 100,
+        width: 160,
+        height: 100,
+      })
+    ).not.toEqual(committed)
+    expect(
+      getEdgeAnchorFromPoint(overlappingNode.type, exactHandle, {
+        x: 240,
+        y: 100,
+        width: 160,
+        height: 100,
+      })
+    ).not.toEqual(committed)
+  })
+})
 
 describe("getConnectionMode", () => {
   it("defaults box shapes (and unknowns) to freeform-rect", () => {

--- a/library/tests/unit/edgeGeometryPreview.test.ts
+++ b/library/tests/unit/edgeGeometryPreview.test.ts
@@ -58,6 +58,83 @@ describe("pending edge-geometry projection", () => {
     expect(pending.size).toBe(0)
   })
 
+  it("stabilizes diagonal route topology without treating every diagonal as invalid", () => {
+    const displayed = [
+      { x: 100, y: 40 },
+      { x: 300, y: 240 },
+    ]
+    const candidate = [
+      { x: 100, y: 40 },
+      { x: 160, y: 180 },
+      { x: 300, y: 240 },
+    ]
+    const pending = new Map<string, string>()
+    const input = {
+      displayedById: { e: displayed },
+      candidateById: { e: candidate },
+      edges: [edge],
+      nodes: new Map([
+        ["source", rect(0, 0)],
+        ["target", rect(300, 200)],
+        ["clear-node", rect(350, 0, 40, 40)],
+      ]),
+      pendingDecisionById: pending,
+    }
+
+    expect(stabilizeProvisionalRoutes(input).routeById.e).toBe(displayed)
+    expect(stabilizeProvisionalRoutes(input).routeById.e).toBe(candidate)
+  })
+
+  it("accepts same-topology diagonal coordinate refinements immediately", () => {
+    const displayed = [
+      { x: 100, y: 40 },
+      { x: 160, y: 180 },
+      { x: 300, y: 240 },
+    ]
+    const refined = [
+      { x: 100, y: 40 },
+      { x: 175, y: 170 },
+      { x: 300, y: 240 },
+    ]
+    const stabilization = stabilizeProvisionalRoutes({
+      displayedById: { e: displayed },
+      candidateById: { e: refined },
+      edges: [edge],
+      nodes: new Map([
+        ["source", rect(0, 0)],
+        ["target", rect(300, 200)],
+      ]),
+      pendingDecisionById: new Map(),
+    })
+    expect(stabilization.routeById.e).toBe(refined)
+    expect(stabilization.heldDecisionCount).toBe(0)
+  })
+
+  it("immediately replaces a held diagonal route that intersects a node", () => {
+    const displayed = [
+      { x: 100, y: 40 },
+      { x: 300, y: 240 },
+    ]
+    const candidate = [
+      { x: 100, y: 40 },
+      { x: 120, y: 220 },
+      { x: 300, y: 240 },
+    ]
+    const stabilization = stabilizeProvisionalRoutes({
+      displayedById: { e: displayed },
+      candidateById: { e: candidate },
+      edges: [edge],
+      nodes: new Map([
+        ["source", rect(0, 0)],
+        ["target", rect(300, 200)],
+        ["obstacle", rect(180, 100, 40, 60)],
+      ]),
+      pendingDecisionById: new Map(),
+    })
+    expect(stabilization.routeById.e).toBe(candidate)
+    expect(stabilization.invalidatedDecisionCount).toBe(1)
+  })
+
   it("stabilizes port changes but accepts same-decision coordinate refinement", () => {
     const displayed = [
       { x: 100, y: 40 },
@@ -194,7 +271,7 @@ describe("pending edge-geometry projection", () => {
       ).toBe(true)
   })
 
-  it("does not animate an already exact preview or a non-orthogonal route", () => {
+  it("does not animate an exact preview and smoothly hands off a diagonal route", () => {
     const exact = [
       { x: 0, y: 0 },
       { x: 100, y: 0 },
@@ -205,17 +282,25 @@ describe("pending edge-geometry projection", () => {
         { exact }
       )
     ).toEqual({})
-    expect(
-      prepareEdgeGeometrySettlement(
-        {
-          diagonal: [
-            { x: 0, y: 0 },
-            { x: 100, y: 100 },
-          ],
-        },
-        { diagonal: exact }
-      )
-    ).toEqual({})
+    const diagonal = [
+      { x: 0, y: 0 },
+      { x: 100, y: 100 },
+    ]
+    const transition = prepareEdgeGeometrySettlement(
+      { diagonal },
+      { diagonal: exact }
+    )
+    expect(interpolateEdgeGeometrySettlement(transition, 0).diagonal).toBe(
+      diagonal
+    )
+    expect(interpolateEdgeGeometrySettlement(transition, 1).diagonal).toBe(
+      exact
+    )
+    const halfway = interpolateEdgeGeometrySettlement(transition, 0.5).diagonal
+    expect(halfway[0]).toEqual({ x: 0, y: 0 })
+    expect(halfway[halfway.length - 1].x).toBe(100)
+    expect(halfway[halfway.length - 1].y).toBeGreaterThan(0)
+    expect(halfway[halfway.length - 1].y).toBeLessThan(100)
   })
 
   it("keeps every interpolated segment orthogonal across topology combinations", () => {

--- a/library/tests/unit/edgeGeometryPreview.test.ts
+++ b/library/tests/unit/edgeGeometryPreview.test.ts
@@ -20,6 +20,10 @@ const edge = {
   source: "source",
   target: "target",
 } as Edge
+const straightEdge = {
+  ...edge,
+  type: "SyntaxTreeLink",
+} as Edge
 
 describe("pending edge-geometry projection", () => {
   it("requires two consecutive provisional generations before changing route decisions", () => {
@@ -85,6 +89,34 @@ describe("pending edge-geometry projection", () => {
     expect(stabilizeProvisionalRoutes(input).routeById.e).toBe(candidate)
   })
 
+  it("holds a valid straight-edge decision for the complete node gesture", () => {
+    const displayed = [
+      { x: 100, y: 40 },
+      { x: 300, y: 240 },
+    ]
+    const candidate = [
+      { x: 100, y: 40 },
+      { x: 160, y: 180 },
+      { x: 300, y: 240 },
+    ]
+    const pending = new Map<string, string>()
+    const input = {
+      displayedById: { e: displayed },
+      candidateById: { e: candidate },
+      edges: [straightEdge],
+      nodes: new Map([
+        ["source", rect(0, 0)],
+        ["target", rect(300, 200)],
+      ]),
+      pendingDecisionById: pending,
+      holdDecisionEdgeTypes: new Set(["SyntaxTreeLink"]),
+    }
+
+    expect(stabilizeProvisionalRoutes(input).routeById.e).toBe(displayed)
+    expect(stabilizeProvisionalRoutes(input).routeById.e).toBe(displayed)
+    expect(stabilizeProvisionalRoutes(input).routeById.e).toBe(displayed)
+  })
+
   it("accepts same-topology diagonal coordinate refinements immediately", () => {
     const displayed = [
       { x: 100, y: 40 },
@@ -123,13 +155,14 @@ describe("pending edge-geometry projection", () => {
     const stabilization = stabilizeProvisionalRoutes({
       displayedById: { e: displayed },
       candidateById: { e: candidate },
-      edges: [edge],
+      edges: [straightEdge],
       nodes: new Map([
         ["source", rect(0, 0)],
         ["target", rect(300, 200)],
         ["obstacle", rect(180, 100, 40, 60)],
       ]),
       pendingDecisionById: new Map(),
+      holdDecisionEdgeTypes: new Set(["SyntaxTreeLink"]),
     })
     expect(stabilization.routeById.e).toBe(candidate)
     expect(stabilization.invalidatedDecisionCount).toBe(1)
@@ -458,6 +491,60 @@ describe("pending edge-geometry projection", () => {
         projected[index - 1].x === projected[index].x ||
           projected[index - 1].y === projected[index].y
       ).toBe(true)
+  })
+
+  it("keeps a diagonal straight edge diagonal while its node moves", () => {
+    const projected = projectRoutesWhileSolving(
+      {
+        e: [
+          { x: 100, y: 40 },
+          { x: 300, y: 240 },
+        ],
+      },
+      [straightEdge],
+      new Map([
+        ["source", rect(0, 0)],
+        ["target", rect(300, 200)],
+      ]),
+      new Map([
+        ["source", rect(40, 30)],
+        ["target", rect(300, 200)],
+      ]),
+      new Set(["SyntaxTreeLink"])
+    ).e
+
+    expect(projected).toEqual([
+      { x: 140, y: 70 },
+      { x: 300, y: 240 },
+    ])
+  })
+
+  it("keeps straight-edge obstacle bends fixed during projection", () => {
+    const projected = projectRoutesWhileSolving(
+      {
+        e: [
+          { x: 100, y: 40 },
+          { x: 180, y: 130 },
+          { x: 300, y: 240 },
+        ],
+      },
+      [straightEdge],
+      new Map([
+        ["source", rect(0, 0)],
+        ["target", rect(300, 200)],
+      ]),
+      new Map([
+        ["source", rect(40, 30)],
+        ["target", rect(300, 200)],
+      ]),
+      new Set(["SyntaxTreeLink"])
+    ).e
+
+    expect(projected).toEqual([
+      { x: 140, y: 70 },
+      { x: 180, y: 130 },
+      { x: 300, y: 240 },
+    ])
   })
 
   it("preserves authored internal bends and terminal directions during resize", () => {

--- a/library/tests/unit/edgeGeometrySolver.test.ts
+++ b/library/tests/unit/edgeGeometrySolver.test.ts
@@ -235,8 +235,46 @@ describe("computeAllEdgeGeometry", () => {
       straightHookTypes: STRAIGHT_HOOK_EDGE_TYPES,
     })
 
-    expect(routeById.e1).toHaveLength(3)
-    expect(routeById.e1[1]).toEqual(waypoint)
+    expect(routeById.e1).toContainEqual(waypoint)
+  })
+
+  it("discovers blockers on waypoint legs outside the endpoint-node corridor", () => {
+    const a = makeNode("a", 0, 0)
+    const b = makeNode("b", 300, 0)
+    const blocker = makeNode("blocker", 108, 190, 32, 64)
+    const checkpoint = { x: 150, y: 500 }
+    const nodeLookup = new Map<string, InternalNode>([
+      ["a", a.internal],
+      ["b", b.internal],
+      ["blocker", blocker.internal],
+    ])
+    const edges: Edge[] = [
+      {
+        id: "e1",
+        source: "a",
+        target: "b",
+        type: "SyntaxTreeLink",
+        data: { points: [checkpoint] },
+      },
+    ]
+    const { routeById } = computeAllEdgeGeometry({
+      nodes: [a.node, b.node, blocker.node],
+      nodeLookup,
+      connectionMode: ConnectionMode.Loose,
+      edges,
+      straightPathTypes: STRAIGHT_PATH_STEP_EDGE_TYPES,
+      straightHookTypes: STRAIGHT_HOOK_EDGE_TYPES,
+    })
+    const route = routeById.e1
+    expect(route).toContainEqual(checkpoint)
+    expect(
+      crossesInterior(route, {
+        x: blocker.node.position.x,
+        y: blocker.node.position.y,
+        width: blocker.node.width!,
+        height: blocker.node.height!,
+      })
+    ).toBe(false)
   })
 
   it("routes all edges when their ids arrive out of order", () => {

--- a/library/tests/unit/edgeGeometrySolver.test.ts
+++ b/library/tests/unit/edgeGeometrySolver.test.ts
@@ -238,7 +238,7 @@ describe("computeAllEdgeGeometry", () => {
     expect(routeById.e1).toContainEqual(waypoint)
   })
 
-  it("discovers blockers on waypoint legs outside the endpoint-node corridor", () => {
+  it("keeps a far-reaching authored waypoint leg exact across a blocker", () => {
     const a = makeNode("a", 0, 0)
     const b = makeNode("b", 300, 0)
     const blocker = makeNode("blocker", 108, 190, 32, 64)
@@ -266,6 +266,7 @@ describe("computeAllEdgeGeometry", () => {
       straightHookTypes: STRAIGHT_HOOK_EDGE_TYPES,
     })
     const route = routeById.e1
+    expect(route).toHaveLength(3)
     expect(route).toContainEqual(checkpoint)
     expect(
       crossesInterior(route, {
@@ -274,7 +275,7 @@ describe("computeAllEdgeGeometry", () => {
         width: blocker.node.width!,
         height: blocker.node.height!,
       })
-    ).toBe(false)
+    ).toBe(true)
   })
 
   it("routes all edges when their ids arrive out of order", () => {

--- a/library/tests/unit/edgeGeometryWorkerExecution.test.ts
+++ b/library/tests/unit/edgeGeometryWorkerExecution.test.ts
@@ -228,6 +228,27 @@ describe("EdgeGeometryWorkerController", () => {
     expect(decision(true, 200, true)).toBe(false)
   })
 
+  it("moves an initialized small straight-edge interaction off the main thread", () => {
+    expect(
+      shouldUseEdgeGeometryWorker({
+        hasRunInitialSolve: true,
+        edgeCount: 1,
+        threshold: EDGE_GEOMETRY_WORKER_EDGE_THRESHOLD,
+        disabled: false,
+        force: true,
+      })
+    ).toBe(true)
+    expect(
+      shouldUseEdgeGeometryWorker({
+        hasRunInitialSolve: false,
+        edgeCount: 1,
+        threshold: EDGE_GEOMETRY_WORKER_EDGE_THRESHOLD,
+        disabled: false,
+        force: true,
+      })
+    ).toBe(false)
+  })
+
   it("defers only large actively changing scenes", () => {
     expect(
       shouldSampleEdgeGeometryWorker({
@@ -245,6 +266,13 @@ describe("EdgeGeometryWorkerController", () => {
       shouldSampleEdgeGeometryWorker({
         edgeCount: EDGE_GEOMETRY_WORKER_EDGE_THRESHOLD,
         interacting: true,
+      })
+    ).toBe(true)
+    expect(
+      shouldSampleEdgeGeometryWorker({
+        edgeCount: 1,
+        interacting: true,
+        force: true,
       })
     ).toBe(true)
   })

--- a/library/tests/unit/integerGeometry.test.ts
+++ b/library/tests/unit/integerGeometry.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest"
+import {
+  distSqInt,
+  isqrt,
+  segLenInt,
+  turnBucket,
+} from "@/utils/geometry/integerGeometry"
+
+describe("isqrt — exact integer floor square root", () => {
+  it("matches a golden table of small values", () => {
+    const golden: Array<[number, number]> = [
+      [0, 0],
+      [1, 1],
+      [2, 1],
+      [3, 1],
+      [4, 2],
+      [5, 2],
+      [8, 2],
+      [9, 3],
+      [15, 3],
+      [16, 4],
+      [24, 4],
+      [25, 5],
+      [26, 5],
+      [99, 9],
+      [100, 10],
+      [101, 10],
+    ]
+    for (const [input, expected] of golden) expect(isqrt(input)).toBe(expected)
+  })
+
+  it("is exact on perfect squares and their boundaries", () => {
+    for (let n = 0; n <= 5000; n++) {
+      const sq = n * n
+      expect(isqrt(sq)).toBe(n)
+      if (n > 0) {
+        // Just below a perfect square floors to n-1; just above still floors to n.
+        expect(isqrt(sq - 1)).toBe(n - 1)
+        expect(isqrt(sq + 1)).toBe(n)
+      }
+    }
+  })
+
+  it("is exact for large values including near 2^53", () => {
+    const cases: Array<[number, number]> = [
+      [1_000_000, 1000],
+      [999_999, 999],
+      [1_000_000_000_000, 1_000_000],
+      [999_999_999_999, 999_999],
+      [Number.MAX_SAFE_INTEGER, 94_906_265], // floor(sqrt(2^53 - 1))
+      [2 ** 52, 67_108_864], // 2^26 exactly
+    ]
+    for (const [input, expected] of cases) {
+      expect(isqrt(input)).toBe(expected)
+      // Defining property: r*r <= n < (r+1)*(r+1).
+      const r = isqrt(input)
+      expect(r * r).toBeLessThanOrEqual(input)
+      expect((r + 1) * (r + 1)).toBeGreaterThan(input)
+    }
+  })
+
+  it("rejects negative and non-integer inputs", () => {
+    expect(() => isqrt(-1)).toThrow(RangeError)
+    expect(() => isqrt(2.5)).toThrow(RangeError)
+  })
+})
+
+describe("segLenInt / distSqInt", () => {
+  it("computes exact squared distance and floored length", () => {
+    expect(distSqInt({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(25)
+    expect(segLenInt({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(5)
+    // 5-12-13 triple
+    expect(segLenInt({ x: 1, y: 1 }, { x: 6, y: 13 })).toBe(13)
+    // Non-integer true length floors down.
+    expect(segLenInt({ x: 0, y: 0 }, { x: 1, y: 1 })).toBe(1) // sqrt(2) -> 1
+    expect(segLenInt({ x: 0, y: 0 }, { x: 2, y: 2 })).toBe(2) // sqrt(8) -> 2
+  })
+})
+
+describe("turnBucket — integer angle classification", () => {
+  const cases: Array<[string, [number, number], [number, number], number]> = [
+    ["dead straight", [1, 0], [1, 0], 0],
+    ["straight (scaled)", [2, 0], [5, 0], 0],
+    ["gentle ~26deg", [1, 0], [2, 1], 0],
+    ["exactly 45deg (inclusive)", [1, 0], [1, 1], 0],
+    ["~63deg", [1, 0], [1, 2], 1],
+    ["right angle", [1, 0], [0, 1], 1],
+    ["right angle other sign", [1, 0], [0, -1], 1],
+    ["~135deg", [1, 0], [-1, 1], 2],
+    ["hairpin reverse", [1, 0], [-1, 0], 2],
+    ["degenerate incoming", [0, 0], [1, 0], 0],
+    ["degenerate outgoing", [1, 0], [0, 0], 0],
+  ]
+  it.each(cases)("%s", (_name, u, v, expected) => {
+    expect(turnBucket(u[0], u[1], v[0], v[1])).toBe(expected)
+  })
+
+  it("is sign-symmetric in the cross product", () => {
+    // Turning left vs right by the same magnitude lands in the same bucket.
+    expect(turnBucket(1, 0, 1, 2)).toBe(turnBucket(1, 0, 1, -2))
+    expect(turnBucket(1, 0, -1, 1)).toBe(turnBucket(1, 0, -1, -1))
+  })
+
+  it("stays exact for large coordinate magnitudes (no overflow)", () => {
+    // dot^2 / cross^2 here far exceed 2^53; BigInt keeps them exact.
+    expect(turnBucket(100_000, 0, 100_000, 0)).toBe(0)
+    expect(turnBucket(100_000, 0, 0, 100_000)).toBe(1)
+    expect(turnBucket(100_000, 1, -100_000, 1)).toBe(2)
+  })
+})

--- a/library/tests/unit/portAssignment.test.ts
+++ b/library/tests/unit/portAssignment.test.ts
@@ -8,6 +8,7 @@ import {
   assignSides,
   assignPorts,
   endKey,
+  redistributeCrowdedStraightEnds,
   type SideEdge,
   type SideMember,
   type EndRef,
@@ -84,6 +85,57 @@ describe("orderSideMembers — the nesting rule", () => {
     )
     expect(reversed).toEqual(forward)
     expect(forward).toEqual(["e0", "e1", "e2", "e3"]) // top→bottom
+  })
+})
+
+describe("redistributeCrowdedStraightEnds", () => {
+  it("overflows the angular outer pair of a five-way fan symmetrically", () => {
+    const hub = rect(0, 0, 70, 60)
+    const partnerXs = [-200, -80, 0, 80, 200]
+    const ends: EndRef[] = partnerXs.map((x, index) => {
+      const partner = rect(x, 240, 70, 60)
+      return {
+        edgeId: `e${index}`,
+        end: "source" as const,
+        nodeId: "hub",
+        rect: hub,
+        side: Position.Bottom,
+        straight: true,
+        partnerCenter: centerOf(partner),
+        partnerNodeId: `partner-${index}`,
+        partnerRect: partner,
+      }
+    })
+    const redistributed = redistributeCrowdedStraightEnds(ends)
+    const sides = new Map(redistributed.map((item) => [item.edgeId, item.side]))
+    expect(sides.get("e0")).toBe(Position.Left)
+    expect(sides.get("e1")).toBe(Position.Bottom)
+    expect(sides.get("e2")).toBe(Position.Bottom)
+    expect(sides.get("e3")).toBe(Position.Bottom)
+    expect(sides.get("e4")).toBe(Position.Right)
+  })
+
+  it("never moves an authored reservation while overflowing mutable ends", () => {
+    const hub = rect(0, 0, 70, 60)
+    const ends: EndRef[] = Array.from({ length: 5 }, (_, index) => {
+      const partner = rect(index * 100 - 200, 240, 70, 60)
+      return {
+        edgeId: `e${index}`,
+        end: "source" as const,
+        nodeId: "hub",
+        rect: hub,
+        side: Position.Bottom,
+        straight: true,
+        partnerCenter: centerOf(partner),
+        partnerNodeId: `partner-${index}`,
+        partnerRect: partner,
+        immutableRatio: index === 0 ? 0.1 : undefined,
+      }
+    })
+    const redistributed = redistributeCrowdedStraightEnds(ends)
+    expect(redistributed.find((item) => item.edgeId === "e0")?.side).toBe(
+      Position.Bottom
+    )
   })
 })
 

--- a/library/tests/unit/rectSides.test.ts
+++ b/library/tests/unit/rectSides.test.ts
@@ -25,4 +25,13 @@ describe("facingSide", () => {
     const wide = rect(0, 0, 400, 20)
     expect(facingSide(wide, { x: 320, y: -30 })).toBe(Position.Top)
   })
+
+  it("can absorb small movements around an axis boundary", () => {
+    const square = rect(0, 0, 100, 100)
+    // Vertical wins by 5% without a deadband. Automatic straight edges opt into a
+    // 5% band so one grid-cell nudge does not make the endpoint jump sides.
+    expect(facingSide(square, { x: 150, y: 155 })).toBe(Position.Bottom)
+    expect(facingSide(square, { x: 150, y: 155 }, 50)).toBe(Position.Right)
+    expect(facingSide(square, { x: 150, y: 170 }, 50)).toBe(Position.Bottom)
+  })
 })

--- a/library/tests/unit/routingCost.test.ts
+++ b/library/tests/unit/routingCost.test.ts
@@ -83,6 +83,32 @@ describe("shared routing cost", () => {
     expect(crossing.crossings).toBe(1)
     expect(crossing.cost).toBe(ROUTING_COST.edgeCrossing)
 
+    // Lying ON another edge is the worst of the three incidences: it is priced
+    // above a crossing per shared pixel, and strictly above merely running close
+    // by. Straight edges rely on this ordering to fan out instead of merging.
+    const shared = [
+      { x: 20, y: 50 },
+      { x: 100, y: 50 },
+    ]
+    const overlapping = polylineConflictCost(route, [shared], 10)
+    const nearby = polylineConflictCost(
+      route,
+      [
+        [
+          { x: 20, y: 56 },
+          { x: 100, y: 56 },
+        ],
+      ],
+      10
+    )
+    expect(overlapping.overlapPx).toBe(80)
+    expect(overlapping.cost).toBe(80 * ROUTING_COST.overlapPerPx)
+    expect(overlapping.cost).toBeGreaterThan(nearby.cost)
+    expect(overlapping.cost).toBeGreaterThan(ROUTING_COST.edgeCrossing)
+    // Crowding is real but an order of magnitude gentler than overlap.
+    expect(nearby.cost).toBeGreaterThan(0)
+    expect(nearby.crowdingPx).toBeGreaterThan(0)
+
     const parallel = polylineConflictCost(
       [
         { x: 0, y: 0 },

--- a/library/tests/unit/straightHookRouting.test.ts
+++ b/library/tests/unit/straightHookRouting.test.ts
@@ -130,6 +130,28 @@ describe("straight-hook edge routing", () => {
     expect(route[route.length - 1].x).toBeLessThan(420)
   })
 
+  it("leaves an authored route untouched even when it crosses another node", () => {
+    // Once a user adds a bend, its segments are direct-manipulation geometry. The
+    // automatic router must not silently add more bends around a later obstruction.
+    const waypoint = { x: 280, y: 200 }
+    const blocker = makeNode("c", 190, 95, 70, 70)
+    const nodes = [makeNode("a", 0, 0), makeNode("b", 520, 0), blocker]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge([waypoint])])
+    )
+    const route = routeById["e1"]
+    expect(route).toHaveLength(3)
+    expect(route[1]).toEqual(waypoint)
+    expect(
+      segIntersectsRect(route[0], route[1], {
+        x: 190,
+        y: 95,
+        width: 70,
+        height: 70,
+      })
+    ).toBe(true)
+  })
+
   it("keeps an unobstructed connection straight (a 2-point line)", () => {
     const nodes = [makeNode("a", 0, 0), makeNode("b", 400, 0)]
     const { routeById } = computeAllEdgeGeometry(
@@ -450,6 +472,21 @@ describe("straight-hook edge routing", () => {
     ]) {
       expect(layout(dx, dy)).toBe(base)
     }
+  })
+
+  it("keeps the facing side through a small nudge near a diagonal boundary", () => {
+    const sourceSide = (targetY: number) => {
+      const nodes = [
+        makeNode("a", 0, 0, 100, 60),
+        makeNode("b", 500, targetY, 100, 60),
+      ]
+      const source = computeAllEdgeGeometry(
+        solverInput(nodes, [straightHookEdge()])
+      ).routeById["e1"][0]
+      return Math.abs(source.x - 100) <= 6 ? "right" : "bottom"
+    }
+    expect(sourceSide(300)).toBe("right")
+    expect(sourceSide(305)).toBe("right")
   })
 
   it("is deterministic: a cold re-solve yields byte-identical routes", () => {

--- a/library/tests/unit/straightHookRouting.test.ts
+++ b/library/tests/unit/straightHookRouting.test.ts
@@ -1,0 +1,466 @@
+import { describe, expect, it } from "vitest"
+import {
+  ConnectionMode,
+  Position,
+  type Edge,
+  type InternalNode,
+  type Node,
+} from "@xyflow/react"
+import {
+  computeAllEdgeGeometry,
+  type SolverInput,
+} from "@/utils/geometry/edgeGeometrySolver"
+import {
+  STRAIGHT_HOOK_EDGE_TYPES,
+  STRAIGHT_PATH_STEP_EDGE_TYPES,
+} from "@/edges/edgeRoutingBehavior"
+import type { IPoint } from "@/edges/Connection"
+
+type TestNode = { node: Node; internal: InternalNode }
+
+const makeNode = (
+  id: string,
+  x: number,
+  y: number,
+  width = 120,
+  height = 80,
+  type = "syntaxTreeNonterminal"
+): TestNode => {
+  const node = {
+    id,
+    type,
+    position: { x, y },
+    width,
+    height,
+    measured: { width, height },
+    data: {},
+  } as Node
+  const internal = {
+    ...node,
+    internals: {
+      positionAbsolute: { x, y },
+      handleBounds: {
+        source: [
+          {
+            id: null,
+            type: "source",
+            position: Position.Right,
+            x: width,
+            y: height / 2,
+            width: 1,
+            height: 1,
+          },
+        ],
+        target: [
+          {
+            id: null,
+            type: "target",
+            position: Position.Left,
+            x: 0,
+            y: height / 2,
+            width: 1,
+            height: 1,
+          },
+        ],
+      },
+    },
+  } as unknown as InternalNode
+  return { node, internal }
+}
+
+const solverInput = (
+  nodes: readonly TestNode[],
+  edges: readonly Edge[]
+): SolverInput => ({
+  nodes: nodes.map(({ node }) => node),
+  nodeLookup: new Map(nodes.map(({ node, internal }) => [node.id, internal])),
+  connectionMode: ConnectionMode.Loose,
+  edges,
+  straightPathTypes: STRAIGHT_PATH_STEP_EDGE_TYPES,
+  straightHookTypes: STRAIGHT_HOOK_EDGE_TYPES,
+})
+
+const straightHookEdge = (points?: IPoint[]): Edge => ({
+  id: "e1",
+  source: "a",
+  target: "b",
+  type: "SyntaxTreeLink",
+  sourceHandle: null,
+  targetHandle: null,
+  data: points ? { points } : {},
+})
+
+const segIntersectsRect = (
+  a: IPoint,
+  b: IPoint,
+  rect: { x: number; y: number; width: number; height: number }
+): boolean => {
+  // Sample the segment densely and check strict-interior containment.
+  const steps = 200
+  for (let i = 1; i < steps; i++) {
+    const t = i / steps
+    const px = a.x + (b.x - a.x) * t
+    const py = a.y + (b.y - a.y) * t
+    if (
+      px > rect.x &&
+      px < rect.x + rect.width &&
+      py > rect.y &&
+      py < rect.y + rect.height
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+describe("straight-hook edge routing", () => {
+  it("passes authored interior waypoints through as diagonal segments (no orthogonalisation)", () => {
+    const nodes = [makeNode("a", 0, 0), makeNode("b", 400, 0)]
+    // An off-axis waypoint that an orthogonal reprojection would rewrite into H/V.
+    const waypoint = { x: 280, y: 200 }
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge([waypoint])])
+    )
+    const route = routeById["e1"]
+    expect(route).toHaveLength(3)
+    // The waypoint is honoured verbatim — proof it was NOT snapped to a staircase.
+    expect(route[1]).toEqual(waypoint)
+    // Endpoints attach to the node sides (right of A, left of B).
+    expect(route[0].x).toBeGreaterThan(100)
+    expect(route[route.length - 1].x).toBeLessThan(420)
+  })
+
+  it("keeps an unobstructed connection straight (a 2-point line)", () => {
+    const nodes = [makeNode("a", 0, 0), makeNode("b", 400, 0)]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge()])
+    )
+    expect(routeById["e1"]).toHaveLength(2)
+  })
+
+  it("auto-bends a general-graph (use-case) edge around a blocking node", () => {
+    // Blocker C straddles the horizontal chord between A and B.
+    const t = "useCaseActor"
+    const blocker = makeNode("c", 210, -20, 100, 120, t)
+    const nodes = [
+      makeNode("a", 0, 0, 120, 80, t),
+      makeNode("b", 520, 0, 120, 80, t),
+      blocker,
+    ]
+    const useCaseEdge: Edge = {
+      id: "e1",
+      source: "a",
+      target: "b",
+      type: "UseCaseAssociation",
+      sourceHandle: null,
+      targetHandle: null,
+      data: {},
+    }
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput(nodes, [useCaseEdge])
+    )
+    const route = routeById["e1"]
+    expect(route.length).toBeGreaterThan(2)
+    const blockerRect = { x: 210, y: -20, width: 100, height: 120 }
+    for (let i = 0; i < route.length - 1; i++) {
+      expect(segIntersectsRect(route[i], route[i + 1], blockerRect)).toBe(false)
+    }
+  })
+
+  it("bends a syntax-tree link around a blocker without grazing either node", () => {
+    const blocker = makeNode("c", 210, -20, 100, 120)
+    const nodes = [makeNode("a", 0, 0, 120, 80), makeNode("b", 520, 0), blocker]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge()])
+    )
+    const route = routeById["e1"]
+    expect(route.length).toBeGreaterThan(2)
+    const blockerRect = { x: 210, y: -20, width: 100, height: 120 }
+    for (let i = 0; i < route.length - 1; i++) {
+      expect(segIntersectsRect(route[i], route[i + 1], blockerRect)).toBe(false)
+    }
+    // The detour stays economical: one corner, not a staircase of kinks.
+    expect(route.length).toBeLessThanOrEqual(4)
+  })
+
+  it("leaves a node squarely rather than grazing along its side", () => {
+    // A blocker directly under the source used to make the route slide out
+    // sideways along the node's own edge (a 90-degree "exit angle") before
+    // turning. The endpoint-angle term prices that above spending a corner.
+    const blocker = makeNode("c", 150, 140, 120, 80)
+    const nodes = [
+      makeNode("a", 150, 0, 120, 80),
+      makeNode("b", 420, 320, 120, 80),
+      blocker,
+    ]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge()])
+    )
+    const route = routeById["e1"]
+    const source = { ...makeNode("a", 150, 0, 120, 80).node.position }
+    const rect = { x: source.x, y: source.y, width: 120, height: 80 }
+    // Outward normal of whichever side the route departs from.
+    const p = route[0]
+    const distances = [
+      { n: { x: -1, y: 0 }, d: Math.abs(p.x - rect.x) },
+      { n: { x: 1, y: 0 }, d: Math.abs(p.x - (rect.x + rect.width)) },
+      { n: { x: 0, y: -1 }, d: Math.abs(p.y - rect.y) },
+      { n: { x: 0, y: 1 }, d: Math.abs(p.y - (rect.y + rect.height)) },
+    ].sort((a, b) => a.d - b.d)
+    const normal = distances[0].n
+    const dir = { x: route[1].x - p.x, y: route[1].y - p.y }
+    const len = Math.hypot(dir.x, dir.y)
+    const cos = (dir.x * normal.x + dir.y * normal.y) / len
+    const degrees = (Math.acos(Math.max(-1, Math.min(1, cos))) * 180) / Math.PI
+    expect(degrees).toBeLessThan(75)
+  })
+
+  it("attaches at the facing side with a centred port (not the drawn handle)", () => {
+    // Parent directly above child. The facing sides are parent-bottom / child-top,
+    // even though the edge was drawn on the right/left handles.
+    const nodes = [makeNode("a", 0, 0, 100, 60), makeNode("b", 0, 300, 100, 60)]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge()])
+    )
+    const route = routeById["e1"]
+    const source = route[0]
+    const target = route[route.length - 1]
+    // Source sits on the parent's BOTTOM edge (y≈60), centred (x≈50) — not on a
+    // left/right handle (x≈0 or 100).
+    expect(Math.abs(source.y - 60)).toBeLessThanOrEqual(6)
+    expect(source.x).toBeGreaterThan(35)
+    expect(source.x).toBeLessThan(65)
+    // Target sits on the child's TOP edge (y≈300), centred.
+    expect(Math.abs(target.y - 300)).toBeLessThanOrEqual(6)
+    expect(target.x).toBeGreaterThan(35)
+    expect(target.x).toBeLessThan(65)
+  })
+
+  it("balances multiple children across a parent's facing side", () => {
+    // A parent with three children below it: their source ports should spread
+    // across the parent's bottom side rather than stacking on one point.
+    const parent = makeNode("p", 200, 0, 120, 60)
+    const c1 = makeNode("c1", 0, 300, 100, 60)
+    const c2 = makeNode("c2", 200, 300, 100, 60)
+    const c3 = makeNode("c3", 400, 300, 100, 60)
+    const edges: Edge[] = [
+      { id: "e1", source: "p", target: "c1", type: "SyntaxTreeLink", data: {} },
+      { id: "e2", source: "p", target: "c2", type: "SyntaxTreeLink", data: {} },
+      { id: "e3", source: "p", target: "c3", type: "SyntaxTreeLink", data: {} },
+    ]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput([parent, c1, c2, c3], edges)
+    )
+    const sourceXs = ["e1", "e2", "e3"]
+      .map((id) => routeById[id][0].x)
+      .sort((a, b) => a - b)
+    // Three distinct ports spread across the parent's bottom side (x in [200,320]).
+    expect(new Set(sourceXs).size).toBe(3)
+    expect(sourceXs[2] - sourceXs[0]).toBeGreaterThan(20)
+    for (const x of sourceXs) {
+      expect(x).toBeGreaterThanOrEqual(200)
+      expect(x).toBeLessThanOrEqual(320)
+    }
+  })
+
+  it("spreads a fan evenly and symmetrically, never twice on one port", () => {
+    // Five children symmetric about the parent's centre. Their source ports must be
+    // five DISTINCT, evenly spaced seats — two edges leaving from one pixel is the
+    // degenerate overlap the coordinated band exists to prevent.
+    // Placed far enough below that every child is "downward" of the parent, so the
+    // whole fan shares one side and the band has to seat all five on it.
+    const parent = makeNode("p", 200, 0, 120, 60)
+    const kids = [-40, 85, 210, 335, 460].map((x, i) =>
+      makeNode(`c${i}`, x, 400, 100, 60)
+    )
+    const edges: Edge[] = kids.map((_, i) => ({
+      id: `e${i}`,
+      source: "p",
+      target: `c${i}`,
+      type: "SyntaxTreeLink",
+      data: {},
+    }))
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput([parent, ...kids], edges)
+    )
+    const ports = edges
+      .map((e) => routeById[e.id][0])
+      .sort((a, b) => a.x - b.x || a.y - b.y)
+    expect(new Set(ports.map((p) => `${p.x},${p.y}`)).size).toBe(ports.length)
+    // All on the parent's bottom side, and mirror-symmetric about its centre.
+    const centre = 200 + 120 / 2
+    expect(ports.every((p) => p.y === 60)).toBe(true)
+    for (let i = 0; i < ports.length; i++) {
+      const mirrored = ports[ports.length - 1 - i]
+      expect(
+        Math.abs(2 * centre - ports[i].x - mirrored.x)
+      ).toBeLessThanOrEqual(1)
+    }
+    // Evenly spaced: no gap more than one grid cell off any other.
+    const gaps = ports.slice(1).map((p, i) => p.x - ports[i].x)
+    expect(Math.max(...gaps) - Math.min(...gaps)).toBeLessThanOrEqual(5)
+  })
+
+  it("nests sibling detours instead of stacking them on one elbow", () => {
+    // Two connectors from the same parent must clear the same obstacle. Shortest
+    // paths send both around its corner, so without a ring preference they bend at
+    // the identical point and the fan reads as a knot.
+    // Real parse-tree geometry: a five-way fan whose two left-hand members must
+    // both clear the same column of nodes. Their coordinated seats sit at different
+    // distances from the side's centre, which picks different corner rings.
+    const parent = makeNode("stmt", 155, 215, 70, 50)
+    const column = [
+      makeNode("colTop", 55, 385, 70, 50),
+      makeNode("colBottom", 55, 460, 70, 50),
+    ]
+    const kids = [
+      makeNode("outer", -35, 550, 50, 50),
+      makeNode("inner", 15, 550, 50, 50),
+      makeNode("mid", 155, 310, 70, 50),
+      makeNode("right1", 315, 550, 50, 50),
+      makeNode("right2", 365, 550, 50, 50),
+    ]
+    const edges: Edge[] = kids.map((k, i) => ({
+      id: `e${i}`,
+      source: "stmt",
+      target: k.node.id,
+      type: "SyntaxTreeLink",
+      data: {},
+    }))
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput([parent, ...column, ...kids], edges)
+    )
+    const outerBends = routeById["e0"].slice(1, -1)
+    const innerBends = routeById["e1"].slice(1, -1)
+    expect(outerBends.length).toBeGreaterThan(0)
+    expect(innerBends.length).toBeGreaterThan(0)
+    // The two never turn at the same point, so the fan reads as nested rather than
+    // knotted at a single shared elbow.
+    const shared = outerBends.filter((a) =>
+      innerBends.some((b) => a.x === b.x && a.y === b.y)
+    )
+    expect(shared).toEqual([])
+  })
+
+  it("nests both flanks of a symmetric fan identically", () => {
+    // Regression: the corner-ring choice compared each seat's distance from its
+    // side's centre against the largest on that side. Mirror-paired seats are the
+    // same distance out in exact arithmetic but NOT in binary floating point — for a
+    // seven-way band, 0.5 - 1/7 and 6/7 - 0.5 differ in the final bit. One flank
+    // therefore took the roomy corner ring and the other the tight one, and the
+    // drawing was visibly lopsided even though every input was symmetric.
+    const AXIS = 190
+    const parent = makeNode("stmt", 155, 215, 70, 50)
+    const columns = [
+      makeNode("colL", 55, 385, 70, 50),
+      makeNode("colR", 255, 385, 70, 50),
+    ]
+    const kids = [
+      makeNode("outerL", -35, 550, 50, 50),
+      makeNode("innerL", 15, 550, 50, 50),
+      makeNode("mid", 155, 310, 70, 50),
+      makeNode("innerR", 315, 550, 50, 50),
+      makeNode("outerR", 365, 550, 50, 50),
+    ]
+    const edges: Edge[] = kids.map((k, i) => ({
+      id: `e${i}`,
+      source: "stmt",
+      target: k.node.id,
+      type: "SyntaxTreeLink",
+      data: {},
+    }))
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput([parent, ...columns, ...kids], edges)
+    )
+    // e0/e4 are the outer pair, e1/e3 the inner pair.
+    for (const [left, right] of [
+      ["e0", "e4"],
+      ["e1", "e3"],
+    ]) {
+      const l = routeById[left]
+      const r = routeById[right]
+      expect(l.length).toBe(r.length)
+      for (let i = 0; i < l.length; i++) {
+        expect(Math.abs(2 * AXIS - l[i].x - r[i].x)).toBeLessThanOrEqual(1)
+        expect(l[i].y).toBe(r[i].y)
+      }
+    }
+    // And the two members of one flank still turn at different points.
+    expect(routeById["e0"][1]).not.toEqual(routeById["e1"][1])
+  })
+
+  it("routes a mirror-symmetric diagram symmetrically", () => {
+    // Everything below is an exact reflection about x = AXIS, including the
+    // obstacles, so every route must be the reflection of its partner. Asymmetry
+    // here means some decision is resolving on a non-geometric tie-break.
+    const AXIS = 300
+    const parent = makeNode("p", 260, 0, 80, 60)
+    const leftKid = makeNode("kl", 0, 400, 80, 60)
+    const rightKid = makeNode("kr", 520, 400, 80, 60)
+    const leftBlock = makeNode("bl", 120, 180, 100, 60)
+    const rightBlock = makeNode("br", 380, 180, 100, 60)
+    const edges: Edge[] = [
+      { id: "eL", source: "p", target: "kl", type: "SyntaxTreeLink", data: {} },
+      { id: "eR", source: "p", target: "kr", type: "SyntaxTreeLink", data: {} },
+    ]
+    const { routeById } = computeAllEdgeGeometry(
+      solverInput([parent, leftKid, rightKid, leftBlock, rightBlock], edges)
+    )
+    const left = routeById["eL"]
+    const right = routeById["eR"]
+    expect(left.length).toBe(right.length)
+    for (let i = 0; i < left.length; i++) {
+      expect(Math.abs(2 * AXIS - left[i].x - right[i].x)).toBeLessThanOrEqual(1)
+      expect(left[i].y).toBe(right[i].y)
+    }
+  })
+
+  it("does not change topology when a node is nudged one grid cell", () => {
+    // Routing is deterministic but not continuous: a small move can in principle
+    // flip a side or buy a corner. Generous bend pricing keeps the drawing from
+    // reorganising itself under an ordinary drag, which is what a user perceives as
+    // the diagram being stable.
+    const layout = (dx: number, dy: number) => {
+      const nodes = [
+        makeNode("a", 150 + dx, 0 + dy, 120, 80),
+        makeNode("b", 420, 320, 120, 80),
+        makeNode("c", 150, 140, 120, 80),
+      ]
+      const route = computeAllEdgeGeometry(
+        solverInput(nodes, [straightHookEdge()])
+      ).routeById["e1"]
+      const rect = { x: 150 + dx, y: 0 + dy, width: 120, height: 80 }
+      const p = route[0]
+      const side = [
+        ["L", Math.abs(p.x - rect.x)],
+        ["R", Math.abs(p.x - (rect.x + rect.width))],
+        ["T", Math.abs(p.y - rect.y)],
+        ["B", Math.abs(p.y - (rect.y + rect.height))],
+      ].sort((l, r) => (l[1] as number) - (r[1] as number))[0][0]
+      return `${side}:${route.length}`
+    }
+    const base = layout(0, 0)
+    for (const [dx, dy] of [
+      [5, 0],
+      [-5, 0],
+      [0, 5],
+      [0, -5],
+      [5, 5],
+      [-5, -5],
+    ]) {
+      expect(layout(dx, dy)).toBe(base)
+    }
+  })
+
+  it("is deterministic: a cold re-solve yields byte-identical routes", () => {
+    const blocker = makeNode("c", 210, -20, 100, 120)
+    const nodes = [makeNode("a", 0, 0), makeNode("b", 520, 0), blocker]
+    const first = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge([{ x: 150, y: 120 }])])
+    ).routeById["e1"]
+    const second = computeAllEdgeGeometry(
+      solverInput(nodes, [straightHookEdge([{ x: 150, y: 120 }])])
+    ).routeById["e1"]
+    expect(second).toEqual(first)
+  })
+})

--- a/library/tests/unit/straightPolylineRouter.test.ts
+++ b/library/tests/unit/straightPolylineRouter.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect } from "vitest"
+import type { IPoint } from "@/edges/Connection"
+import { EDGES } from "@/utils/geometry/routingConstants"
+import {
+  chordClearsObstacles,
+  routeStraightPolyline,
+  type StraightRouteObstacle,
+  type StraightRouteRequest,
+} from "@/utils/geometry/straightPolylineRouter"
+
+const CLEAR = EDGES.NODE_CLEARANCE_PX
+const MIN = EDGES.MIN_NODE_CLEARANCE_PX
+
+type Rect = { x: number; y: number; width: number; height: number }
+
+/** Independent strict interior-crossing tester used to VERIFY router output
+ * (deliberately not sharing code with the module under test). */
+const crossesRectInterior = (a: IPoint, b: IPoint, r: Rect): boolean => {
+  const inside = (p: IPoint) =>
+    p.x > r.x && p.x < r.x + r.width && p.y > r.y && p.y < r.y + r.height
+  if (inside(a) || inside(b)) return true
+  const cross = (p: IPoint, q: IPoint, s: IPoint) =>
+    (q.x - p.x) * (s.y - p.y) - (q.y - p.y) * (s.x - p.x)
+  const open = (a1: IPoint, a2: IPoint, b1: IPoint, b2: IPoint) =>
+    cross(a1, a2, b1) * cross(a1, a2, b2) < 0 &&
+    cross(b1, b2, a1) * cross(b1, b2, a2) < 0
+  const c0 = { x: r.x, y: r.y }
+  const c1 = { x: r.x + r.width, y: r.y }
+  const c2 = { x: r.x + r.width, y: r.y + r.height }
+  const c3 = { x: r.x, y: r.y + r.height }
+  return (
+    open(a, b, c0, c1) ||
+    open(a, b, c1, c2) ||
+    open(a, b, c2, c3) ||
+    open(a, b, c3, c0)
+  )
+}
+
+const inflated = (r: Rect, d: number): Rect => ({
+  x: r.x - d,
+  y: r.y - d,
+  width: r.width + 2 * d,
+  height: r.height + 2 * d,
+})
+
+/** Assert the whole route keeps MIN clearance from a hard obstacle. */
+const expectRouteClears = (
+  route: IPoint[],
+  obstacle: StraightRouteObstacle
+): void => {
+  const guard = inflated(obstacle, MIN)
+  for (let i = 1; i < route.length; i++)
+    expect(crossesRectInterior(route[i - 1], route[i], guard)).toBe(false)
+}
+
+const isInteger = (route: IPoint[]): boolean =>
+  route.every((p) => Number.isInteger(p.x) && Number.isInteger(p.y))
+
+const routesCrossOpen = (left: IPoint[], right: IPoint[]): boolean => {
+  const orient = (a: IPoint, b: IPoint, c: IPoint) =>
+    (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+  for (let i = 1; i < left.length; i++)
+    for (let j = 1; j < right.length; j++) {
+      const a = left[i - 1]
+      const b = left[i]
+      const c = right[j - 1]
+      const d = right[j]
+      if (
+        orient(a, b, c) * orient(a, b, d) < 0 &&
+        orient(c, d, a) * orient(c, d, b) < 0
+      )
+        return true
+    }
+  return false
+}
+
+const baseReq = (
+  over: Partial<StraightRouteRequest>
+): StraightRouteRequest => ({
+  source: { x: 0, y: 0 },
+  target: { x: 100, y: 0 },
+  checkpoints: [],
+  obstacles: [],
+  neighborRoutes: [],
+  clearancePx: CLEAR,
+  ...over,
+})
+
+describe("routeStraightPolyline — empty and gated cases", () => {
+  it("returns the straight 2-point chord when there is no obstacle", () => {
+    const route = routeStraightPolyline(baseReq({}))
+    expect(route).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ])
+  })
+
+  it("returns the straight chord when a hard obstacle is well clear of it", () => {
+    const obstacle: StraightRouteObstacle = {
+      id: "n1",
+      x: 40,
+      y: 200,
+      width: 40,
+      height: 40,
+      soft: false,
+    }
+    const route = routeStraightPolyline(baseReq({ obstacles: [obstacle] }))
+    expect(route).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ])
+  })
+
+  it("ignores soft obstacles for visibility (never routes around them)", () => {
+    const soft: StraightRouteObstacle = {
+      id: "pkg",
+      x: 40,
+      y: -50,
+      width: 20,
+      height: 100,
+      soft: true,
+    }
+    const route = routeStraightPolyline(baseReq({ obstacles: [soft] }))
+    expect(route).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ])
+  })
+})
+
+describe("routeStraightPolyline — obstacle avoidance", () => {
+  it("routes around a single blocking obstacle without crossing it", () => {
+    const obstacle: StraightRouteObstacle = {
+      id: "block",
+      x: 80,
+      y: -20,
+      width: 40,
+      height: 40,
+      soft: false,
+    }
+    const route = routeStraightPolyline(
+      baseReq({
+        source: { x: 0, y: 0 },
+        target: { x: 200, y: 0 },
+        obstacles: [obstacle],
+      })
+    )
+    expect(route.length).toBeGreaterThanOrEqual(3)
+    expect(route[0]).toEqual({ x: 0, y: 0 })
+    expect(route[route.length - 1]).toEqual({ x: 200, y: 0 })
+    expect(isInteger(route)).toBe(true)
+    expectRouteClears(route, obstacle)
+  })
+
+  it("threads a two-obstacle corridor, clearing both", () => {
+    const a: StraightRouteObstacle = {
+      id: "A",
+      x: 80,
+      y: -15,
+      width: 40,
+      height: 75,
+      soft: false,
+    }
+    const b: StraightRouteObstacle = {
+      id: "B",
+      x: 180,
+      y: -60,
+      width: 40,
+      height: 75,
+      soft: false,
+    }
+    const route = routeStraightPolyline(
+      baseReq({
+        source: { x: 0, y: 0 },
+        target: { x: 300, y: 0 },
+        obstacles: [a, b],
+      })
+    )
+    expect(route.length).toBeGreaterThanOrEqual(3)
+    expect(route[0]).toEqual({ x: 0, y: 0 })
+    expect(route[route.length - 1]).toEqual({ x: 300, y: 0 })
+    expectRouteClears(route, a)
+    expectRouteClears(route, b)
+  })
+
+  it("keeps obstacle avoidance when the graph exceeds the directed-state limit", () => {
+    // 22 blockers × two four-corner rings + two endpoints = 178 vertices. The old
+    // overload branch returned the direct chord here, straight through every node.
+    const blockers: StraightRouteObstacle[] = Array.from(
+      { length: 22 },
+      (_, index) => ({
+        id: `block-${index}`,
+        x: 40 + index * 40,
+        y: -10,
+        width: 20,
+        height: 20,
+        soft: false,
+      })
+    )
+    const route = routeStraightPolyline(
+      baseReq({
+        target: { x: 940, y: 0 },
+        obstacles: blockers,
+      })
+    )
+    expect(route.length).toBeGreaterThan(2)
+    expect(route[0]).toEqual({ x: 0, y: 0 })
+    expect(route[route.length - 1]).toEqual({ x: 940, y: 0 })
+    for (const blocker of blockers) expectRouteClears(route, blocker)
+  })
+})
+
+describe("routeStraightPolyline — edge conflicts", () => {
+  const crossingNeighbor: IPoint[] = [
+    { x: 100, y: -80 },
+    { x: 100, y: 80 },
+  ]
+
+  it("opens the visibility graph for a clear chord that crosses another edge", () => {
+    const route = routeStraightPolyline(
+      baseReq({
+        target: { x: 200, y: 0 },
+        neighborRoutes: [crossingNeighbor],
+      })
+    )
+    expect(route.length).toBeGreaterThan(2)
+    expect(routesCrossOpen(route, crossingNeighbor)).toBe(false)
+  })
+
+  it("is independent of the order of conflicting neighbor routes", () => {
+    const diagonal: IPoint[] = [
+      { x: 40, y: 90 },
+      { x: 160, y: -90 },
+    ]
+    const request = {
+      target: { x: 200, y: 0 },
+      neighborRoutes: [crossingNeighbor, diagonal],
+    }
+    const forward = routeStraightPolyline(baseReq(request))
+    const reverse = routeStraightPolyline(
+      baseReq({
+        ...request,
+        neighborRoutes: [...request.neighborRoutes].reverse(),
+      })
+    )
+    expect(reverse).toEqual(forward)
+  })
+})
+
+describe("routeStraightPolyline — checkpoints", () => {
+  it("passes through a checkpoint in order with no obstacles", () => {
+    const route = routeStraightPolyline(
+      baseReq({
+        source: { x: 0, y: 0 },
+        target: { x: 100, y: 0 },
+        checkpoints: [{ x: 50, y: 50 }],
+      })
+    )
+    expect(route).toEqual([
+      { x: 0, y: 0 },
+      { x: 50, y: 50 },
+      { x: 100, y: 0 },
+    ])
+  })
+
+  it("keeps checkpoints as mandatory via-points around an obstacle", () => {
+    const obstacle: StraightRouteObstacle = {
+      id: "block",
+      x: 120,
+      y: -20,
+      width: 40,
+      height: 40,
+      soft: false,
+    }
+    const cp1 = { x: 60, y: 40 }
+    const cp2 = { x: 260, y: 40 }
+    const route = routeStraightPolyline(
+      baseReq({
+        source: { x: 0, y: 0 },
+        target: { x: 320, y: 0 },
+        checkpoints: [cp1, cp2],
+        obstacles: [obstacle],
+      })
+    )
+    // Both checkpoints appear, and in order.
+    const i1 = route.findIndex((p) => p.x === cp1.x && p.y === cp1.y)
+    const i2 = route.findIndex((p) => p.x === cp2.x && p.y === cp2.y)
+    expect(i1).toBeGreaterThanOrEqual(0)
+    expect(i2).toBeGreaterThan(i1)
+    expectRouteClears(route, obstacle)
+  })
+})
+
+describe("routeStraightPolyline — endpoint own-node exemption", () => {
+  it("leaves a node the source sits on instead of being trapped", () => {
+    // Source (0,0) lies on the right edge of its own node body; the node overlaps
+    // the source, so it must be exempt or the edge could never depart.
+    const ownNode: StraightRouteObstacle = {
+      id: "own",
+      x: -50,
+      y: -25,
+      width: 50,
+      height: 50,
+      soft: false,
+    }
+    const route = routeStraightPolyline(
+      baseReq({
+        source: { x: 0, y: 0 },
+        target: { x: 100, y: 0 },
+        obstacles: [ownNode],
+      })
+    )
+    // The obstacle is behind the source, so the straight chord is valid.
+    expect(route).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ])
+  })
+})
+
+describe("chordClearsObstacles", () => {
+  const obstacle: StraightRouteObstacle = {
+    id: "n",
+    x: 40,
+    y: -20,
+    width: 40,
+    height: 40,
+    soft: false,
+  }
+  it("is false when the chord passes through the obstacle", () => {
+    expect(
+      chordClearsObstacles({ x: 0, y: 0 }, { x: 100, y: 0 }, [obstacle], MIN)
+    ).toBe(false)
+  })
+  it("is true when the chord keeps clearance", () => {
+    expect(
+      chordClearsObstacles(
+        { x: 0, y: 200 },
+        { x: 100, y: 200 },
+        [obstacle],
+        MIN
+      )
+    ).toBe(true)
+  })
+  it("ignores soft obstacles", () => {
+    const soft = { ...obstacle, id: "s", soft: true }
+    expect(
+      chordClearsObstacles({ x: 0, y: 0 }, { x: 100, y: 0 }, [soft], MIN)
+    ).toBe(true)
+  })
+})
+
+describe("routeStraightPolyline — determinism under shuffled input", () => {
+  const shuffle = <T>(items: T[], seed: number): T[] => {
+    // Deterministic Fisher–Yates from a tiny LCG — same seed, same permutation.
+    const out = items.slice()
+    let s = seed >>> 0
+    for (let i = out.length - 1; i > 0; i--) {
+      s = (s * 1_664_525 + 1_013_904_223) >>> 0
+      const j = s % (i + 1)
+      ;[out[i], out[j]] = [out[j], out[i]]
+    }
+    return out
+  }
+
+  const obstacles: StraightRouteObstacle[] = [
+    { id: "b1", x: 80, y: -15, width: 40, height: 75, soft: false },
+    { id: "b2", x: 180, y: -60, width: 40, height: 75, soft: false },
+    { id: "b3", x: 130, y: 120, width: 40, height: 40, soft: false },
+    { id: "far", x: 500, y: 500, width: 30, height: 30, soft: false },
+    { id: "soft", x: 40, y: -200, width: 20, height: 100, soft: true },
+  ]
+  const neighbors: IPoint[][] = [
+    [
+      { x: 0, y: -100 },
+      { x: 300, y: 100 },
+    ],
+    [
+      { x: 150, y: -200 },
+      { x: 150, y: 200 },
+    ],
+  ]
+
+  it("produces byte-identical output regardless of obstacle & neighbour order", () => {
+    const reference = routeStraightPolyline(
+      baseReq({
+        source: { x: 0, y: 0 },
+        target: { x: 300, y: 0 },
+        obstacles,
+        neighborRoutes: neighbors,
+      })
+    )
+    for (let seed = 1; seed <= 8; seed++) {
+      const shuffled = routeStraightPolyline(
+        baseReq({
+          source: { x: 0, y: 0 },
+          target: { x: 300, y: 0 },
+          obstacles: shuffle(obstacles, seed),
+          neighborRoutes: shuffle(neighbors, seed * 7 + 1),
+        })
+      )
+      expect(shuffled).toEqual(reference)
+    }
+    expect(reference[0]).toEqual({ x: 0, y: 0 })
+    expect(reference[reference.length - 1]).toEqual({ x: 300, y: 0 })
+    expect(isInteger(reference)).toBe(true)
+  })
+})

--- a/library/tests/unit/straightPolylineRouter.test.ts
+++ b/library/tests/unit/straightPolylineRouter.test.ts
@@ -111,6 +111,25 @@ describe("routeStraightPolyline — empty and gated cases", () => {
     ])
   })
 
+  it("does not bend merely to create preferred clearance around a nearby node", () => {
+    // A visible 2 px gap is not a collision. Using the full 10 px routing margin as
+    // the intervention threshold made this tiny nudge replace a straight edge with
+    // a conspicuous detour.
+    const nearby: StraightRouteObstacle = {
+      id: "nearby",
+      x: 40,
+      y: 2,
+      width: 40,
+      height: 30,
+      soft: false,
+    }
+    const route = routeStraightPolyline(baseReq({ obstacles: [nearby] }))
+    expect(route).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ])
+  })
+
   it("ignores soft obstacles for visibility (never routes around them)", () => {
     const soft: StraightRouteObstacle = {
       id: "pkg",
@@ -150,6 +169,26 @@ describe("routeStraightPolyline — obstacle avoidance", () => {
     expect(route[route.length - 1]).toEqual({ x: 200, y: 0 })
     expect(isInteger(route)).toBe(true)
     expectRouteClears(route, obstacle)
+  })
+
+  it("never exempts a blocker merely because its clearance halo contains the source", () => {
+    const blocker: StraightRouteObstacle = {
+      id: "near-source",
+      x: 5,
+      y: -10,
+      width: 30,
+      height: 20,
+      soft: false,
+    }
+    const route = routeStraightPolyline(baseReq({ obstacles: [blocker] }))
+    expect(route.length).toBeGreaterThan(2)
+    for (let index = 1; index < route.length; index++)
+      expect(crossesRectInterior(route[index - 1], route[index], blocker)).toBe(
+        false
+      )
+    expect(
+      chordClearsObstacles({ x: 0, y: 0 }, { x: 100, y: 0 }, [blocker], MIN)
+    ).toBe(false)
   })
 
   it("threads a two-obstacle corridor, clearing both", () => {
@@ -225,6 +264,37 @@ describe("routeStraightPolyline — edge conflicts", () => {
     )
     expect(route.length).toBeGreaterThan(2)
     expect(routesCrossOpen(route, crossingNeighbor)).toBe(false)
+  })
+
+  it("also avoids structural conflicts with sibling routes", () => {
+    const route = routeStraightPolyline(
+      baseReq({
+        target: { x: 200, y: 0 },
+        siblingRoutes: [crossingNeighbor],
+      })
+    )
+    expect(route.length).toBeGreaterThan(2)
+    expect(routesCrossOpen(route, crossingNeighbor)).toBe(false)
+  })
+
+  it("accepts a readable crossing when avoiding it would require a large excursion", () => {
+    // Apollon renders crossings with a line jump. Crossing should still be costly
+    // enough to avoid cheaply, but not so costly that a 200 px edge travels around
+    // the end of a 240 px neighbour.
+    const longNeighbor: IPoint[] = [
+      { x: 100, y: -120 },
+      { x: 100, y: 120 },
+    ]
+    const route = routeStraightPolyline(
+      baseReq({
+        target: { x: 200, y: 0 },
+        neighborRoutes: [longNeighbor],
+      })
+    )
+    expect(route).toEqual([
+      { x: 0, y: 0 },
+      { x: 200, y: 0 },
+    ])
   })
 
   it("is independent of the order of conflicting neighbor routes", () => {

--- a/library/tests/unit/straightPolylineRouter.test.ts
+++ b/library/tests/unit/straightPolylineRouter.test.ts
@@ -56,24 +56,6 @@ const expectRouteClears = (
 const isInteger = (route: IPoint[]): boolean =>
   route.every((p) => Number.isInteger(p.x) && Number.isInteger(p.y))
 
-const routesCrossOpen = (left: IPoint[], right: IPoint[]): boolean => {
-  const orient = (a: IPoint, b: IPoint, c: IPoint) =>
-    (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
-  for (let i = 1; i < left.length; i++)
-    for (let j = 1; j < right.length; j++) {
-      const a = left[i - 1]
-      const b = left[i]
-      const c = right[j - 1]
-      const d = right[j]
-      if (
-        orient(a, b, c) * orient(a, b, d) < 0 &&
-        orient(c, d, a) * orient(c, d, b) < 0
-      )
-        return true
-    }
-  return false
-}
-
 const baseReq = (
   over: Partial<StraightRouteRequest>
 ): StraightRouteRequest => ({
@@ -81,7 +63,6 @@ const baseReq = (
   target: { x: 100, y: 0 },
   checkpoints: [],
   obstacles: [],
-  neighborRoutes: [],
   clearancePx: CLEAR,
   ...over,
 })
@@ -249,74 +230,6 @@ describe("routeStraightPolyline — obstacle avoidance", () => {
   })
 })
 
-describe("routeStraightPolyline — edge conflicts", () => {
-  const crossingNeighbor: IPoint[] = [
-    { x: 100, y: -80 },
-    { x: 100, y: 80 },
-  ]
-
-  it("opens the visibility graph for a clear chord that crosses another edge", () => {
-    const route = routeStraightPolyline(
-      baseReq({
-        target: { x: 200, y: 0 },
-        neighborRoutes: [crossingNeighbor],
-      })
-    )
-    expect(route.length).toBeGreaterThan(2)
-    expect(routesCrossOpen(route, crossingNeighbor)).toBe(false)
-  })
-
-  it("also avoids structural conflicts with sibling routes", () => {
-    const route = routeStraightPolyline(
-      baseReq({
-        target: { x: 200, y: 0 },
-        siblingRoutes: [crossingNeighbor],
-      })
-    )
-    expect(route.length).toBeGreaterThan(2)
-    expect(routesCrossOpen(route, crossingNeighbor)).toBe(false)
-  })
-
-  it("accepts a readable crossing when avoiding it would require a large excursion", () => {
-    // Apollon renders crossings with a line jump. Crossing should still be costly
-    // enough to avoid cheaply, but not so costly that a 200 px edge travels around
-    // the end of a 240 px neighbour.
-    const longNeighbor: IPoint[] = [
-      { x: 100, y: -120 },
-      { x: 100, y: 120 },
-    ]
-    const route = routeStraightPolyline(
-      baseReq({
-        target: { x: 200, y: 0 },
-        neighborRoutes: [longNeighbor],
-      })
-    )
-    expect(route).toEqual([
-      { x: 0, y: 0 },
-      { x: 200, y: 0 },
-    ])
-  })
-
-  it("is independent of the order of conflicting neighbor routes", () => {
-    const diagonal: IPoint[] = [
-      { x: 40, y: 90 },
-      { x: 160, y: -90 },
-    ]
-    const request = {
-      target: { x: 200, y: 0 },
-      neighborRoutes: [crossingNeighbor, diagonal],
-    }
-    const forward = routeStraightPolyline(baseReq(request))
-    const reverse = routeStraightPolyline(
-      baseReq({
-        ...request,
-        neighborRoutes: [...request.neighborRoutes].reverse(),
-      })
-    )
-    expect(reverse).toEqual(forward)
-  })
-})
-
 describe("routeStraightPolyline — checkpoints", () => {
   it("passes through a checkpoint in order with no obstacles", () => {
     const route = routeStraightPolyline(
@@ -440,24 +353,12 @@ describe("routeStraightPolyline — determinism under shuffled input", () => {
     { id: "far", x: 500, y: 500, width: 30, height: 30, soft: false },
     { id: "soft", x: 40, y: -200, width: 20, height: 100, soft: true },
   ]
-  const neighbors: IPoint[][] = [
-    [
-      { x: 0, y: -100 },
-      { x: 300, y: 100 },
-    ],
-    [
-      { x: 150, y: -200 },
-      { x: 150, y: 200 },
-    ],
-  ]
-
-  it("produces byte-identical output regardless of obstacle & neighbour order", () => {
+  it("produces byte-identical output regardless of obstacle order", () => {
     const reference = routeStraightPolyline(
       baseReq({
         source: { x: 0, y: 0 },
         target: { x: 300, y: 0 },
         obstacles,
-        neighborRoutes: neighbors,
       })
     )
     for (let seed = 1; seed <= 8; seed++) {
@@ -466,7 +367,6 @@ describe("routeStraightPolyline — determinism under shuffled input", () => {
           source: { x: 0, y: 0 },
           target: { x: 300, y: 0 },
           obstacles: shuffle(obstacles, seed),
-          neighborRoutes: shuffle(neighbors, seed * 7 + 1),
         })
       )
       expect(shuffled).toEqual(reference)

--- a/library/tests/unit/straightRoutingPerformance.test.ts
+++ b/library/tests/unit/straightRoutingPerformance.test.ts
@@ -1,0 +1,82 @@
+import { expect, it } from "vitest"
+import {
+  ConnectionMode,
+  Position,
+  type Edge,
+  type InternalNode,
+  type Node,
+} from "@xyflow/react"
+import { computeAllEdgeGeometry } from "@/utils/geometry/edgeGeometrySolver"
+import {
+  STRAIGHT_HOOK_EDGE_TYPES,
+  STRAIGHT_PATH_STEP_EDGE_TYPES,
+} from "@/edges/edgeRoutingBehavior"
+
+it("keeps a crossing-heavy straight scene bounded to node-driven detours", () => {
+  const count = 12
+  const nodes = Array.from({ length: count * 2 }, (_, index) => {
+    const side = index < count ? 0 : 1
+    const slot = index % count
+    const node = {
+      id: `n${index}`,
+      type: "syntaxTreeNonterminal",
+      position: { x: side === 0 ? 220 : 1_020, y: -500 + slot * 140 },
+      width: 120,
+      height: 70,
+      measured: { width: 120, height: 70 },
+      data: {},
+    } as Node
+    const internal = {
+      ...node,
+      internals: {
+        positionAbsolute: node.position,
+        handleBounds: {
+          source: [
+            {
+              id: null,
+              type: "source",
+              position: Position.Right,
+              x: 120,
+              y: 35,
+              width: 1,
+              height: 1,
+            },
+          ],
+          target: [
+            {
+              id: null,
+              type: "target",
+              position: Position.Left,
+              x: 0,
+              y: 35,
+              width: 1,
+              height: 1,
+            },
+          ],
+        },
+      },
+    } as unknown as InternalNode
+    return { node, internal }
+  })
+  const edges: Edge[] = Array.from({ length: count }, (_, index) => ({
+    id: `e${index}`,
+    source: `n${index}`,
+    target: `n${count + count - 1 - index}`,
+    type: "SyntaxTreeLink",
+    data: { points: [] },
+  }))
+  const result = computeAllEdgeGeometry({
+    nodes: nodes.map(({ node }) => node),
+    nodeLookup: new Map(nodes.map(({ node, internal }) => [node.id, internal])),
+    connectionMode: ConnectionMode.Loose,
+    edges,
+    straightPathTypes: STRAIGHT_PATH_STEP_EDGE_TYPES,
+    straightHookTypes: STRAIGHT_HOOK_EDGE_TYPES,
+  })
+  expect(Object.keys(result.routeById)).toHaveLength(count)
+  const segmentCounts = Object.values(result.routeById).map(
+    (route) => route.length - 1
+  )
+  expect(segmentCounts).toContain(1)
+  expect(Math.max(...segmentCounts)).toBeLessThanOrEqual(3)
+})

--- a/library/tests/unit/tidyForest.test.ts
+++ b/library/tests/unit/tidyForest.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest"
+import type { Node, Edge } from "@xyflow/react"
+import { buildSyntaxTreeForest } from "@/utils/tidyTree/buildForest"
+import { computeTidyLayout } from "@/utils/tidyTree/applyTidyLayout"
+
+const stNode = (
+  id: string,
+  x: number,
+  y: number,
+  extra: Partial<Node> = {}
+): Node => ({
+  id,
+  type: "syntaxTreeNonterminal",
+  position: { x, y },
+  data: {},
+  measured: { width: 60, height: 40 },
+  ...extra,
+})
+
+const link = (source: string, target: string): Edge => ({
+  id: `${source}->${target}`,
+  source,
+  target,
+  type: "SyntaxTreeLink",
+})
+
+const idSet = (nodes: Node[]): Set<string> => new Set(nodes.map((n) => n.id))
+
+describe("buildSyntaxTreeForest", () => {
+  it("lays out every clean root of a three-tree forest, dropping nothing", () => {
+    const nodes = [
+      stNode("r1", 0, 0),
+      stNode("r1c", 0, 100),
+      stNode("r2", 300, 0),
+      stNode("r2c", 300, 100),
+      stNode("r3", 600, 0),
+      stNode("r3c", 600, 100),
+    ]
+    const edges = [link("r1", "r1c"), link("r2", "r2c"), link("r3", "r3c")]
+    const forest = buildSyntaxTreeForest(nodes, edges)
+
+    expect(forest.roots.sort()).toEqual(["r1", "r2", "r3"])
+    expect(forest.laidOut.size).toBe(6)
+    expect(forest.skipped.size).toBe(0)
+  })
+
+  it("skips a multi-parent node and its whole subtree, leaving them unchanged", () => {
+    const nodes = [
+      stNode("p1", 0, 0),
+      stNode("p2", 200, 0),
+      stNode("c", 100, 100),
+      stNode("gc", 100, 200),
+    ]
+    const edges = [link("p1", "c"), link("p2", "c"), link("c", "gc")]
+    const forest = buildSyntaxTreeForest(nodes, edges)
+
+    expect(forest.skipped.has("c")).toBe(true)
+    expect(forest.skipped.has("gc")).toBe(true)
+    expect(forest.laidOut.has("c")).toBe(false)
+    expect(forest.laidOut.has("gc")).toBe(false)
+
+    const out = computeTidyLayout(nodes, edges)
+    const byId = new Map(out.map((n) => [n.id, n]))
+    // Skipped nodes keep their exact object (position untouched).
+    expect(byId.get("c")).toBe(nodes[2])
+    expect(byId.get("gc")).toBe(nodes[3])
+  })
+
+  it("skips a directed cycle and returns its nodes by reference", () => {
+    const nodes = [stNode("a", 0, 0), stNode("b", 100, 0), stNode("c", 200, 0)]
+    const edges = [link("a", "b"), link("b", "c"), link("c", "a")]
+    const forest = buildSyntaxTreeForest(nodes, edges)
+
+    expect(forest.roots).toEqual([])
+    expect(forest.laidOut.size).toBe(0)
+    expect(forest.skipped).toEqual(new Set(["a", "b", "c"]))
+
+    const out = computeTidyLayout(nodes, edges)
+    out.forEach((n, i) => expect(n).toBe(nodes[i]))
+  })
+
+  it("ignores non-syntax nodes and non-syntax edges entirely", () => {
+    const nodes = [
+      stNode("r", 0, 0),
+      stNode("rc", 0, 100),
+      { ...stNode("box", 500, 500), type: "package" } as Node,
+      { ...stNode("cls", 700, 700), type: "class" } as Node,
+    ]
+    const edges = [
+      link("r", "rc"),
+      { id: "assoc", source: "box", target: "cls", type: "ClassLink" } as Edge,
+    ]
+    const forest = buildSyntaxTreeForest(nodes, edges)
+
+    expect(forest.laidOut).toEqual(new Set(["r", "rc"]))
+    expect(forest.skipped.size).toBe(0)
+
+    const out = computeTidyLayout(nodes, edges)
+    const byId = new Map(out.map((n) => [n.id, n]))
+    // The non-syntax nodes are returned untouched, by reference.
+    expect(byId.get("box")).toBe(nodes[2])
+    expect(byId.get("cls")).toBe(nodes[3])
+  })
+})
+
+describe("computeTidyLayout", () => {
+  it("preserves the node count and id set", () => {
+    const nodes = [
+      stNode("r", 0, 0),
+      stNode("a", -50, 100),
+      stNode("b", 50, 100),
+      { ...stNode("other", 900, 900), type: "package" } as Node,
+    ]
+    const edges = [link("r", "a"), link("r", "b")]
+    const out = computeTidyLayout(nodes, edges)
+
+    expect(out.length).toBe(nodes.length)
+    expect(idSet(out)).toEqual(idSet(nodes))
+  })
+
+  it("keeps the root pinned and writes container-relative child positions", () => {
+    const container = {
+      id: "container",
+      type: "package",
+      position: { x: 500, y: 400 },
+      data: {},
+      measured: { width: 400, height: 400 },
+    } as Node
+    const nodes = [
+      container,
+      stNode("root", 10, 10, { parentId: "container" }),
+      stNode("child", 200, 10, { parentId: "container" }),
+    ]
+    const edges = [link("root", "child")]
+    const out = computeTidyLayout(nodes, edges)
+    const byId = new Map(out.map((n) => [n.id, n]))
+
+    // Root does not move (returned by reference).
+    expect(byId.get("root")).toBe(nodes[1])
+    // Child sits one level below the root: canvas y = rootCanvasY + h + levelGap
+    // = 410 + 40 + 60 = 510, minus the container origin (400) => 110 relative.
+    // Centred under the equal-width root: canvas x = 510, minus 500 => 10.
+    expect(byId.get("child")!.position).toEqual({ x: 10, y: 110 })
+  })
+
+  it("marks a cross-container link's deeper node as skipped", () => {
+    const container = {
+      id: "container",
+      type: "package",
+      position: { x: 500, y: 500 },
+      data: {},
+      measured: { width: 300, height: 300 },
+    } as Node
+    const nodes = [
+      container,
+      stNode("outer", 0, 0),
+      stNode("inner", 10, 10, { parentId: "container" }),
+    ]
+    const edges = [link("outer", "inner")]
+    const forest = buildSyntaxTreeForest(nodes, edges)
+
+    expect(forest.skipped.has("inner")).toBe(true)
+    expect(forest.laidOut.has("inner")).toBe(false)
+  })
+
+  it("is idempotent: re-laying-out a tidy tree returns nodes by reference", () => {
+    const nodes = [
+      stNode("r", 0, 0),
+      stNode("a", -80, 100),
+      stNode("b", 80, 100),
+      stNode("a1", -120, 200),
+      stNode("a2", -40, 200),
+    ]
+    const edges = [
+      link("r", "a"),
+      link("r", "b"),
+      link("a", "a1"),
+      link("a", "a2"),
+    ]
+    const first = computeTidyLayout(nodes, edges)
+    const second = computeTidyLayout(first, edges)
+
+    // A second pass over an already-tidy tree moves nothing.
+    second.forEach((n, i) => expect(n).toBe(first[i]))
+    for (let i = 0; i < first.length; i++) {
+      expect(second[i].position).toEqual(first[i].position)
+    }
+  })
+})

--- a/library/tests/unit/tidyTree.test.ts
+++ b/library/tests/unit/tidyTree.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from "vitest"
+import {
+  layoutTidyTree,
+  type TidyNodeInput,
+  type TidyOptions,
+  type TidyPosition,
+} from "@/utils/tidyTree/tidyTree"
+
+const OPTS: TidyOptions = {
+  siblingGap: 30,
+  subtreeGap: 20,
+  levelGap: 60,
+  gridSnap: 5,
+}
+
+/** Build a `nodesById` map from a flat list of node specs. */
+const toMap = (
+  specs: ReadonlyArray<TidyNodeInput>
+): Map<string, TidyNodeInput> => {
+  const map = new Map<string, TidyNodeInput>()
+  for (const spec of specs) map.set(spec.id, spec)
+  return map
+}
+
+const node = (
+  id: string,
+  width: number,
+  height: number,
+  childIds: string[] = []
+): TidyNodeInput => ({ id, width, height, childIds })
+
+const centerX = (pos: TidyPosition, spec: TidyNodeInput): number =>
+  pos.x + spec.width / 2
+
+const requiredSeparation = (
+  left: TidyNodeInput,
+  right: TidyNodeInput
+): number => left.width / 2 + OPTS.siblingGap + right.width / 2
+
+describe("layoutTidyTree", () => {
+  it("places a single node at the normalised origin", () => {
+    const specs = [node("a", 160, 100)]
+    const layout = layoutTidyTree(["a"], toMap(specs), OPTS)
+    expect(layout.get("a")).toEqual({ x: 0, y: 0 })
+  })
+
+  it("lays out a balanced binary tree symmetrically with no sibling overlap", () => {
+    const specs = [
+      node("r", 60, 40, ["l", "rr"]),
+      node("l", 60, 40, ["ll", "lr"]),
+      node("rr", 60, 40, ["rl", "rrr"]),
+      node("ll", 60, 40),
+      node("lr", 60, 40),
+      node("rl", 60, 40),
+      node("rrr", 60, 40),
+    ]
+    const map = toMap(specs)
+    const layout = layoutTidyTree(["r"], map, OPTS)
+
+    const c = (id: string) => centerX(layout.get(id)!, map.get(id)!)
+
+    // Depth 1 siblings clear the required separation.
+    expect(c("rr") - c("l")).toBeGreaterThanOrEqual(
+      requiredSeparation(map.get("l")!, map.get("rr")!)
+    )
+    // Depth 2 sibling pairs likewise.
+    expect(c("lr") - c("ll")).toBeGreaterThanOrEqual(
+      requiredSeparation(map.get("ll")!, map.get("lr")!)
+    )
+    expect(c("rrr") - c("rl")).toBeGreaterThanOrEqual(
+      requiredSeparation(map.get("rl")!, map.get("rrr")!)
+    )
+
+    // Symmetry: the tree is a mirror image about the root's centre.
+    const root = c("r")
+    expect(c("rr") - root).toBeCloseTo(root - c("l"), 6)
+    expect(c("rl") - root).toBeCloseTo(root - c("lr"), 6)
+    expect(c("rrr") - root).toBeCloseTo(root - c("ll"), 6)
+  })
+
+  it("draws a mirror-symmetric tree symmetrically", () => {
+    // The classic parse-tree shape: a root over a deep middle spine with matching
+    // subtrees either side. Reflecting the input must reflect the output — the
+    // "identical subtrees are drawn identically" aesthetic Reingold–Tilford
+    // guarantees, and the property a reader perceives as the drawing being tidy.
+    const specs = [
+      node("root", 70, 50, ["l", "m", "r"]),
+      node("l", 70, 50, ["lc"]),
+      node("lc", 70, 50, []),
+      node("m", 70, 50, ["mc"]),
+      node("mc", 70, 50, []),
+      node("r", 70, 50, ["rc"]),
+      node("rc", 70, 50, []),
+    ]
+    const map = toMap(specs)
+    const layout = layoutTidyTree(["root"], map, OPTS)
+    const cx = (id: string) => centerX(layout.get(id)!, map.get(id)!)
+
+    // The root and the middle spine share one axis.
+    const axis = cx("root")
+    expect(cx("m")).toBe(axis)
+    expect(cx("mc")).toBe(axis)
+    // Each flanking subtree is the reflection of its partner about that axis.
+    expect(axis - cx("l")).toBe(cx("r") - axis)
+    expect(axis - cx("lc")).toBe(cx("rc") - axis)
+    // Matching depths share a row.
+    expect(layout.get("l")!.y).toBe(layout.get("r")!.y)
+    expect(layout.get("lc")!.y).toBe(layout.get("rc")!.y)
+  })
+
+  it("keeps an odd fan symmetric about its parent", () => {
+    const specs = [
+      node("p", 70, 50, ["a", "b", "c", "d", "e"]),
+      node("a", 50, 50),
+      node("b", 50, 50),
+      node("c", 50, 50),
+      node("d", 50, 50),
+      node("e", 50, 50),
+    ]
+    const map = toMap(specs)
+    const layout = layoutTidyTree(["p"], map, OPTS)
+    const axis = centerX(layout.get("p")!, map.get("p")!)
+    const centres = ["a", "b", "c", "d", "e"].map((id) =>
+      centerX(layout.get(id)!, map.get(id)!)
+    )
+    // Middle child under the parent; outer pairs equidistant; even spacing.
+    expect(centres[2]).toBe(axis)
+    expect(axis - centres[0]).toBe(centres[4] - axis)
+    expect(axis - centres[1]).toBe(centres[3] - axis)
+    const gaps = centres.slice(1).map((c, i) => c - centres[i])
+    expect(new Set(gaps).size).toBe(1)
+  })
+
+  it("centres an n-ary parent over its children", () => {
+    const specs = [
+      node("p", 60, 40, ["a", "b", "c", "d"]),
+      node("a", 60, 40),
+      node("b", 60, 40),
+      node("c", 60, 40),
+      node("d", 60, 40),
+    ]
+    const map = toMap(specs)
+    const layout = layoutTidyTree(["p"], map, OPTS)
+    const c = (id: string) => centerX(layout.get(id)!, map.get(id)!)
+
+    const childrenMidpoint = (c("a") + c("d")) / 2
+    expect(Math.abs(c("p") - childrenMidpoint)).toBeLessThanOrEqual(
+      OPTS.gridSnap
+    )
+
+    // Children are evenly spaced and non-overlapping.
+    for (const [left, right] of [
+      ["a", "b"],
+      ["b", "c"],
+      ["c", "d"],
+    ] as const) {
+      expect(c(right) - c(left)).toBeGreaterThanOrEqual(
+        requiredSeparation(map.get(left)!, map.get(right)!)
+      )
+    }
+  })
+
+  it("pushes siblings apart around a wide-label child (#282 guard)", () => {
+    const specs = [
+      node("p", 60, 40, ["a", "wide", "c"]),
+      node("a", 60, 40),
+      node("wide", 400, 40),
+      node("c", 60, 40),
+    ]
+    const map = toMap(specs)
+    const layout = layoutTidyTree(["p"], map, OPTS)
+    const c = (id: string) => centerX(layout.get(id)!, map.get(id)!)
+
+    // No bounding-box overlap on either side of the wide child.
+    expect(c("wide") - c("a")).toBeGreaterThanOrEqual(
+      map.get("a")!.width / 2 + map.get("wide")!.width / 2
+    )
+    expect(c("c") - c("wide")).toBeGreaterThanOrEqual(
+      map.get("wide")!.width / 2 + map.get("c")!.width / 2
+    )
+    // And the full separation clearance is honoured.
+    expect(c("wide") - c("a")).toBeGreaterThanOrEqual(
+      requiredSeparation(map.get("a")!, map.get("wide")!)
+    )
+    expect(c("c") - c("wide")).toBeGreaterThanOrEqual(
+      requiredSeparation(map.get("wide")!, map.get("c")!)
+    )
+  })
+
+  it("stacks a deep skewed chain with no cross-level overlap", () => {
+    const specs = [
+      node("n0", 60, 40, ["n1"]),
+      node("n1", 60, 40, ["n2"]),
+      node("n2", 60, 40, ["n3"]),
+      node("n3", 60, 40, ["n4"]),
+      node("n4", 60, 40),
+    ]
+    const map = toMap(specs)
+    const layout = layoutTidyTree(["n0"], map, OPTS)
+
+    for (let d = 1; d <= 4; d++) {
+      const parent = layout.get(`n${d - 1}`)!
+      const child = layout.get(`n${d}`)!
+      expect(child.y - parent.y).toBeGreaterThanOrEqual(
+        map.get(`n${d - 1}`)!.height + OPTS.levelGap
+      )
+    }
+  })
+
+  it("is deterministic and produces integer, grid-snapped coordinates", () => {
+    const specs = [
+      node("r", 90, 50, ["a", "b"]),
+      node("a", 70, 40, ["a1", "a2", "a3"]),
+      node("b", 120, 40, ["b1"]),
+      node("a1", 60, 40),
+      node("a2", 60, 40),
+      node("a3", 60, 40),
+      node("b1", 200, 40),
+    ]
+    const map = toMap(specs)
+    const first = layoutTidyTree(["r"], map, OPTS)
+    const second = layoutTidyTree(["r"], map, OPTS)
+
+    expect([...second.entries()].sort()).toEqual([...first.entries()].sort())
+
+    for (const pos of first.values()) {
+      expect(Number.isInteger(pos.x)).toBe(true)
+      expect(Number.isInteger(pos.y)).toBe(true)
+      expect(pos.x % OPTS.gridSnap).toBe(0)
+      expect(pos.y % OPTS.gridSnap).toBe(0)
+    }
+  })
+
+  it("normalises a forest so the minimum x and y are 0", () => {
+    const specs = [
+      node("r1", 60, 40, ["r1a"]),
+      node("r1a", 60, 40),
+      node("r2", 60, 40),
+    ]
+    const layout = layoutTidyTree(["r1", "r2"], toMap(specs), OPTS)
+    const minX = Math.min(...[...layout.values()].map((p) => p.x))
+    const minY = Math.min(...[...layout.values()].map((p) => p.y))
+    expect(minX).toBe(0)
+    expect(minY).toBe(0)
+  })
+})

--- a/standalone/webapp/tests/e2e/edge-ghost-preview.spec.ts
+++ b/standalone/webapp/tests/e2e/edge-ghost-preview.spec.ts
@@ -219,18 +219,29 @@ test("a straight-edge ghost preserves the exact native target handle", async ({
     x: sourceBox.x + sourceBox.width / 2,
     y: sourceBox.y + sourceBox.height / 2,
   }
-  const drop = {
+  const targetCenter = {
     x: targetBox.x + targetBox.width / 2,
     y: targetBox.y + targetBox.height / 2,
   }
+  // Release well off-centre but still inside the native handle. React Flow's
+  // validated target is the handle centre; the raw pointer must not shift the
+  // persisted anchor away from what the ghost previews.
+  const releaseInsideHandle = {
+    x: targetBox.x + targetBox.width * 0.2,
+    y: targetBox.y + targetBox.height * 0.8,
+  }
   await page.mouse.move(start.x, start.y)
   await page.mouse.down()
-  await page.mouse.move(drop.x, drop.y, { steps: 16 })
+  await page.mouse.move(releaseInsideHandle.x, releaseInsideHandle.y, {
+    steps: 16,
+  })
 
   await expect
     .poll(async () => {
       const end = (await ghost(page)).end
-      return end ? Math.hypot(end.x - drop.x, end.y - drop.y) : Infinity
+      return end
+        ? Math.hypot(end.x - targetCenter.x, end.y - targetCenter.y)
+        : Infinity
     })
     .toBeLessThanOrEqual(2)
   const previewEnd = (await ghost(page)).end!
@@ -246,7 +257,6 @@ test("a straight-edge ghost preserves the exact native target handle", async ({
     const model = parsed.state.models[parsed.state.currentModelId]?.model
     return model?.edges?.[0]?.targetHandle
   })
-
   expect(storedTargetHandle).toBe("left-top")
   expect(
     Math.hypot(previewEnd.x - committedEnd.x, previewEnd.y - committedEnd.y)

--- a/standalone/webapp/tests/perf/straight-routing.spec.ts
+++ b/standalone/webapp/tests/perf/straight-routing.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test"
+import {
+  dragNodeBy,
+  loadFixture,
+  openLocalWithPerf,
+  readPerf,
+} from "./perfHelpers"
+
+test.describe.configure({ mode: "serial" })
+
+const MAX_P95_INTERACTION_FRAME_MS = 40
+const MAX_STRAIGHT_SOLVE_MS = 500
+
+test("dense straight-edge crossings stay responsive and node-driven", async ({
+  page,
+}) => {
+  const base = loadFixture("syntax-tree.json")
+  const sideCount = 12
+  const nodes = Array.from({ length: sideCount * 2 }, (_, index) => {
+    const side = index < sideCount ? 0 : 1
+    const slot = index % sideCount
+    return {
+      id: `cross-node-${index}`,
+      width: 120,
+      height: 70,
+      measured: { width: 120, height: 70 },
+      type: "syntaxTreeNonterminal",
+      position: {
+        x: side === 0 ? 220 : 1_020,
+        y: -500 + slot * 140,
+      },
+      data: { name: `N${index}` },
+    }
+  })
+  const edges = Array.from({ length: sideCount }, (_, index) => ({
+    id: `cross-edge-${index}`,
+    source: `cross-node-${index}`,
+    target: `cross-node-${sideCount + sideCount - 1 - index}`,
+    type: "SyntaxTreeLink",
+    data: { points: [] },
+  }))
+  const fixture = {
+    ...base,
+    id: "straight-routing-crossing-performance",
+    nodes,
+    edges,
+  }
+  await openLocalWithPerf(page, fixture)
+
+  const editor = page.locator(`#react-flow-library-${fixture.id}`)
+  const node = editor.locator('.react-flow__node[data-id="cross-node-5"]')
+  const before = await readPerf(page, true)
+  const frames = await dragNodeBy(node, page, 180, 90, {
+    steps: 30,
+    measureFrames: true,
+  })
+  const after = await readPerf(page, true)
+  const sorted = [...frames].sort((a, b) => a - b)
+  const p95 = sorted[Math.floor(sorted.length * 0.95)] ?? 0
+
+  expect(
+    after.workerSmallSyncCount - before.workerSmallSyncCount,
+    "a small straight-edge drag fell back to whole-diagram main-thread solves"
+  ).toBe(0)
+  expect(
+    after.workerSolveCount - before.workerSolveCount,
+    "the straight-edge interaction never reached the routing Worker"
+  ).toBeGreaterThan(0)
+  expect(
+    after.solveMaxMs,
+    "one straight-edge solve is paying for edge crossings as graph obstacles"
+  ).toBeLessThan(MAX_STRAIGHT_SOLVE_MS)
+  expect(p95, `straight-edge drag p95 was ${p95.toFixed(1)} ms`).toBeLessThan(
+    MAX_P95_INTERACTION_FRAME_MS
+  )
+})

--- a/standalone/webapp/tests/perf/straight-routing.spec.ts
+++ b/standalone/webapp/tests/perf/straight-routing.spec.ts
@@ -8,7 +8,7 @@ import {
 
 test.describe.configure({ mode: "serial" })
 
-const MAX_P95_INTERACTION_FRAME_MS = 40
+const MAX_P95_INTERACTION_FRAME_MS = 34
 const MAX_STRAIGHT_SOLVE_MS = 500
 
 test("dense straight-edge crossings stay responsive and node-driven", async ({
@@ -50,13 +50,21 @@ test("dense straight-edge crossings stay responsive and node-driven", async ({
   const editor = page.locator(`#react-flow-library-${fixture.id}`)
   const node = editor.locator('.react-flow__node[data-id="cross-node-5"]')
   const before = await readPerf(page, true)
-  const frames = await dragNodeBy(node, page, 180, 90, {
-    steps: 30,
-    measureFrames: true,
-  })
+  const frames: number[] = []
+  // Aggregate several real gestures, as the established large-diagram frame
+  // budget does. A single 30-step gesture has too few samples for p95: one
+  // scheduler hiccup can move the selected order statistic by a whole frame.
+  for (let gesture = 0; gesture < 4; gesture++)
+    frames.push(
+      ...(await dragNodeBy(node, page, 45, gesture % 2 === 0 ? 24 : 21, {
+        steps: 12,
+        measureFrames: true,
+      }))
+    )
   const after = await readPerf(page, true)
   const sorted = [...frames].sort((a, b) => a - b)
-  const p95 = sorted[Math.floor(sorted.length * 0.95)] ?? 0
+  expect(sorted.length).toBeGreaterThan(20)
+  const p95 = sorted[Math.ceil(sorted.length * 0.95) - 1] ?? 0
 
   expect(
     after.workerSmallSyncCount - before.workerSmallSyncCount,


### PR DESCRIPTION
### Summary

This PR adds automatic routing for straight-edge diagram families and a tidy
layout for syntax trees:

- Clear connections stay straight. A connection reroutes only when it actually
  meets a node; connector crossings keep the existing line-jump presentation.
- Necessary detours keep breathing room around nodes, favor short and gentle
  paths, and never replace a readable crossing with a disproportionate trip
  around the diagram.
- Connections choose facing sides and spread sibling endpoints across shared
  borders instead of stacking on one point.
- Hand-placed routes remain exactly as drawn. Automatic bends are derived and
  never written into the diagram model.
- Syntax trees gain a **Tidy tree layout** toolbar action and the additive
  `ApollonEditor.layoutSyntaxTree()` API.

The branch is rebased directly onto the current `main`, which includes the
straight-edge editing work from #834.

Follow-up to the node-overlap report in #282, which was closed by the manual
straight-edge editing work in #834. Long-text wrapping is outside this PR and is
not claimed as fixed.

### Why this is intentionally conservative

Automatic routing should help without making a diagram feel restless:

- The direct line has a 1 px collision guard, while a generated detour receives
  the full 10 px minimum clearance. A nearby node therefore does not trigger a
  route change just because it enters the preferred clearance halo.
- Other connections do not become routing obstacles. Crossings therefore remain
  direct and predictable, while the existing line jumps preserve readability.
- A 5% deterministic endpoint-side deadband prevents small movements near a
  node corner from flipping the connection to another side.
- While a node is moving, its valid straight-edge topology is kept for the full
  gesture. It changes immediately only if keeping it would cross a node, then
  settles to the exact route on release.
- Node drags involving straight connections use the routing worker even in small
  diagrams. The display-only handoff preserves diagonal polylines instead of
  briefly turning them into step edges.

### Compatibility and failure behavior

- Existing hand-authored straight routes bypass automatic obstacle routing.
- Existing orthogonal routing is unchanged.
- Native-handle previews and commits use the same validated handle point, even
  when the pointer is off-center or nodes overlap.
- Tidy layout is one undoable operation. Valid trees and forests are arranged;
  cyclic, multi-parent, and otherwise malformed components stay where the user
  placed them.
- The toolbar waits for controlled node positions to reach React Flow and then
  performs the same inset-aware fit as the public API.
- `layoutSyntaxTree()` is additive and is a no-op for other diagram types.

### Release note

Keep straight connections clear, stable, and responsive automatically. They now
choose facing sides, spread sibling links across shared borders, and route around
nodes without reorganizing when other connections cross them; clear shots remain
straight and hand-placed routes stay exactly as drawn. Syntax trees also gain a
one-click tidy layout that arranges valid parent-child forests while leaving
malformed portions untouched.

### Implementation notes

- Routing uses a deterministic, integer-based visibility graph and A* search,
  including deterministic tie-breaking.
- The visibility graph starts with obstacles that block the direct route, adds
  newly relevant node bodies locally, and has a bounded full-field fallback.
- Third-party node bodies are never exempted when an endpoint starts inside
  their clearance halo.
- Coordinated endpoint seats keep straight-edge fans evenly distributed.
- In a new crossing-heavy 12-edge Chromium regression fixture, local profiling
  reduced the worst solve from 2,629.7 ms to 20.5 ms. This is a regression
  fixture result, not a general-purpose benchmark.
- Bundle cost remains explicit and within the existing budgets:
  - main entry: 125.72 kB / 126 kB
  - routing worker: 41.45 kB / 44 kB
  - model chunk: 5.08 kB / 8 kB
  - export chunk: 413.41 kB / 700 kB

### Steps for testing

1. Open a crowded use-case, syntax-tree, or Petri-net diagram and confirm that
   straight connections avoid intervening nodes.
2. Move a node close to a clear connection without touching it; the edge should
   remain straight. Move it into the line; the edge should take a compact,
   well-cleared detour.
3. Move a node repeatedly near an endpoint-side boundary and confirm the edge
   does not jump sides on small movements.
4. Create sibling connections and confirm their endpoints fan out. Cross two
   connections and confirm they remain direct and use the existing line jump.
5. Add or move a manual bend, then place a node over that route. The authored
   route should remain exactly as drawn.
6. Drop a connection off-center within a native handle and confirm the committed
   endpoint exactly matches the preview.
7. Apply **Tidy tree layout** to a valid forest and confirm one-step undo and an
   inset-aware fit. Repeat with cyclic or multi-parent content and confirm the
   malformed components are not rearranged.
8. Call `ApollonEditor.layoutSyntaxTree()` on a syntax tree and on another
   diagram type; confirm layout in the former and a no-op in the latter.

### Verification

- `pnpm lint && pnpm format:check && pnpm build && pnpm test`
  - 95 test files passed
  - 1,860 tests passed; 1 skipped
- Fresh production-build Chromium interaction run:
  - 17/17 targeted connection and straight-edge UX tests passed
- Fresh production-build crossing-heavy performance regression:
  - passed 5/5 Chromium runs and 5/5 Firefox runs at the 34 ms p95 frame budget
- `pnpm --filter @tumaet/apollon size`
  - all four published bundle budgets passed

### Screenshots / screencasts

![A syntax tree after applying the tidy tree layout, with a balanced hierarchy and clear straight connections](https://raw.githubusercontent.com/ls1intum/Apollon/pr-834-835-assets/docs/static/img/pr-assets/straight-routing-tidy-layout.png)

Captured from this branch's production build after choosing **Tidy tree layout**.
Deterministic geometry fixtures cover route quality and failure cases beyond this
representative diagram.

### Checklist

- [x] Linked the applicable portion of #282
- [x] Added a user-facing changeset
- [x] Used a Conventional Commit PR title matching the user-visible feature
- [x] Added unit and browser interaction coverage
- [x] Passed the complete local pre-PR gate
- [x] Kept published bundles within their documented budgets
- [x] Documented the additive public API inline
- [x] Included a representative screenshot
