### PR TITLE
fix(library): keep floating editor surfaces visible in fullscreen

### DIFF
--- a/.changeset/bright-portals-float.md
+++ b/.changeset/bright-portals-float.md
@@ -1,0 +1,5 @@
+---
+"@tumaet/apollon": patch
+---
+
+Popovers, selects, tooltips, color pickers, and drag previews remain visible and interactive when an embedded editor enters fullscreen.

--- a/library/lib/App.tsx
+++ b/library/lib/App.tsx
@@ -62,6 +62,10 @@ import {
 } from "@/components/collaboration/CollaborationLayer"
 import { TooltipProvider } from "@/components/ui"
 import { EdgeGeometrySolver } from "@/components/EdgeGeometrySolver"
+import {
+  ApollonPortalContainerProvider,
+  ApollonPortalRoot,
+} from "@/components/ui/portalContainer"
 
 interface AppProps {
   onReactFlowInit: (instance: ReactFlowInstance) => void
@@ -271,6 +275,7 @@ function App({
           <ScrollOverlay />
           <CollaborationLayer options={collaboration} awareness={awareness} />
         </div>
+        <ApollonPortalRoot />
       </div>
     </TooltipProvider>
   )
@@ -279,7 +284,9 @@ function App({
 export function AppWithProvider(props: AppProps) {
   return (
     <ReactFlowProvider>
-      <App {...props} />
+      <ApollonPortalContainerProvider>
+        <App {...props} />
+      </ApollonPortalContainerProvider>
     </ReactFlowProvider>
   )
 }

--- a/library/lib/components/DraggableGhost.tsx
+++ b/library/lib/components/DraggableGhost.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom"
 import { useReactFlow, type XYPosition } from "@xyflow/react"
 import { useMetadataStore } from "@/store/context"
 import { resolveApollonThemeVars } from "@/components/ui/portalTheme"
+import { useApollonPortalContainer } from "@/components/ui/portalContainer"
 import { useShallow } from "zustand/shallow"
 import { usePalettePlacement } from "@/hooks/usePalettePlacement"
 
@@ -63,6 +64,7 @@ export const DraggableGhost: React.FC<DraggableGhostProps> = ({
       nodeTypeLabel: state.labels.nodeTypeLabel,
     }))
   )
+  const portalContainer = useApollonPortalContainer()
 
   const [isDragging, setIsDragging] = useState(false)
   const [ghostPosition, setGhostPosition] = useState({ x: 0, y: 0 })
@@ -281,7 +283,7 @@ export const DraggableGhost: React.FC<DraggableGhostProps> = ({
       >
         {children}
       </button>
-      {isDragging && createPortal(ghostElement, document.body)}
+      {isDragging && createPortal(ghostElement, portalContainer)}
     </>
   )
 }

--- a/library/lib/components/popovers/GenericPopover.tsx
+++ b/library/lib/components/popovers/GenericPopover.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from "react"
 import { Popover } from "@base-ui/react/popover"
 import { PopoverOrigin } from "@/types"
 import { usePortalThemeVars } from "@/components/ui/portalTheme"
+import { useApollonPortalContainer } from "@/components/ui/portalContainer"
 
 interface GenericPopoverProps {
   id: string
@@ -54,6 +55,7 @@ export const GenericPopover: React.FC<GenericPopoverProps> = ({
   const popoverThemeVars = usePortalThemeVars(
     anchorEl instanceof Element ? anchorEl : null
   )
+  const portalContainer = useApollonPortalContainer()
 
   const { side, align } = toSideAlign(transformOrigin)
 
@@ -66,7 +68,7 @@ export const GenericPopover: React.FC<GenericPopoverProps> = ({
         if (!next) onClose()
       }}
     >
-      <Popover.Portal>
+      <Popover.Portal container={portalContainer}>
         {anchorEl && (
           <Popover.Positioner
             anchor={anchorEl}

--- a/library/lib/components/popovers/TagPicker.tsx
+++ b/library/lib/components/popovers/TagPicker.tsx
@@ -3,6 +3,7 @@ import { Check, Plus, Tag, X } from "lucide-react"
 import { Popover } from "@base-ui/react/popover"
 import { IconButton, Tooltip } from "@/components/ui"
 import { usePortalThemeVars } from "@/components/ui/portalTheme"
+import { useApollonPortalContainer } from "@/components/ui/portalContainer"
 import { useLabels } from "@/i18n/useLabels"
 import { useTagConfig } from "@/hooks/useTagConfig"
 import { normalizeTags } from "@/utils"
@@ -68,6 +69,7 @@ export const TagPicker: React.FC<TagControlProps> = ({
   const [draft, setDraft] = useState("")
   const [trigger, setTrigger] = useState<HTMLElement | null>(null)
   const portalThemeVars = usePortalThemeVars(trigger)
+  const portalContainer = useApollonPortalContainer()
 
   if (!enabled) return null
 
@@ -105,7 +107,7 @@ export const TagPicker: React.FC<TagControlProps> = ({
           <Tag width={16} height={16} aria-hidden="true" />
         </Popover.Trigger>
       </Tooltip>
-      <Popover.Portal>
+      <Popover.Portal container={portalContainer}>
         <Popover.Positioner sideOffset={6} align="start">
           <Popover.Popup
             data-slot="tag-picker-content"

--- a/library/lib/components/styleEditor/ColorButtons.tsx
+++ b/library/lib/components/styleEditor/ColorButtons.tsx
@@ -9,6 +9,7 @@ import {
   SWATCH_NAMES,
 } from "@tumaet/ui/lib/color-swatch-tokens"
 import { usePortalThemeVars } from "@/components/ui/portalTheme"
+import { useApollonPortalContainer } from "@/components/ui/portalContainer"
 import { useLabels } from "@/i18n/useLabels"
 
 // Embed-safe editor color-picker. Mirrors the @tumaet/ui color-picker STRUCTURE
@@ -56,6 +57,7 @@ export const EditorColorPicker: React.FC<EditorColorPickerProps> = ({
   // onto it so a dark or custom embed theme paints the picker.
   const [trigger, setTrigger] = React.useState<HTMLElement | null>(null)
   const portalThemeVars = usePortalThemeVars(trigger)
+  const portalContainer = useApollonPortalContainer()
 
   const isCustom =
     selectedColor !== "" &&
@@ -82,7 +84,7 @@ export const EditorColorPicker: React.FC<EditorColorPickerProps> = ({
           } as React.CSSProperties
         }
       />
-      <Popover.Portal>
+      <Popover.Portal container={portalContainer}>
         <Popover.Positioner sideOffset={6} align="start">
           <Popover.Popup
             data-slot="color-picker-content"

--- a/library/lib/components/styleEditor/StyleEditorPanel.tsx
+++ b/library/lib/components/styleEditor/StyleEditorPanel.tsx
@@ -4,6 +4,7 @@ import { Popover } from "@base-ui/react/popover"
 import { DividerLine, Tooltip, Typography } from "@/components/ui"
 import { EditorColorPicker } from "./ColorButtons"
 import { usePortalThemeVars } from "@/components/ui/portalTheme"
+import { useApollonPortalContainer } from "@/components/ui/portalContainer"
 import { useLabels } from "@/i18n/useLabels"
 
 /**
@@ -51,6 +52,7 @@ export function StyleEditorPanel<K extends string>({
   // picker) so a dark/custom embed theme paints the panel.
   const [trigger, setTrigger] = useState<HTMLElement | null>(null)
   const portalThemeVars = usePortalThemeVars(trigger)
+  const portalContainer = useApollonPortalContainer()
   const paintToggleLabel = colorEditorActionLabel ?? t.editColors
 
   return (
@@ -75,7 +77,7 @@ export function StyleEditorPanel<K extends string>({
                 <PaintRoller width={16} height={16} aria-hidden="true" />
               </Popover.Trigger>
             </Tooltip>
-            <Popover.Portal>
+            <Popover.Portal container={portalContainer}>
               <Popover.Positioner sideOffset={6} align="end">
                 <Popover.Popup
                   data-slot="style-editor-content"

--- a/library/lib/components/ui/Select.tsx
+++ b/library/lib/components/ui/Select.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useId, useRef, useState } from "react"
 import { Popover } from "@base-ui/react/popover"
 import { ChevronDown } from "lucide-react"
+import { useApollonPortalContainer } from "./portalContainer"
 import { usePortalThemeVars } from "./portalTheme"
 import { useLabels } from "@/i18n/useLabels"
 
@@ -59,6 +60,7 @@ export const Select: React.FC<SelectProps> = ({
   // scopes `--apollon-*`; carry the resolved theme onto the popup so a dark or
   // custom embed theme paints the open menu.
   const portalThemeVars = usePortalThemeVars(trigger)
+  const portalContainer = useApollonPortalContainer()
 
   const selected = options.find((o) => o.value === value)
 
@@ -180,7 +182,7 @@ export const Select: React.FC<SelectProps> = ({
             </button>
           }
         />
-        <Popover.Portal>
+        <Popover.Portal container={portalContainer}>
           <Popover.Positioner align="start" sideOffset={4} collisionPadding={8}>
             <Popover.Popup
               initialFocus={false}

--- a/library/lib/components/ui/Tooltip.tsx
+++ b/library/lib/components/ui/Tooltip.tsx
@@ -5,6 +5,7 @@ import {
   TooltipContent,
   TooltipProvider as SharedTooltipProvider,
 } from "@tumaet/ui/components/tooltip"
+import { useApollonPortalContainer } from "./portalContainer"
 import { usePortalThemeVars } from "./portalTheme"
 
 // Wraps the shared @tumaet/ui Tooltip so the editor renders the same primitive as
@@ -41,6 +42,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   const [triggerElement, setTriggerElement] =
     React.useState<HTMLButtonElement | null>(null)
   const portalThemeVars = usePortalThemeVars(triggerElement)
+  const portalContainer = useApollonPortalContainer()
 
   if (!title) return <>{children}</>
 
@@ -59,7 +61,11 @@ export const Tooltip: React.FC<TooltipProps> = ({
   return (
     <SharedTooltip>
       {trigger}
-      <TooltipContent side={side} style={portalThemeVars}>
+      <TooltipContent
+        side={side}
+        style={portalThemeVars}
+        portalContainer={portalContainer}
+      >
         {title}
       </TooltipContent>
     </SharedTooltip>

--- a/library/lib/components/ui/portalContainer.tsx
+++ b/library/lib/components/ui/portalContainer.tsx
@@ -1,0 +1,101 @@
+import {
+  createContext,
+  use,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react"
+
+interface PortalContainerContextValue {
+  portalContainer: HTMLElement | null
+  setPortalContainer: (container: HTMLDivElement | null) => void
+}
+
+const ApollonPortalContainerContext =
+  createContext<PortalContainerContextValue | null>(null)
+
+const fullscreenListeners = new Set<() => void>()
+const notifyFullscreenListeners = () => {
+  for (const listener of fullscreenListeners) listener()
+}
+
+function subscribeToFullscreen(listener: () => void): () => void {
+  fullscreenListeners.add(listener)
+  if (fullscreenListeners.size === 1) {
+    document.addEventListener("fullscreenchange", notifyFullscreenListeners)
+  }
+  return () => {
+    fullscreenListeners.delete(listener)
+    if (fullscreenListeners.size === 0) {
+      document.removeEventListener(
+        "fullscreenchange",
+        notifyFullscreenListeners
+      )
+    }
+  }
+}
+
+/**
+ * Owns one layout-neutral portal destination for a single editor instance.
+ * Keeping the root in React's tree makes its lifetime match the editor and
+ * prevents fullscreen in one editor from capturing another editor's surfaces.
+ */
+export function ApollonPortalContainerProvider({
+  children,
+}: {
+  children: ReactNode
+}) {
+  const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(
+    null
+  )
+  const context = useMemo(
+    () => ({ portalContainer, setPortalContainer }),
+    [portalContainer]
+  )
+
+  return (
+    <ApollonPortalContainerContext value={context}>
+      {children}
+    </ApollonPortalContainerContext>
+  )
+}
+
+/** Declarative root rendered inside the editor's own stacking context. */
+export function ApollonPortalRoot() {
+  const context = use(ApollonPortalContainerContext)
+  return (
+    <div
+      ref={context?.setPortalContainer}
+      className="apollon-editor__portal-root"
+      data-apollon-portal-root=""
+    />
+  )
+}
+
+/**
+ * Returns body whenever it remains in the browser's fullscreen subtree. For
+ * element-level fullscreen that excludes body, it returns this editor's local
+ * root instead. The subscription re-portals already-open surfaces when
+ * fullscreen changes.
+ */
+export function useApollonPortalContainer(): HTMLElement {
+  const portalContainer =
+    use(ApollonPortalContainerContext)?.portalContainer ?? null
+  const fullscreenElement = useSyncExternalStore(
+    subscribeToFullscreen,
+    () => document.fullscreenElement ?? null,
+    () => null
+  )
+
+  const bodyExcludedFromFullscreen =
+    fullscreenElement != null && !fullscreenElement.contains(document.body)
+  if (
+    portalContainer &&
+    bodyExcludedFromFullscreen &&
+    fullscreenElement.contains(portalContainer)
+  ) {
+    return portalContainer
+  }
+  return document.body
+}

--- a/library/lib/styles/app.css
+++ b/library/lib/styles/app.css
@@ -63,6 +63,20 @@
   z-index: var(--apollon-z-chrome);
 }
 
+/* Each editor owns a layout-neutral portal root. Floating surfaces use it only
+   while this editor participates in fullscreen, keeping them in the browser's
+   fullscreen subtree without escaping the editor's host stacking context. */
+.apollon-editor__portal-root {
+  position: absolute;
+  z-index: var(--apollon-z-chrome);
+  inset: 0;
+  pointer-events: none;
+}
+
+.apollon-editor__portal-root > * {
+  pointer-events: auto;
+}
+
 /* The chrome frame. A CSS grid over the full-bleed canvas: the header/footer own
    the top/bottom rows, rails span the side tracks between those bands, corner
    slots float over the side/center tracks, and the centre cell is the canvas

--- a/library/tests/unit/portalContainer.test.tsx
+++ b/library/tests/unit/portalContainer.test.tsx
@@ -1,0 +1,134 @@
+import { act, cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { createPortal } from "react-dom"
+import {
+  ApollonPortalContainerProvider,
+  ApollonPortalRoot,
+  useApollonPortalContainer,
+} from "@/components/ui/portalContainer"
+
+const originalFullscreenElement = Object.getOwnPropertyDescriptor(
+  document,
+  "fullscreenElement"
+)
+
+function setFullscreenElement(element: Element | null): void {
+  Object.defineProperty(document, "fullscreenElement", {
+    configurable: true,
+    value: element,
+  })
+}
+
+function PortalContainerProbe({ name }: { name: string }) {
+  const container = useApollonPortalContainer()
+  return (
+    <span data-testid={`${name}-destination`}>
+      {container === document.body ? "body" : name}
+    </span>
+  )
+}
+
+function PortalSurface({ name }: { name: string }) {
+  const container = useApollonPortalContainer()
+  return createPortal(<div data-testid={`${name}-surface`} />, container)
+}
+
+function TestEditor({ name }: { name: string }) {
+  return (
+    <section data-testid={name}>
+      <ApollonPortalContainerProvider>
+        <PortalContainerProbe name={name} />
+        <PortalSurface name={name} />
+        <ApollonPortalRoot />
+      </ApollonPortalContainerProvider>
+    </section>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  if (originalFullscreenElement) {
+    Object.defineProperty(
+      document,
+      "fullscreenElement",
+      originalFullscreenElement
+    )
+  } else {
+    Reflect.deleteProperty(document, "fullscreenElement")
+  }
+})
+
+describe("fullscreen-safe portal container", () => {
+  it("treats an omitted fullscreenElement as an ordinary embed", () => {
+    Reflect.deleteProperty(document, "fullscreenElement")
+    render(<TestEditor name="first" />)
+
+    expect(screen.getByTestId("first-destination")).toHaveTextContent("body")
+    expect(screen.getByTestId("first-surface").parentElement).toBe(
+      document.body
+    )
+  })
+
+  it("uses body outside fullscreen and the editor-owned root in fullscreen", () => {
+    setFullscreenElement(null)
+    render(<TestEditor name="first" />)
+
+    const editor = screen.getByTestId("first")
+    const root = editor.querySelector("[data-apollon-portal-root]")
+    expect(root).not.toBeNull()
+    expect(screen.getByTestId("first-destination")).toHaveTextContent("body")
+    expect(screen.getByTestId("first-surface").parentElement).toBe(
+      document.body
+    )
+
+    act(() => {
+      setFullscreenElement(editor)
+      document.dispatchEvent(new Event("fullscreenchange"))
+    })
+
+    expect(screen.getByTestId("first-destination")).toHaveTextContent("first")
+    expect(screen.getByTestId("first-surface").closest("section")).toBe(editor)
+  })
+
+  it("keeps editor instances isolated during subtree fullscreen", () => {
+    setFullscreenElement(null)
+    render(
+      <>
+        <TestEditor name="first" />
+        <TestEditor name="second" />
+      </>
+    )
+
+    act(() => {
+      setFullscreenElement(screen.getByTestId("first"))
+      document.dispatchEvent(new Event("fullscreenchange"))
+    })
+
+    expect(screen.getByTestId("first-destination")).toHaveTextContent("first")
+    expect(screen.getByTestId("second-destination")).toHaveTextContent("body")
+    expect(screen.getByTestId("first-surface").closest("section")).toBe(
+      screen.getByTestId("first")
+    )
+    expect(screen.getByTestId("second-surface").parentElement).toBe(
+      document.body
+    )
+  })
+
+  it("preserves the body portal for document-root fullscreen and removes roots on unmount", () => {
+    setFullscreenElement(document.documentElement)
+    const { unmount } = render(<TestEditor name="first" />)
+
+    expect(screen.getByTestId("first-destination")).toHaveTextContent("body")
+    expect(screen.getByTestId("first-surface").parentElement).toBe(
+      document.body
+    )
+    expect(
+      document.querySelectorAll("[data-apollon-portal-root]")
+    ).toHaveLength(1)
+
+    unmount()
+    expect(
+      document.querySelectorAll("[data-apollon-portal-root]")
+    ).toHaveLength(0)
+  })
+})

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -25,6 +25,7 @@ function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
 
 function TooltipContent({
   className,
+  portalContainer,
   side = "top",
   sideOffset = 4,
   align = "center",
@@ -35,9 +36,12 @@ function TooltipContent({
   Pick<
     TooltipPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  > & {
+    /** Optional host for fullscreen-safe embedding; defaults to document.body. */
+    portalContainer?: TooltipPrimitive.Portal.Props["container"]
+  }) {
   return (
-    <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Portal container={portalContainer}>
       <TooltipPrimitive.Positioner
         data-slot="tooltip-positioner"
         align={align}

--- a/packages/ui/tests/tooltip.test.tsx
+++ b/packages/ui/tests/tooltip.test.tsx
@@ -37,4 +37,27 @@ describe("Tooltip", () => {
     expect(screen.getByRole("button", { name: "Hover me" })).toHaveFocus()
     await waitFor(() => expect(screen.getByText("Help text")).toBeVisible())
   })
+
+  it("forwards a custom portal container", async () => {
+    const user = userEvent.setup()
+    const portalContainer = document.createElement("div")
+    document.body.append(portalContainer)
+
+    render(
+      <TooltipProvider delay={0}>
+        <Tooltip>
+          <TooltipTrigger>Fullscreen help</TooltipTrigger>
+          <TooltipContent portalContainer={portalContainer}>
+            Portaled help
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+
+    await user.hover(screen.getByRole("button", { name: "Fullscreen help" }))
+    await waitFor(() =>
+      expect(portalContainer).toHaveTextContent("Portaled help")
+    )
+    portalContainer.remove()
+  })
 })

--- a/standalone/webapp/tests/e2e/fullscreen-portals.spec.ts
+++ b/standalone/webapp/tests/e2e/fullscreen-portals.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "@playwright/test"
+import { openFixtureInLocalEditor, waitForCanvasReady } from "../helpers/canvas"
+
+const MODEL = {
+  id: "e2e-fullscreen-portals",
+  type: "ClassDiagram",
+  version: "4.0.0",
+  title: "Fullscreen portals",
+  assessments: {},
+  edges: [],
+  nodes: [
+    {
+      id: "fullscreen-class-0000-0000-000000000001",
+      type: "class",
+      width: 200,
+      height: 100,
+      position: { x: 300, y: 280 },
+      measured: { width: 200, height: 100 },
+      data: { name: "FullscreenClass", attributes: [], methods: [] },
+    },
+  ],
+}
+
+test("keeps editor-owned floating surfaces inside subtree fullscreen", async ({
+  page,
+}) => {
+  await openFixtureInLocalEditor(page, MODEL)
+  await waitForCanvasReady(page)
+
+  await page.evaluate(() => {
+    const trigger = document.createElement("button")
+    trigger.dataset.testid = "enter-editor-fullscreen"
+    trigger.textContent = "Enter editor fullscreen"
+    trigger.style.position = "fixed"
+    trigger.style.zIndex = "2147483647"
+    trigger.addEventListener("click", () => {
+      void document
+        .querySelector<HTMLElement>(".apollon-editor")
+        ?.requestFullscreen()
+    })
+    document.body.append(trigger)
+  })
+  await page.getByTestId("enter-editor-fullscreen").click()
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        document.fullscreenElement?.classList.contains("apollon-editor")
+      )
+    )
+    .toBe(true)
+
+  const editor = page.locator(".apollon-editor").first()
+  const portalRoot = editor.locator(":scope > [data-apollon-portal-root]")
+  await expect(portalRoot).toHaveCount(1)
+
+  const node = editor.locator(".react-flow__node").filter({
+    hasText: "FullscreenClass",
+  })
+  await node.click()
+  await page.getByRole("button", { name: "Edit element" }).click()
+  const popover = page.locator(".apollon-popover")
+  await expect(popover).toBeVisible()
+  expect(
+    await popover.evaluate((popup) =>
+      Boolean(popup.closest("[data-apollon-portal-root]"))
+    )
+  ).toBe(true)
+
+  await page.keyboard.press("Escape")
+  const fitView = editor.getByRole("button", { name: "Fit view" })
+  await fitView.hover()
+  const tooltip = page.locator('[data-slot="tooltip-content"]')
+  await expect(tooltip).toBeVisible()
+  expect(
+    await tooltip.evaluate((tip) =>
+      Boolean(tip.closest("[data-apollon-portal-root]"))
+    )
+  ).toBe(true)
+  await page.mouse.move(1, 1)
+  await expect(tooltip).toBeHidden()
+
+  const paletteItem = editor.getByRole("button", {
+    name: "Add element: Class",
+  })
+  const paletteBox = await paletteItem.boundingBox()
+  const canvasBox = await editor.locator(".react-flow").boundingBox()
+  expect(paletteBox).not.toBeNull()
+  expect(canvasBox).not.toBeNull()
+  await page.mouse.move(
+    paletteBox!.x + paletteBox!.width / 2,
+    paletteBox!.y + paletteBox!.height / 2
+  )
+  await page.mouse.down()
+  try {
+    await page.mouse.move(
+      canvasBox!.x + canvasBox!.width * 0.6,
+      canvasBox!.y + canvasBox!.height * 0.5,
+      { steps: 10 }
+    )
+    await expect
+      .poll(() =>
+        portalRoot.evaluate((root) =>
+          [...root.children].some(
+            (child) =>
+              getComputedStyle(child).position === "fixed" &&
+              getComputedStyle(child).zIndex === "9999"
+          )
+        )
+      )
+      .toBe(true)
+  } finally {
+    await page.mouse.up()
+  }
+
+  await page.evaluate(() => document.exitFullscreen())
+  await expect
+    .poll(() => page.evaluate(() => document.fullscreenElement))
+    .toBeNull()
+
+  await node.click()
+  await page.getByRole("button", { name: "Edit element" }).click()
+  await expect(popover).toBeVisible()
+  expect(
+    await popover.evaluate((popup) =>
+      Boolean(popup.closest("[data-apollon-portal-root]"))
+    )
+  ).toBe(false)
+})


### PR DESCRIPTION
### Summary

Route editor-owned floating surfaces through an editor-local portal root when element-level fullscreen excludes the document body. This keeps popovers, selects, tooltips, color controls, and palette drag previews visible and interactive in subtree fullscreen without a global shared root or host-specific z-index workarounds.

### Release note

Popovers, selects, tooltips, color pickers, and drag previews remain visible and interactive when an embedded editor enters fullscreen.

### Implementation notes

- Each editor declaratively owns one lifecycle-bound, layout-neutral portal root.
- Surfaces continue to portal to `document.body` whenever body remains in the fullscreen subtree, preserving normal embedding and host dialog layering.
- Subtree fullscreen uses the editor-local root only when body is excluded by the browser's fullscreen top layer.
- The fullscreen subscription re-portals already-open surfaces when the Fullscreen API state changes.
- Multiple editors remain isolated: only the editor contained by `document.fullscreenElement` uses its local root.
- The shared UI tooltip now accepts Base UI's native portal container option instead of adding a parallel portal implementation.

### Steps for testing

1. Run `pnpm lint && pnpm format:check && pnpm build && pnpm test`.
2. Run `pnpm exec playwright test standalone/webapp/tests/e2e/fullscreen-portals.spec.ts`.
3. In the local editor, fullscreen the editor subtree, edit a node, hover a chrome control, and drag a palette item; confirm the popover, tooltip, and drag preview stay visible.
4. Exit fullscreen and confirm floating surfaces return to the document portal.

### Screenshots / screencasts

Not attached: this fixes top-layer behavior rather than static appearance. The added Playwright test exercises the behavior in a real browser.

### Checklist

- [ ] Linked to a related issue (not applicable)
- [x] Added a changeset whose summary is written in the user's voice
- [x] PR title's Conventional Commit type matches the kind of change
- [x] Tests added or updated
- [x] Ran `pnpm lint && pnpm format:check && pnpm build && pnpm test` locally — green
- [ ] Documentation updated (not applicable)
- [ ] Screenshots or screencasts attached (behavior covered by Playwright)
